### PR TITLE
[LibOverhaul 07] Seed the random number generator only once

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set(LIBRARY_SOURCE_FILES
     platforminfo.cc
     project.cc
     proxy.cc
+    random.cc
     rectangle.cc
     related_data.cc
     settings.cc

--- a/src/context.cc
+++ b/src/context.cc
@@ -22,6 +22,7 @@
 #include "./https_client.h"
 #include "./obm_action.h"
 #include "./project.h"
+#include "./random.h"
 #include "./settings.h"
 #include "./task.h"
 #include "./time_entry.h"
@@ -46,7 +47,6 @@
 #include "Poco/Net/StringPartSource.h"
 #include "Poco/Path.h"
 #include "Poco/PatternFormatter.h"
-#include "Poco/Random.h"
 #include "Poco/SimpleFileChannel.h"
 #include "Poco/Stopwatch.h"
 #include "Poco/StreamCopier.h"
@@ -992,9 +992,7 @@ error Context::displayError(const error &err) {
 }
 
 int Context::nextSyncIntervalSeconds() const {
-    Poco::Random random;
-    random.seed();
-    int n = static_cast<int>(random.next(kSyncIntervalRangeSeconds)) + kSyncIntervalRangeSeconds;
+    int n = static_cast<int>(Random::next(kSyncIntervalRangeSeconds)) + kSyncIntervalRangeSeconds;
     std::stringstream ss;
     ss << "Next autosync in " << n << " seconds";
     logger().trace(ss.str());

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		74F7CDDB18199FA300630BD0 /* window_change_recorder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 74F7CDD918199FA300630BD0 /* window_change_recorder.cc */; };
 		74F7CDDC18199FA300630BD0 /* window_change_recorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F7CDDA18199FA300630BD0 /* window_change_recorder.h */; };
 		BA1AB53E235DEAD4000433AE /* MacOSVersionChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */; };
+		B8470E4C2334C377000D88CE /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = B8470E4A2334C377000D88CE /* random.h */; };
+		B8470E4D2334C377000D88CE /* random.cc in Sources */ = {isa = PBXBuildFile; fileRef = B8470E4B2334C377000D88CE /* random.cc */; };
 		BA2DA11C21A6864D0027B7A5 /* rectangle.h in Headers */ = {isa = PBXBuildFile; fileRef = BA2DA11A21A6864D0027B7A5 /* rectangle.h */; };
 		BA2DA11D21A6864D0027B7A5 /* rectangle.cc in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11B21A6864D0027B7A5 /* rectangle.cc */; };
 		BAD233E321D60A4D0039C742 /* libPocoNet.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BAD233DA21D60A4D0039C742 /* libPocoNet.dylib */; };
@@ -178,6 +180,8 @@
 		74F7CDD918199FA300630BD0 /* window_change_recorder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = window_change_recorder.cc; path = ../../../window_change_recorder.cc; sourceTree = "<group>"; };
 		74F7CDDA18199FA300630BD0 /* window_change_recorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = window_change_recorder.h; path = ../../../window_change_recorder.h; sourceTree = "<group>"; };
 		BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MacOSVersionChecker.mm; sourceTree = "<group>"; };
+		B8470E4A2334C377000D88CE /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = random.h; path = ../../../random.h; sourceTree = "<group>"; };
+		B8470E4B2334C377000D88CE /* random.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = random.cc; path = ../../../random.cc; sourceTree = "<group>"; };
 		BA2DA11A21A6864D0027B7A5 /* rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rectangle.h; path = ../../../rectangle.h; sourceTree = "<group>"; };
 		BA2DA11B21A6864D0027B7A5 /* rectangle.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rectangle.cc; path = ../../../rectangle.cc; sourceTree = "<group>"; };
 		BAD233DA21D60A4D0039C742 /* libPocoNet.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoNet.dylib; path = ../../../third_party/poco/lib/Darwin/x86_64/libPocoNet.dylib; sourceTree = "<group>"; };
@@ -268,6 +272,8 @@
 		C55DA59E17F06A3B00B42178 /* lib */ = {
 			isa = PBXGroup;
 			children = (
+				B8470E4B2334C377000D88CE /* random.cc */,
+				B8470E4A2334C377000D88CE /* random.h */,
 				7426535C1BEAD91900F0944C /* help_article.cc */,
 				7426535D1BEAD91900F0944C /* help_article.h */,
 				7497E9081BEA786A00517BAF /* obm_action.cc */,
@@ -404,6 +410,7 @@
 				7484A2A818887BEE0025A88B /* toggl_api_private.h in Headers */,
 				748A0F411B388CCA0001A41E /* urls.h in Headers */,
 				74EB0F1817F9A2600046ABC1 /* https_client.h in Headers */,
+				B8470E4C2334C377000D88CE /* random.h in Headers */,
 				7497E90B1BEA786A00517BAF /* obm_action.h in Headers */,
 				74BAD32A18BEC4FD002FD4CF /* base_model.h in Headers */,
 				7426535F1BEAD91900F0944C /* help_article.h in Headers */,
@@ -526,6 +533,7 @@
 				748B7DA51AC5963B00FE01D2 /* custom_error_handler.cc in Sources */,
 				74B587C618BBC77E00E9F6CE /* tag.cc in Sources */,
 				C5DA1FB617F1942A001C4565 /* toggl_api.cc in Sources */,
+				B8470E4D2334C377000D88CE /* random.cc in Sources */,
 				74CBDA3A19F97740008494FE /* jsoncpp.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -509,6 +509,7 @@
     <ClInclude Include="..\..\..\migrations.h" />
     <ClInclude Include="..\..\..\netconf.h" />
     <ClInclude Include="..\..\..\obm_action.h" />
+    <ClInclude Include="..\..\..\random.h" />
     <ClInclude Include="..\..\..\Rectangle.h" />
     <ClInclude Include="..\..\..\toggl_api.h" />
     <ClInclude Include="..\..\..\toggl_api_private.h" />
@@ -586,6 +587,7 @@
     <ClCompile Include="..\..\..\migrations.cc" />
     <ClCompile Include="..\..\..\netconf.cc" />
     <ClCompile Include="..\..\..\obm_action.cc" />
+    <ClCompile Include="..\..\..\random.cc" />
     <ClCompile Include="..\..\..\Rectangle.cc" />
     <ClCompile Include="..\..\..\settings.cc" />
     <ClCompile Include="..\..\..\timeline_event.cc" />

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClInclude Include="..\..\..\toggl_api.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\random.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -444,6 +447,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\Rectangle.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\random.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -4,8 +4,7 @@
 
 #include "./const.h"
 #include "./database.h"
-
-#include "Poco/Random.h"
+#include "./random.h"
 
 namespace toggl {
 
@@ -849,10 +848,8 @@ error Migrations::migrateSettings() {
         return err;
     }
     if (!has_settings) {
-        Poco::Random random;
-        random.seed();
         std::string channel("stable");
-        Poco::UInt32 r = random.next(100);
+        Poco::UInt32 r = Random::next(100);
         if (r < kBetaChannelPercentage) {
             channel = "beta";
         }

--- a/src/random.cc
+++ b/src/random.cc
@@ -1,0 +1,15 @@
+//
+//  random.cc
+//  TogglDesktopLibrary
+//
+//  Created by Martin Bříza on Jun 13, 2019.
+//  Copyright © 2019 Toggl. All rights reserved.
+//
+
+#include "./random.h"
+
+namespace toggl {
+
+Poco::Random Random::_random;
+
+}

--- a/src/random.h
+++ b/src/random.h
@@ -1,0 +1,26 @@
+// Copyright 2014 Toggl Desktop developers.
+
+#ifndef SRC_RANDOM_H
+#define SRC_RANDOM_H
+
+#include "Poco/Random.h"
+
+namespace toggl {
+
+class Random
+{
+public:
+    static inline Poco::UInt32 next(Poco::UInt32 n) {
+        static bool initialized = false;
+        if (!initialized) {
+            _random.seed();
+            initialized = true;
+        }
+        return _random.next(n);
+    }
+private:
+    static Poco::Random _random;
+};
+
+}  // namespace toggl
+#endif // SRC_RANDOM_H

--- a/src/websocket_client.cc
+++ b/src/websocket_client.cc
@@ -19,12 +19,12 @@
 #include "Poco/Net/PrivateKeyPassphraseHandler.h"
 #include "Poco/Net/SSLManager.h"
 #include "Poco/Net/WebSocket.h"
-#include "Poco/Random.h"
 #include "Poco/URI.h"
 
 #include "./const.h"
 #include "./https_client.h"
 #include "./netconf.h"
+#include "./random.h"
 #include "./urls.h"
 
 namespace toggl {
@@ -322,9 +322,7 @@ Poco::Logger &WebSocketClient::logger() const {
 }
 
 int WebSocketClient::nextWebsocketRestartInterval() {
-    Poco::Random random;
-    random.seed();
-    int res = static_cast<int>(random.next(kWebsocketRestartRangeSeconds)) + 1;
+    int res = static_cast<int>(Random::next(kWebsocketRestartRangeSeconds)) + 1;
     std::stringstream ss;
     ss << "Next websocket restart in " << res << " seconds";
     logger().trace(ss.str());


### PR DESCRIPTION
### 📒 Description
Seeding the pseudo random number generator with each generated number is a bad practice and especially in our case it was atrocious to the performance because it seems POCO actually uses a real random number generator (and these tend to be really slow and they're provided by the OS) to get the seed values. There are  three places where we use random numbers so I added a helper class that keeps the Poco::Random instance for all of these.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
- Same as with most library overhaul PRs, warnings should disappear and the app should continue to compile and work the same on all platforms.

