### PR TITLE
[LibOverhaul 06] Mark override methods

### DIFF
--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -36,9 +36,9 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     void SetTID(const Poco::UInt64 value);
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
 
  private:
     std::string term_;

--- a/src/client.h
+++ b/src/client.h
@@ -33,13 +33,13 @@ class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
     void SetName(const std::string &value);
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    void LoadFromJSON(Json::Value value);
-    Json::Value SaveToJSON() const;
-    bool ResolveError(const toggl::error &err);
-    bool ResourceCannotBeCreated(const toggl::error &err) const;
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    void LoadFromJSON(Json::Value value) override;
+    Json::Value SaveToJSON() const override;
+    bool ResolveError(const toggl::error &err) override;
+    bool ResourceCannotBeCreated(const toggl::error &err) const override;
 
  private:
     Poco::UInt64 wid_;

--- a/src/context.h
+++ b/src/context.h
@@ -463,11 +463,11 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     std::string UserEmail();
 
     // Timeline datasource
-    error StartAutotrackerEvent(const TimelineEvent &event);
-    error CreateCompressedTimelineBatchForUpload(TimelineBatch *batch);
-    error StartTimelineEvent(TimelineEvent *event);
+    error StartAutotrackerEvent(const TimelineEvent &event) override;
+    error CreateCompressedTimelineBatchForUpload(TimelineBatch *batch) override;
+    error StartTimelineEvent(TimelineEvent *event) override;
     error MarkTimelineBatchAsUploaded(
-        const std::vector<TimelineEvent> &events);
+        const std::vector<TimelineEvent> &events) override;
 
     error SetPromotionResponse(
         const int64_t promotion_type,

--- a/src/gui.h
+++ b/src/gui.h
@@ -397,7 +397,7 @@ class TOGGL_INTERNAL_EXPORT GUI : public SyncStateMonitor {
     void DisplayHelpArticles(
         const std::vector<HelpArticle> &articles);
 
-    void DisplaySyncState(const Poco::Int64 state);
+    void DisplaySyncState(const Poco::Int64 state) override;
 
     void DisplayOnlineState(const Poco::Int64 state);
 

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -190,9 +190,9 @@ class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPSClient {
 
  protected:
     virtual HTTPSResponse request(
-        HTTPSRequest req);
+        HTTPSRequest req) override;
 
-    virtual Poco::Logger &logger() const;
+    virtual Poco::Logger &logger() const override;
 
  private:
     SyncStateMonitor *monitor_;

--- a/src/obm_action.h
+++ b/src/obm_action.h
@@ -37,10 +37,10 @@ class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
     void SetExperimentID(const Poco::UInt64 value);
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    Json::Value SaveToJSON() const;
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    Json::Value SaveToJSON() const override;
 
  private:
     Poco::UInt64 experiment_id_;
@@ -78,9 +78,9 @@ class TOGGL_INTERNAL_EXPORT ObmExperiment : public BaseModel {
     void SetActions(const std::string &value);
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
 
  private:
     bool included_;

--- a/src/project.h
+++ b/src/project.h
@@ -78,14 +78,14 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
     std::string FullName() const;
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    void LoadFromJSON(Json::Value value);
-    Json::Value SaveToJSON() const;
-    bool DuplicateResource(const toggl::error &err) const;
-    bool ResourceCannotBeCreated(const toggl::error &err) const;
-    bool ResolveError(const toggl::error &err);
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    void LoadFromJSON(Json::Value value) override;
+    Json::Value SaveToJSON() const override;
+    bool DuplicateResource(const toggl::error &err) const override;
+    bool ResourceCannotBeCreated(const toggl::error &err) const override;
+    bool ResolveError(const toggl::error &err) override;
 
     static std::vector<std::string> ColorCodes;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -83,10 +83,10 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
 
     // Override BaseModel
 
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    Json::Value SaveToJSON() const;
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    Json::Value SaveToJSON() const override;
 };
 
 }  // namespace toggl

--- a/src/tag.h
+++ b/src/tag.h
@@ -29,10 +29,10 @@ class TOGGL_INTERNAL_EXPORT Tag : public BaseModel {
     void SetName(const std::string &value);
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    void LoadFromJSON(Json::Value data);
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    void LoadFromJSON(Json::Value data) override;
 
  private:
     Poco::UInt64 wid_;

--- a/src/task.h
+++ b/src/task.h
@@ -43,10 +43,10 @@ class TOGGL_INTERNAL_EXPORT Task : public BaseModel {
     void SetActive(const bool value);
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    void LoadFromJSON(Json::Value value);
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    void LoadFromJSON(Json::Value value) override;
 
  private:
     std::string name_;

--- a/src/time_entry.h
+++ b/src/time_entry.h
@@ -84,7 +84,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string StartString() const;
     void SetStartString(const std::string &value);
 
-    const Poco::Int64 &Start() const {
+    const Poco::Int64 &Start() const override {
         return start_;
     }
     void SetStart(const Poco::Int64 value);
@@ -124,16 +124,16 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
 
     // Override BaseModel
 
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    std::string String() const;
-    virtual bool ResolveError(const error &err);
-    void LoadFromJSON(Json::Value value);
-    Json::Value SaveToJSON() const;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    std::string String() const override;
+    virtual bool ResolveError(const error &err) override;
+    void LoadFromJSON(Json::Value value) override;
+    Json::Value SaveToJSON() const override;
 
     // Implement TimedEvent
 
-    virtual Poco::Int64 Duration() const {
+    virtual Poco::Int64 Duration() const override {
         return DurationInSeconds();
     }
 

--- a/src/timeline_event.h
+++ b/src/timeline_event.h
@@ -32,7 +32,7 @@ class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent 
     }
     void SetTitle(const std::string &value);
 
-    const Poco::Int64 &Start() const {
+    const Poco::Int64 &Start() const  override{
         return start_time_;
     }
     void SetStart(const Poco::Int64 value);
@@ -68,14 +68,14 @@ class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent 
 
     // Override BaseModel
 
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    Json::Value SaveToJSON() const;
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    Json::Value SaveToJSON() const override;
 
     // Implement TimedEvent
 
-    virtual Poco::Int64 Duration() const {
+    virtual Poco::Int64 Duration() const override {
         return EndTime() - Start();
     }
 

--- a/src/user.h
+++ b/src/user.h
@@ -168,9 +168,9 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     RelatedData related;
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
 
     // Handle related model deletions
     void DeleteRelatedModelsWithWorkspace(const Poco::UInt64 wid);

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -59,10 +59,11 @@ class TOGGL_INTERNAL_EXPORT Workspace : public BaseModel {
     void SetLockedTime(const time_t value);
 
     // Override BaseModel
-    std::string String() const;
-    std::string ModelName() const;
-    std::string ModelURL() const;
-    void LoadFromJSON(Json::Value value);
+    std::string String() const override;
+    std::string ModelName() const override;
+    std::string ModelURL() const override;
+    void LoadFromJSON(Json::Value value) override;
+
     void LoadSettingsFromJson(Json::Value value);
 
  private:


### PR DESCRIPTION
### 📒 Description
It's better to mark overriden virtual methods in child classes to avoid mixups when changing the underlying API or to just be sure that we're working with a virtual method in the child class.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
- Same as with most library overhaul PRs, warnings should disappear and the app should continue to compile and work the same on all platforms.

