### PR TITLE
Fix 1px border issue when clicking Start/Stop

### DIFF
--- a/src/ui/osx/test2.project/TimerEditViewController.xib
+++ b/src/ui/osx/test2.project/TimerEditViewController.xib
@@ -31,15 +31,15 @@
                         <rect key="frame" x="1" y="1" width="254" height="37"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <box autoresizesSubviews="NO" misplaced="YES" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-HH-zd7">
-                                <rect key="frame" x="198" y="-3" width="58" height="41"/>
+                            <box autoresizesSubviews="NO" borderWidth="0.0" title="Box" boxType="custom" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-HH-zd7">
+                                <rect key="frame" x="197" y="-2" width="58" height="38"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <view key="contentView">
-                                    <rect key="frame" x="1" y="1" width="56" height="39"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="58" height="38"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aQh-bG-0Xd">
-                                            <rect key="frame" x="10" y="9" width="38" height="17"/>
+                                            <rect key="frame" x="10" y="8" width="38" height="17"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Start" id="hJl-zl-B9m">
                                                 <font key="font" metaFont="systemBold"/>
@@ -48,7 +48,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button toolTip="Start" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2Fx-4L-YGZ">
-                                            <rect key="frame" x="-1" y="-5" width="58" height="45"/>
+                                            <rect key="frame" x="-1" y="-6" width="58" height="45"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" state="on" imageScaling="proportionallyDown" inset="2" id="jVO-3V-i8I">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -166,7 +166,7 @@ DQ
                     <color key="fillColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="750" fixedFrame="YES" title="Box" boxType="separator" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="lEH-md-7M7">
-                    <rect key="frame" x="0.0" y="-37" width="264" height="5"/>
+                    <rect key="frame" x="0.0" y="-37" width="264" height="9"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
When the Start/Stop button is clicked it goes gray except for a 1px border that continues to show the button's background color (green if clicking start and red if clicking stop). It may look a little strange to some people so I removed the border to keep it uniform in appearance.
