### PR TITLE
[LibOverhaul 05] Use the prefix increment operator

### DIFF
--- a/src/batch_update_result.cc
+++ b/src/batch_update_result.cc
@@ -59,7 +59,7 @@ void BatchUpdateResult::ProcessResponseArray(
     Poco::Logger &logger = Poco::Logger::get("BatchUpdateResult");
     for (std::vector<BatchUpdateResult>::const_iterator it = results->begin();
             it != results->end();
-            it++) {
+            ++it) {
         BatchUpdateResult result = *it;
 
         logger.debug(result.String());

--- a/src/context.cc
+++ b/src/context.cc
@@ -431,7 +431,7 @@ void UIElements::ApplyChanges(
     for (std::vector<ModelChange>::const_iterator it =
         changes.begin();
             it != changes.end();
-            it++) {
+            ++it) {
         ModelChange ch = *it;
 
         if (ch.ModelType() == kModelWorkspace
@@ -575,7 +575,7 @@ void Context::updateUI(const UIElements &what) {
                 for (std::vector<std::string>::const_iterator
                         it = tags.begin();
                         it != tags.end();
-                        it++) {
+                        ++it) {
                     view::Generic view;
                     view.Name = *it;
                     tag_views.push_back(view);
@@ -589,7 +589,7 @@ void Context::updateUI(const UIElements &what) {
             for (std::vector<Workspace *>::const_iterator
                     it = workspaces.begin();
                     it != workspaces.end();
-                    it++) {
+                    ++it) {
                 Workspace *ws = *it;
                 view::Generic view;
                 view.GUID = ws->GUID();
@@ -607,7 +607,7 @@ void Context::updateUI(const UIElements &what) {
             user_->related.ClientList(&models);
             for (std::vector<Client *>::const_iterator it = models.begin();
                     it != models.end();
-                    it++) {
+                    ++it) {
                 Client *c = *it;
                 view::Generic view;
                 view.GUID = c->GUID();
@@ -810,7 +810,7 @@ void Context::updateUI(const UIElements &what) {
                 for (std::vector<toggl::AutotrackerRule *>::const_iterator
                         it = user_->related.AutotrackerRules.begin();
                         it != user_->related.AutotrackerRules.end();
-                        it++) {
+                        ++it) {
                     AutotrackerRule *model = *it;
                     Project *p = user_->related.ProjectByID(model->PID());
                     Task *t = user_->related.TaskByID(model->TID());
@@ -3637,7 +3637,7 @@ Project *Context::CreateProject(
         }
         for (std::vector<Project *>::iterator it =
             user_->related.Projects.begin();
-                it != user_->related.Projects.end(); it++) {
+                it != user_->related.Projects.end(); ++it) {
             Project *p = *it;
 
             bool clientIsSame = false;
@@ -3771,7 +3771,7 @@ Client *Context::CreateClient(
         }
         for (std::vector<Client *>::iterator it =
             user_->related.Clients.begin();
-                it != user_->related.Clients.end(); it++) {
+                it != user_->related.Clients.end(); ++it) {
             Client *c = *it;
             if (c->WID() == workspace_id && c->Name() == trimmed_client_name) {
                 displayError(kClientNameAlreadyExists);
@@ -3934,7 +3934,7 @@ error Context::runObmExperiments() {
             for (std::vector<ObmExperiment *>::const_iterator it =
                 user_->related.ObmExperiments.begin();
                     it != user_->related.ObmExperiments.end();
-                    it++) {
+                    ++it) {
                 ObmExperiment *model = *it;
                 if (!model->DeletedAt()) {
                     experiments[model->Nr()] = *model;
@@ -3951,7 +3951,7 @@ error Context::runObmExperiments() {
         for (std::map<Poco::UInt64, ObmExperiment>::const_iterator
                 it = experiments.begin();
                 it != experiments.end();
-                it++) {
+                ++it) {
             ObmExperiment experiment = it->second;
             UI()->DisplayObmExperiment(
                 experiment.Nr(),
@@ -4835,7 +4835,7 @@ error Context::pushClients(
     error err = noError;
     for (std::vector<Client *>::const_iterator it =
         clients.begin();
-            it != clients.end(); it++) {
+            it != clients.end(); ++it) {
         Json::Value clientJson = (*it)->SaveToJSON();
 
         Json::StyledWriter writer;
@@ -4879,12 +4879,12 @@ error Context::pushProjects(const std::vector<Project *> &projects,
     std::string project_json("");
     for (std::vector<Project *>::const_iterator it =
         projects.begin();
-            it != projects.end(); it++) {
+            it != projects.end(); ++it) {
         if (!(*it)->CID() && !(*it)->ClientGUID().empty()) {
             // Find client id
             for (std::vector<Client *>::const_iterator itc =
                 clients.begin();
-                    itc != clients.end(); itc++) {
+                    itc != clients.end(); ++itc) {
                 if ((*itc)->GUID().compare((*it)->ClientGUID()) == 0) {
                     (*it)->SetCID((*itc)->ID());
                     break;
@@ -4931,12 +4931,12 @@ error Context::updateEntryProjects(const std::vector<Project *> &projects,
                                    const std::vector<TimeEntry *> &time_entries) {
     for (std::vector<TimeEntry *>::const_iterator it =
         time_entries.begin();
-            it != time_entries.end(); it++) {
+            it != time_entries.end(); ++it) {
         if (!(*it)->PID() && !(*it)->ProjectGUID().empty()) {
             // Find project id
             for (std::vector<Project *>::const_iterator itc =
                 projects.begin();
-                    itc != projects.end(); itc++) {
+                    itc != projects.end(); ++itc) {
                 if ((*itc)->GUID().compare((*it)->ProjectGUID()) == 0) {
                     (*it)->SetPID((*itc)->ID());
                     break;
@@ -4961,7 +4961,7 @@ error Context::pushEntries(
 
     for (std::vector<TimeEntry *>::const_iterator it =
         time_entries.begin();
-            it != time_entries.end(); it++) {
+            it != time_entries.end(); ++it) {
         // Avoid trying to POST when we're offline
         if (offline) {
             // Mark the time entry as unsynced now
@@ -5128,7 +5128,7 @@ error Context::pushObmAction() {
             for (std::vector<ObmAction *>::iterator it =
                 user_->related.ObmActions.begin();
                     it != user_->related.ObmActions.end();
-                    it++) {
+                    ++it) {
                 ObmAction *model = *it;
                 if (!model->IsMarkedAsDeletedOnServer()) {
                     for_upload = model;
@@ -5307,7 +5307,7 @@ error Context::pullWorkspacePreferences(TogglClient* toggl_client) {
     for (std::vector<Workspace*>::const_iterator
             it = workspaces.begin();
             it != workspaces.end();
-            it++) {
+            ++it) {
         Workspace* ws = *it;
 
         if (!ws->Business())
@@ -5641,7 +5641,7 @@ void Context::collectPushableModels(
     for (typename std::vector<T *>::const_iterator it =
         list.begin();
             it != list.end();
-            it++) {
+            ++it) {
         T *model = *it;
         if (!model->NeedsPush()) {
             continue;

--- a/src/formatter.cc
+++ b/src/formatter.cc
@@ -544,7 +544,7 @@ std::string Formatter::EscapeJSONString(const std::string &input) {
     std::ostringstream ss;
     for (std::string::const_iterator iter = input.begin();
             iter != input.end();
-            iter++) {
+            ++iter) {
         switch (*iter) {
         case '"':
             ss << "\"";
@@ -574,7 +574,7 @@ error Formatter::CollectErrors(std::vector<error> * const errors) {
     std::set<error> unique;
     for (std::vector<error>::const_iterator it = errors->begin();
             it != errors->end();
-            it++) {
+            ++it) {
         error err = *it;
         if (!err.empty() && err[err.size() - 1] == '\n') {
             err[err.size() - 1] = '.';

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -484,7 +484,7 @@ void GUI::DisplayAutotrackerRules(
     for (std::vector<view::AutotrackerRule>::const_iterator
             it = autotracker_rules.begin();
             it != autotracker_rules.end();
-            it++) {
+            ++it) {
         TogglAutotrackerRuleView *item = autotracker_rule_to_view_item(*it);
         item->Next = first;
         first = item;

--- a/src/help_article.cc
+++ b/src/help_article.cc
@@ -597,7 +597,7 @@ std::vector<HelpArticle> HelpDatabase::GetArticles(
     std::vector<HelpArticle> result;
     for (std::vector<HelpArticle>::const_iterator it = articles_.begin();
             it != articles_.end();
-            it++) {
+            ++it) {
         HelpArticle article = *it;
         for (Poco::StringTokenizer::Iterator sit = tokenizer.begin();
                 sit != tokenizer.end();

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -58,7 +58,7 @@ error RelatedData::DeleteAutotrackerRule(const Poco::Int64 local_id) {
     }
     for (std::vector<AutotrackerRule *>::iterator it =
         AutotrackerRules.begin();
-            it != AutotrackerRules.end(); it++) {
+            it != AutotrackerRules.end(); ++it) {
         AutotrackerRule *rule = *it;
         // Autotracker settings are not saved to DB,
         // so the ID will be 0 always. But will have local ID
@@ -75,7 +75,7 @@ AutotrackerRule *RelatedData::FindAutotrackerRule(
     const TimelineEvent &event) const {
     for (std::vector<AutotrackerRule *>::const_iterator it =
         AutotrackerRules.begin();
-            it != AutotrackerRules.end(); it++) {
+            it != AutotrackerRules.end(); ++it) {
         AutotrackerRule *rule = *it;
         if (rule->Matches(event)) {
             return rule;
@@ -88,7 +88,7 @@ bool RelatedData::HasMatchingAutotrackerRule(
     const std::string &lowercase_term) const {
     for (std::vector<AutotrackerRule *>::const_iterator it =
         AutotrackerRules.begin();
-            it != AutotrackerRules.end(); it++) {
+            it != AutotrackerRules.end(); ++it) {
         AutotrackerRule *rule = *it;
         if (rule->Term() == lowercase_term) {
             return true;
@@ -102,7 +102,7 @@ Poco::Int64 RelatedData::NumberOfUnsyncedTimeEntries() const {
 
     for (std::vector<TimeEntry *>::const_iterator it =
         TimeEntries.begin();
-            it != TimeEntries.end(); it++) {
+            it != TimeEntries.end(); ++it) {
         TimeEntry *te = *it;
         if (te->NeedsPush()) {
             count++;
@@ -130,7 +130,7 @@ std::vector<TimeEntry *> RelatedData::VisibleTimeEntries() const {
     std::vector<TimeEntry *> result;
     for (std::vector<TimeEntry *>::const_iterator it =
         TimeEntries.begin();
-            it != TimeEntries.end(); it++) {
+            it != TimeEntries.end(); ++it) {
         TimeEntry *te = *it;
         if (te->GUID().empty()) {
             continue;
@@ -148,7 +148,7 @@ Poco::Int64 RelatedData::TotalDurationForDate(const TimeEntry *match) const {
     Poco::Int64 duration(0);
     for (std::vector<TimeEntry *>::const_iterator it =
         TimeEntries.begin();
-            it != TimeEntries.end(); it++) {
+            it != TimeEntries.end(); ++it) {
         TimeEntry *te = *it;
         if (te->GUID().empty()) {
             continue;
@@ -171,7 +171,7 @@ TimeEntry *RelatedData::LatestTimeEntry() const {
     // Find the time entry that was stopped most recently
     for (std::vector<TimeEntry *>::const_iterator it =
         TimeEntries.begin();
-            it != TimeEntries.end(); it++) {
+            it != TimeEntries.end(); ++it) {
         TimeEntry *te = *it;
 
         if (te->GUID().empty()) {
@@ -210,7 +210,7 @@ void RelatedData::timeEntryAutocompleteItems(
 
     for (std::vector<TimeEntry *>::const_iterator it =
         TimeEntries.begin();
-            it != TimeEntries.end(); it++) {
+            it != TimeEntries.end(); ++it) {
         TimeEntry *te = *it;
 
         if (te->DeletedAt() || te->IsMarkedAsDeletedOnServer()
@@ -302,7 +302,7 @@ void RelatedData::taskAutocompleteItems(
 
     for (std::vector<Task *>::const_iterator it =
         Tasks.begin();
-            it != Tasks.end(); it++) {
+            it != Tasks.end(); ++it) {
         Task *t = *it;
 
         if (t == nullptr) {
@@ -380,7 +380,7 @@ void RelatedData::projectAutocompleteItems(
 
     for (std::vector<Project *>::const_iterator it =
         Projects.begin();
-            it != Projects.end(); it++) {
+            it != Projects.end(); ++it) {
         Project *p = *it;
 
         if (!p->Active()) {
@@ -426,7 +426,7 @@ void RelatedData::projectAutocompleteItems(
             if (task_items) {
                 for (std::vector<view::Autocomplete>::const_iterator it =
                     (*task_items)[autocomplete_item.ProjectID].begin();
-                        it != (*task_items)[autocomplete_item.ProjectID].end(); it++) {
+                        it != (*task_items)[autocomplete_item.ProjectID].end(); ++it) {
                     view::Autocomplete ac = *it;
                     (*items)[autocomplete_item.WorkspaceName].push_back(ac);
                 }
@@ -436,7 +436,7 @@ void RelatedData::projectAutocompleteItems(
             if (task_items) {
                 for (std::vector<view::Autocomplete>::const_iterator it =
                     (*task_items)[autocomplete_item.ProjectID].begin();
-                        it != (*task_items)[autocomplete_item.ProjectID].end(); it++) {
+                        it != (*task_items)[autocomplete_item.ProjectID].end(); ++it) {
                     view::Autocomplete ac = *it;
                     list->push_back(ac);
                 }
@@ -510,7 +510,7 @@ void RelatedData::workspaceAutocompleteItems(
     std::set<Poco::UInt64> ws_ids_with_projects;
     for (std::vector<Project *>::const_iterator it =
         Projects.begin();
-            it != Projects.end(); it++) {
+            it != Projects.end(); ++it) {
         Project *p = *it;
 
         if (p->Active()) {
@@ -520,7 +520,7 @@ void RelatedData::workspaceAutocompleteItems(
 
     for (std::vector<Workspace *>::const_iterator it =
         Workspaces.begin();
-            it != Workspaces.end(); it++) {
+            it != Workspaces.end(); ++it) {
         Workspace *ws = *it;
 
         if (ws_ids_with_projects.find(ws->ID()) == ws_ids_with_projects.end()) {
@@ -543,7 +543,7 @@ void RelatedData::TagList(
     for (std::vector<Tag *>::const_iterator it =
         Tags.begin();
             it != Tags.end();
-            it++) {
+            ++it) {
         Tag *tag = *it;
         if (wid && tag->WID() != wid) {
             continue;
@@ -565,7 +565,7 @@ void RelatedData::WorkspaceList(std::vector<Workspace *> *result) const {
     for (std::vector<Workspace *>::const_iterator it =
         Workspaces.begin();
             it != Workspaces.end();
-            it++) {
+            ++it) {
         Workspace *ws = *it;
         if (!ws->Admin() && ws->OnlyAdminsMayCreateProjects()) {
             continue;
@@ -692,7 +692,7 @@ T *modelByGUID(const guid GUID, std::vector<T *> const *list) {
         return nullptr;
     }
     typedef typename std::vector<T *>::const_iterator iterator;
-    for (iterator it = list->begin(); it != list->end(); it++) {
+    for (iterator it = list->begin(); it != list->end(); ++it) {
         T *model = *it;
         if (model->GUID() == GUID) {
             return model;
@@ -707,7 +707,7 @@ T *modelByID(const Poco::UInt64 id, std::vector<T *> const *list) {
         return nullptr;
     }
     typedef typename std::vector<T *>::const_iterator iterator;
-    for (iterator it = list->begin(); it != list->end(); it++) {
+    for (iterator it = list->begin(); it != list->end(); ++it) {
         T *model = *it;
         if (model->ID() == id) {
             return model;

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -507,7 +507,7 @@ Json::Value TimeEntry::SaveToJSON() const {
     if (TagNames.size() > 0) {
         for (std::vector<std::string>::const_iterator it = TagNames.begin();
                 it != TagNames.end();
-                it++) {
+                ++it) {
             std::string tag_name = Formatter::EscapeJSONString(*it);
             tag_nodes.append(Json::Value(tag_name));
         }

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -90,7 +90,7 @@ TogglGenericView *generic_to_view_item_list(
     for (std::vector<toggl::view::Generic>::const_iterator
             it = list.begin();
             it != list.end();
-            it++) {
+            ++it) {
         TogglGenericView *item = generic_to_view_item(*it);
         item->Next = first;
         first = item;
@@ -258,7 +258,7 @@ TogglCountryView *country_list_init(
     for (std::vector<TogglCountryView>::const_iterator
             it = items->begin();
             it != items->end();
-            it++) {
+            ++it) {
         TogglCountryView *item = new TogglCountryView();
         poco_check_ptr(item);
 
@@ -491,7 +491,7 @@ TogglAutocompleteView *autocomplete_list_init(
     for (std::vector<toggl::view::Autocomplete>::const_reverse_iterator it =
         items->rbegin();
             it != items->rend();
-            it++) {
+            ++it) {
         TogglAutocompleteView *item = autocomplete_item_init(*it);
         item->Next = first;
         first = item;
@@ -539,7 +539,7 @@ TogglHelpArticleView *help_article_list_init(const std::vector<toggl::HelpArticl
     for (std::vector<toggl::HelpArticle>::const_reverse_iterator it =
         items.rbegin();
             it != items.rend();
-            it++) {
+            ++it) {
         TogglHelpArticleView *item = help_article_init(*it);
         item->Next = first;
         first = item;

--- a/src/user.cc
+++ b/src/user.cc
@@ -77,7 +77,7 @@ void User::AddProjectToList(Project *p) {
     // (since we try to avoid sorting the large list)
     for (std::vector<Project *>::iterator it =
         related.Projects.begin();
-            it != related.Projects.end(); it++) {
+            it != related.Projects.end(); ++it) {
         Project *pr = *it;
         if (p->WID() == pr->WID()) {
             WIDMatch = true;
@@ -136,7 +136,7 @@ void User::AddClientToList(Client *c) {
     // (since we try to avoid sorting the large list)
     for (std::vector<Client *>::iterator it =
         related.Clients.begin();
-            it != related.Clients.end(); it++) {
+            it != related.Clients.end(); ++it) {
         Client *cl = *it;
         if (c->WID() == cl->WID()) {
             foundMatch = true;
@@ -268,7 +268,7 @@ std::string User::DateDuration(TimeEntry * const te) const {
     for (std::vector<TimeEntry *>::const_iterator it =
         related.TimeEntries.begin();
             it != related.TimeEntries.end();
-            it++) {
+            ++it) {
         TimeEntry *n = *it;
         if (Formatter::FormatDateHeader(n->Start()) == date_header) {
             Poco::Int64 duration = n->DurationInSeconds();
@@ -284,7 +284,7 @@ bool User::HasPremiumWorkspaces() const {
     for (std::vector<Workspace *>::const_iterator it =
         related.Workspaces.begin();
             it != related.Workspaces.end();
-            it++) {
+            ++it) {
         Workspace *model = *it;
         if (model->Premium()) {
             return true;
@@ -297,7 +297,7 @@ bool User::CanAddProjects() const {
     for (std::vector<Workspace *>::const_iterator it =
         related.Workspaces.begin();
             it != related.Workspaces.end();
-            it++) {
+            ++it) {
         Workspace *model = *it;
         if (model->OnlyAdminsMayCreateProjects()) {
             return false;
@@ -450,7 +450,7 @@ TimeEntry *User::RunningTimeEntry() const {
     for (std::vector<TimeEntry *>::const_iterator it =
         related.TimeEntries.begin();
             it != related.TimeEntries.end();
-            it++) {
+            ++it) {
         if ((*it)->DurationInSeconds() < 0) {
             return *it;
         }
@@ -496,7 +496,7 @@ void User::DeleteRelatedModelsWithWorkspace(const Poco::UInt64 wid) {
 
 void User::RemoveClientFromRelatedModels(const Poco::UInt64 cid) {
     for (std::vector<Project *>::iterator it = related.Projects.begin();
-            it != related.Projects.end(); it++) {
+            it != related.Projects.end(); ++it) {
         Project *model = *it;
         if (model->CID() == cid) {
             model->SetCID(0);
@@ -766,7 +766,7 @@ void User::loadObmExperimentFromJson(Json::Value const &obm) {
     for (std::vector<ObmExperiment *>::const_iterator it =
         related.ObmExperiments.begin();
             it != related.ObmExperiments.end();
-            it++) {
+            ++it) {
         ObmExperiment *existing = *it;
         if (existing->Nr() == nr) {
             model = existing;
@@ -1139,7 +1139,7 @@ error User::UpdateJSON(
     // Time entries go last
     for (std::vector<TimeEntry *>::const_iterator it =
         time_entries->begin();
-            it != time_entries->end(); it++) {
+            it != time_entries->end(); ++it) {
         Json::Value update;
         error err = (*it)->BatchUpdateJSON(&update);
         if (err != noError) {
@@ -1456,7 +1456,7 @@ template <typename T>
 void deleteRelatedModelsWithWorkspace(const Poco::UInt64 wid,
                                       std::vector<T *> *list) {
     typedef typename std::vector<T *>::iterator iterator;
-    for (iterator it = list->begin(); it != list->end(); it++) {
+    for (iterator it = list->begin(); it != list->end(); ++it) {
         T *model = *it;
         if (model->WID() == wid) {
             model->MarkAsDeletedOnServer();
@@ -1468,7 +1468,7 @@ template <typename T>
 void removeProjectFromRelatedModels(const Poco::UInt64 pid,
                                     std::vector<T *> *list) {
     typedef typename std::vector<T *>::iterator iterator;
-    for (iterator it = list->begin(); it != list->end(); it++) {
+    for (iterator it = list->begin(); it != list->end(); ++it) {
         T *model = *it;
         if (model->PID() == pid) {
             model->SetPID(0);


### PR DESCRIPTION
### 📒 Description
Because of the (perfectly logical) way how C++ works, there's a (very) slight peformance benefit of using the prefix increment operator (`++it`) compared to the postfix variant (`it++`) with iterators. `cpplint` complains about this so I wrote a patch to get rid of the warning.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
- Same as with most library overhaul PRs, warnings should disappear and the app should continue to compile and work the same on all platforms.

