### PR TITLE
Replace deprecated convert func (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
@@ -209,9 +209,9 @@ extern void *ctx;
 
 - (void)focusFieldName
 {
-	NSPoint globalLocation = [ NSEvent mouseLocation ];
-	NSPoint windowLocation = [ [ self window ] convertScreenToBase:globalLocation ];
-	NSPoint mouseLocation = [ self convertPoint:windowLocation fromView:nil ];
+	NSPoint globalLocation = [NSEvent mouseLocation];
+    NSPoint windowLocation = [self.window convertPointFromScreen:globalLocation];
+	NSPoint mouseLocation = [self convertPoint:windowLocation fromView:nil];
 
 	[self setFocused];
 


### PR DESCRIPTION
### 📒 Description
`convertScreenToBase` is deprecated in 10.7. It's time to upgrade to modern one ⚒

### 🕶️ Types of changes
- [x] General fix (non-breaking change which fixes an issue)

### 🤯 List of changes
- Replace deprecated `convertScreenToBase` with `convertPointFromScreen`
- Fix code convention (off space)

### 👫 Relationships
Closes #2658 

### 🔎 Review hints
Build and check if the warning is gone or not
