### PR TITLE
Move time amount down to align with arrow in time entry cells

### DIFF
--- a/src/ui/osx/test2.project/test2/TimeEntryCell.xib
+++ b/src/ui/osx/test2.project/test2/TimeEntryCell.xib
@@ -32,7 +32,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xwb-FG-Z4X">
-                                <rect key="frame" x="195" y="17" width="56" height="16"/>
+                                <rect key="frame" x="195" y="15" width="56" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="03:21:30" id="Ten-lK-6RR">
                                     <font key="font" metaFont="cellTitle"/>
@@ -64,12 +64,12 @@
                         <constraint firstItem="deS-e6-3Ui" firstAttribute="leading" secondItem="ar8-w3-mLZ" secondAttribute="leading" constant="14" id="FOo-PQ-AK1"/>
                         <constraint firstItem="CwR-d5-aWs" firstAttribute="leading" secondItem="2k6-j2-GWi" secondAttribute="trailing" constant="6" id="GnS-F9-01O"/>
                         <constraint firstItem="deS-e6-3Ui" firstAttribute="top" secondItem="CwR-d5-aWs" secondAttribute="bottom" constant="2" id="HZ7-Mc-iQ2"/>
-                        <constraint firstItem="xwb-FG-Z4X" firstAttribute="top" secondItem="ar8-w3-mLZ" secondAttribute="top" constant="17" id="HsG-Zm-aF4"/>
+                        <constraint firstItem="xwb-FG-Z4X" firstAttribute="top" secondItem="ar8-w3-mLZ" secondAttribute="top" constant="19" id="HsG-Zm-aF4"/>
                         <constraint firstItem="CwR-d5-aWs" firstAttribute="leading" secondItem="ar8-w3-mLZ" secondAttribute="leading" priority="750" constant="15" id="KZ4-JV-5xD"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="deS-e6-3Ui" secondAttribute="trailing" constant="92" id="L9d-4A-NVt"/>
                         <constraint firstAttribute="trailing" secondItem="CwR-d5-aWs" secondAttribute="trailing" constant="94" id="OD9-hN-DXz"/>
                         <constraint firstAttribute="trailing" secondItem="xwb-FG-Z4X" secondAttribute="trailing" constant="15" id="SKX-kj-jDT"/>
-                        <constraint firstAttribute="bottom" secondItem="xwb-FG-Z4X" secondAttribute="bottom" constant="17" id="Wxi-cu-zKj"/>
+                        <constraint firstAttribute="bottom" secondItem="xwb-FG-Z4X" secondAttribute="bottom" constant="15" id="Wxi-cu-zKj"/>
                         <constraint firstItem="2k6-j2-GWi" firstAttribute="top" secondItem="ar8-w3-mLZ" secondAttribute="top" constant="10" id="eeE-x8-PUA"/>
                         <constraint firstItem="CwR-d5-aWs" firstAttribute="top" secondItem="ar8-w3-mLZ" secondAttribute="top" constant="8" id="p6t-ka-sVG"/>
                         <constraint firstAttribute="bottom" secondItem="deS-e6-3Ui" secondAttribute="bottom" constant="12" id="sXL-6H-yCQ"/>

--- a/src/ui/osx/test2.project/test2/TimeEntryCellWithHeader.xib
+++ b/src/ui/osx/test2.project/test2/TimeEntryCellWithHeader.xib
@@ -41,7 +41,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="chv-we-eud">
-                                <rect key="frame" x="214" y="11" width="58" height="16"/>
+                                <rect key="frame" x="214" y="9" width="58" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="03:21:30" id="P10-iS-flR">
                                     <font key="font" metaFont="cellTitle"/>
@@ -89,12 +89,12 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="76" id="9D9-zv-Fzd"/>
                         <constraint firstItem="Eux-yk-8iS" firstAttribute="leading" secondItem="HvF-1T-7Z3" secondAttribute="leading" constant="15" id="A8Z-So-Phd"/>
-                        <constraint firstAttribute="bottom" secondItem="chv-we-eud" secondAttribute="bottom" constant="21" id="DfN-j5-3fA"/>
+                        <constraint firstAttribute="bottom" secondItem="chv-we-eud" secondAttribute="bottom" constant="19" id="DfN-j5-3fA"/>
                         <constraint firstItem="IPX-6P-J70" firstAttribute="top" secondItem="A9Z-Z5-Qzd" secondAttribute="bottom" constant="10" id="EXs-Uc-xRg"/>
                         <constraint firstItem="IPX-6P-J70" firstAttribute="leading" secondItem="HvF-1T-7Z3" secondAttribute="leading" priority="750" constant="15" id="LMV-jW-9Cu"/>
                         <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="4mY-N2-UMI" secondAttribute="bottom" constant="13" id="LqQ-nY-KdU"/>
                         <constraint firstItem="zWp-bg-ZH9" firstAttribute="top" secondItem="Eux-yk-8iS" secondAttribute="bottom" constant="11" id="Qqy-oF-tuo"/>
-                        <constraint firstItem="chv-we-eud" firstAttribute="top" secondItem="HvF-1T-7Z3" secondAttribute="top" constant="39" id="T36-mh-JHV"/>
+                        <constraint firstItem="chv-we-eud" firstAttribute="top" secondItem="HvF-1T-7Z3" secondAttribute="top" constant="41" id="T36-mh-JHV"/>
                         <constraint firstItem="4mY-N2-UMI" firstAttribute="top" secondItem="IPX-6P-J70" secondAttribute="bottom" constant="2" id="bqJ-J2-JcY"/>
                         <constraint firstItem="Eux-yk-8iS" firstAttribute="top" secondItem="HvF-1T-7Z3" secondAttribute="top" constant="6" id="cFj-Kg-rLU"/>
                         <constraint firstItem="IPX-6P-J70" firstAttribute="leading" secondItem="zWp-bg-ZH9" secondAttribute="trailing" constant="6" id="cZY-5Q-Eqe"/>


### PR DESCRIPTION
I noticed that the time amount in the time entry cells (in the Mac OS X version of Toggl) is about two pixels above the arrow icon to the left of it.  I made some changes in the TimeEntryCell.xib and TimeEntryCellWithHeader.xib files and it seems to get the time in line with the arrow.
