### PR TITLE
Fix system proxy autodetect to properly detect more string formats

### DIFF
--- a/src/netconf.cc
+++ b/src/netconf.cc
@@ -50,7 +50,13 @@ error Netconf::autodetectProxy(
         std::wstring proxy_url_wide(ie_config.lpszProxy);
         std::string s("");
         Poco::UnicodeConverter::toUTF8(proxy_url_wide, s);
-        proxy_strings->push_back(s);
+        s = Poco::replace(s, std::string("http="), std::string("http://"));
+        s = Poco::replace(s, std::string("https="), std::string("https://"));
+        std::stringstream ss(s);
+        std::string proxy_address;
+        while (std::getline(ss, proxy_address, ';')) {
+            proxy_strings->push_back(proxy_address);
+        }
     }
 #endif
 


### PR DESCRIPTION
### 📒 Description
Windows proxy autodetection now properly detects strings like:"http=127.0.0.1:8888;https=127.0.0.1:8888"

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Replaces `http=` and `https=` with `http://` and `https://`.
- Splits the proxy address string by `;`

### 👫 Relationships
Closes #1808.
Closes #2100.

### 🔎 Review hints
STR:
- Open Fiddler
- Run Toggl Desktop
- "Preferences->Proxy->Use system proxy settings" is checked (it's the default value).

Expected result:
- Toggl Desktop works normally