### PR TITLE
[LibOverhaul 08] Constify methods in HttpsClient 

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4830,7 +4830,7 @@ error Context::pushChanges(
 error Context::pushClients(
     const std::vector<Client *> &clients,
     const std::string &api_token,
-    TogglClient toggl_client) {
+    const TogglClient &toggl_client) {
     std::string client_json("");
     error err = noError;
     for (std::vector<Client *>::const_iterator it =
@@ -4871,10 +4871,11 @@ error Context::pushClients(
     return err;
 }
 
-error Context::pushProjects(const std::vector<Project *> &projects,
-                            const std::vector<Client *> &clients,
-                            const std::string &api_token,
-                            TogglClient toggl_client) {
+error Context::pushProjects(
+    const std::vector<Project *> &projects,
+    const std::vector<Client *> &clients,
+    const std::string &api_token,
+    const TogglClient &toggl_client) {
     error err = noError;
     std::string project_json("");
     for (std::vector<Project *>::const_iterator it =
@@ -4952,7 +4953,7 @@ error Context::pushEntries(
     const std::map<std::string, BaseModel *>&,
     const std::vector<TimeEntry *> &time_entries,
     const std::string &api_token,
-    TogglClient toggl_client) {
+    const TogglClient &toggl_client) {
 
     std::string entry_json("");
     std::string error_message("");

--- a/src/context.h
+++ b/src/context.h
@@ -590,18 +590,20 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pushChanges(
         TogglClient *https_client,
         bool *had_something_to_push);
-    error pushClients(const std::vector<Client *> &clients,
-                      const std::string &api_token,
-                      TogglClient toggl_client);
+    error pushClients(
+        const std::vector<Client *> &clients,
+        const std::string &api_token,
+        const TogglClient &toggl_client);
     error pushProjects(
         const std::vector<Project *> &projects,
         const std::vector<Client *> &clients,
         const std::string &api_token,
-        TogglClient toggl_client);
-    error pushEntries(const std::map<std::string, BaseModel *> &models,
-                      const std::vector<TimeEntry *> &time_entries,
-                      const std::string &api_token,
-                      TogglClient toggl_client);
+        const TogglClient &toggl_client);
+    error pushEntries(
+        const std::map<std::string, BaseModel *> &models,
+        const std::vector<TimeEntry *> &time_entries,
+        const std::string &api_token,
+        const TogglClient &toggl_client);
     error updateEntryProjects(
         const std::vector<Project *> &projects,
         const std::vector<TimeEntry *> &time_entries);

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -225,38 +225,38 @@ error HTTPSClient::statusCodeToError(const Poco::Int64 status_code) const {
 }
 
 HTTPSResponse HTTPSClient::Post(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_POST;
     return request(req);
 }
 
 HTTPSResponse HTTPSClient::Get(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_GET;
     return request(req);
 }
 
 HTTPSResponse HTTPSClient::GetFile(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_GET;
     req.timeout_seconds = kHTTPClientTimeoutSeconds * 10;
     return request(req);
 }
 
 HTTPSResponse HTTPSClient::Delete(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_DELETE;
     return request(req);
 }
 
 HTTPSResponse HTTPSClient::Put(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_PUT;
     return request(req);
 }
 
 HTTPSResponse HTTPSClient::request(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
     HTTPSResponse resp = makeHttpRequest(req);
 
     if (kCannotConnectError == resp.err && isRedirect(resp.status_code)) {
@@ -278,7 +278,7 @@ HTTPSResponse HTTPSClient::request(
 }
 
 HTTPSResponse HTTPSClient::makeHttpRequest(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
 
     HTTPSResponse resp;
 
@@ -520,7 +520,7 @@ Poco::Logger &TogglClient::logger() const {
 }
 
 HTTPSResponse TogglClient::request(
-    HTTPSRequest req) {
+    HTTPSRequest req) const {
 
     error err = TogglStatus.Status();
     if (err != noError) {

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -140,25 +140,25 @@ class TOGGL_INTERNAL_EXPORT HTTPSClient {
     virtual ~HTTPSClient() {}
 
     HTTPSResponse Post(
-        HTTPSRequest req);
+        HTTPSRequest req) const;
 
     HTTPSResponse Get(
-        HTTPSRequest req);
+        HTTPSRequest req) const;
 
     HTTPSResponse GetFile(
-        HTTPSRequest req);
+        HTTPSRequest req) const;
 
     HTTPSResponse Delete(
-        HTTPSRequest req);
+        HTTPSRequest req) const;
 
     HTTPSResponse Put(
-        HTTPSRequest req);
+        HTTPSRequest req) const;
 
     static HTTPSClientConfig Config;
 
  protected:
     virtual HTTPSResponse request(
-        HTTPSRequest req);
+        HTTPSRequest req) const;
 
     virtual Poco::Logger &logger() const;
 
@@ -171,7 +171,7 @@ class TOGGL_INTERNAL_EXPORT HTTPSClient {
     bool isRedirect(const Poco::Int64 status_code) const;
 
     virtual HTTPSResponse makeHttpRequest(
-        HTTPSRequest req);
+        HTTPSRequest req) const;
 };
 
 class TOGGL_INTERNAL_EXPORT SyncStateMonitor {
@@ -190,7 +190,7 @@ class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPSClient {
 
  protected:
     virtual HTTPSResponse request(
-        HTTPSRequest req) override;
+        HTTPSRequest req) const override;
 
     virtual Poco::Logger &logger() const override;
 


### PR DESCRIPTION
### 📒 Description
Not only we used to pass the TogglClient instances as values but a ton of the methods in the class were unnecessarily not marked `const` even though no mutations are going on inside. Now it's possible to safely pass them as const references around. 
Again, this brings along a really slight performance improvement and especailly a bit cleaner code.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
- Same as with most library overhaul PRs, warnings should disappear and the app should continue to compile and work the same on all platforms.

