### PR TITLE
Fix race condition in loadUserTimeEntryFromJSON

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -5238,6 +5238,22 @@ error Context::pushEntries(
             return error("error parsing time entry POST response");
         }
 
+        auto id = root["id"].asUInt64();
+        if (!id) {
+            logger().error("Backend is sending invalid data: ignoring update without an ID");
+            continue;
+        }
+
+        if (!(*it)->ID()) {
+            if (!(user_->SetTimeEntryID(id, (*it)))) {
+                continue;
+            }
+        }
+
+        if ((*it)->ID() != id) {
+            return error("Backend has changed the ID of the entry");
+        }
+
         (*it)->LoadFromJSON(root);
     }
 

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -410,10 +410,6 @@ void TimeEntry::LoadFromJSON(Json::Value data) {
         updated_at = at.asInt64();
     }
 
-    if (data.isMember("id")) {
-        SetID(data["id"].asUInt64());
-    }
-
     if (updated_at != 0 &&
             (UIModifiedAt() >= updated_at ||
              UpdatedAt() >= updated_at)) {

--- a/src/user.cc
+++ b/src/user.cc
@@ -1052,6 +1052,33 @@ void User::loadUserProjectFromJSON(
     model->LoadFromJSON(data);
 }
 
+bool User::SetTimeEntryID(
+    Poco::UInt64 id,
+    TimeEntry* timeEntry) {
+
+    poco_check_ptr(timeEntry);
+
+    {
+        Poco::Mutex::ScopedLock lock(loadTimeEntries_m_);
+        auto otherTimeEntry = related.TimeEntryByID(id);
+        if (otherTimeEntry) {
+            // this means that somehow we already have a time entry with the ID
+            // that was just returned from a response to time entry creation request
+            logger().error("There is already a newer version of this entry");
+
+            // clearing the GUID to make sure there's no GUID conflict
+            timeEntry->SetGUID("");
+
+            // deleting the duplicate entry
+            // this entry has no ID so the corresponding server entry will not be deleted
+            timeEntry->Delete();
+            return false;
+        }
+        timeEntry->SetID(id);
+        return true;
+    }
+}
+
 void User::loadUserTimeEntryFromJSON(
     Json::Value data,
     std::set<Poco::UInt64> *alive) {
@@ -1084,6 +1111,11 @@ void User::loadUserTimeEntryFromJSON(
             model = new TimeEntry();
             model->SetID(id);
             related.pushBackTimeEntry(model);
+        }
+
+        if (!model->ID()) {
+            // case where model was matched by GUID
+            model->SetID(id);
         }
     }
 

--- a/src/user.h
+++ b/src/user.h
@@ -325,6 +325,8 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     bool has_loaded_more_;
     bool collapse_entries_;
+
+    Poco::Mutex loadTimeEntries_m_;
 };
 
 template<class T>

--- a/src/user.h
+++ b/src/user.h
@@ -204,6 +204,10 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     bool LoadUserPreferencesFromJSON(
         Json::Value data);
 
+    bool SetTimeEntryID(
+        Poco::UInt64 id,
+        TimeEntry* timeEntry);
+
     template<typename T>
     void EnsureWID(T *model) const {
         // Do nothing if TE already has WID assigned


### PR DESCRIPTION
### 📒 Description
The method `User::loadUserTimeEntryFromJSON` is being called from multiple threads:
- from the thread performing syncing
- from the thread handling WebSocket messages
- from the thread performing Load More
- from the thread performing post-login user data loading

The `Constraint violation` issue can happen when `related.TimeEntries` vector contains time entries with the same ID. 
The way it can happen is when two threads call `User::loadUserTimeEntryFromJSON` at the same time with JSON data of a brand new entry. This way `TimeEntry *model = related.TimeEntryByID(id);` will return `nullptr` for both of the threads and two entries with the same ID would get added to `related.TimeEntries`. Locking the code between getting the time entry by ID and adding a time entry with ID should fix the issue.
This scenario makes sense considering the users reporting these issues usually mention they often create entries with a web app or a mobile app.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3374
Closes #2186

### 🔎 Review hints
I wasn't able to find proper steps to reproduce. See Description on my explanation on how the bug actually happens.
- Review the code itself
- Test the following:
1. time entry creation
2. time entry editing
3. syncing while starting/editing entries on web or mobile
4. clear cache and sync
5. offline mode