### PR TITLE
No Private Touch Bar APIs In AppStore scheme

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
@@ -63,7 +63,7 @@
                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EMT-i8-OD1" customClass="DescriptionAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
                                             <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Description…" usesSingleLineMode="YES" id="0MM-Wa-hOG" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
-                                                <font key="font" metaFont="system" size="14"/>
+                                                <font key="font" metaFont="menu" size="14"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 <userDefinedRuntimeAttributes>
@@ -97,7 +97,7 @@
                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Doe-dQ-82A" customClass="ProjectAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
                                             <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Select project" usesSingleLineMode="YES" id="6po-73-koG" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
-                                                <font key="font" metaFont="system" size="14"/>
+                                                <font key="font" metaFont="menu" size="14"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 <userDefinedRuntimeAttributes>
@@ -149,7 +149,7 @@
                                                     <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TEs-AY-h6J" customClass="AddTagButton" customModule="TogglDesktop" customModuleProvider="target">
                                                         <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Add tags" usesSingleLineMode="YES" id="yAk-86-67A" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
-                                                            <font key="font" metaFont="system" size="14"/>
+                                                            <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                             <userDefinedRuntimeAttributes>
@@ -195,7 +195,7 @@
                                         <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q9U-uY-bOj" customClass="UndoTextField">
                                             <rect key="frame" x="-2" y="0.0" width="82" height="28"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" title="0:00:00" placeholderString="0:00:00" id="dJu-5a-D7u" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
-                                                <font key="font" metaFont="system" size="14"/>
+                                                <font key="font" metaFont="menu" size="14"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 <userDefinedRuntimeAttributes>
@@ -238,7 +238,7 @@
                                         <rect key="frame" x="-2" y="24" width="69" height="18"/>
                                         <buttonCell key="cell" type="check" title="Billable" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="y28-TJ-qRF">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                            <font key="font" metaFont="system" size="14"/>
+                                            <font key="font" metaFont="menu" size="14"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="billableCheckBoxOnChange:" target="-2" id="P99-UM-Dcd"/>
@@ -308,25 +308,25 @@
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <stackView distribution="equalSpacing" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gKy-N8-5Oe">
-                                                        <rect key="frame" x="23" y="3" width="145" height="25"/>
+                                                        <rect key="frame" x="22" y="3" width="147" height="25"/>
                                                         <subviews>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UYO-W1-uSI" customClass="CursorButton" customModule="TogglDesktop" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="3" width="61" height="18"/>
                                                                 <buttonCell key="cell" type="bevel" title="Tuesday," bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="DZ6-Ag-EuF">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                    <font key="font" metaFont="system" size="14"/>
+                                                                    <font key="font" metaFont="menu" size="14"/>
                                                                 </buttonCell>
                                                                 <connections>
                                                                     <action selector="dayButtonOnTap:" target="-2" id="9Xi-H2-Cv0"/>
                                                                 </connections>
                                                             </button>
                                                             <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PKt-Ig-fee" customClass="KeyboardDatePicker" customModule="TogglDesktop" customModuleProvider="target">
-                                                                <rect key="frame" x="61" y="0.0" width="84" height="25"/>
+                                                                <rect key="frame" x="61" y="0.0" width="86" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="jpF-3X-qFm"/>
                                                                 </constraints>
                                                                 <datePickerCell key="cell" alignment="left" drawsBackground="NO" datePickerStyle="textField" id="eIj-kY-idV">
-                                                                    <font key="font" size="14" name=".SFNSText"/>
+                                                                    <font key="font" metaFont="menu" size="14"/>
                                                                     <date key="date" timeIntervalSinceReferenceDate="-569750400">
                                                                         <!--1982-12-12 16:00:00 +0000-->
                                                                     </date>
@@ -421,7 +421,7 @@
                                         <textField hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aeq-aC-W8G" customClass="TagAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
                                             <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Select tags" id="u0H-N9-7h5" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
-                                                <font key="font" metaFont="system" size="14"/>
+                                                <font key="font" metaFont="menu" size="14"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 <userDefinedRuntimeAttributes>
@@ -451,7 +451,7 @@
                                     <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-ON-SgR" customClass="UndoTextField">
                                         <rect key="frame" x="-2" y="0.0" width="74" height="18"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="center" title="09:20 AM" id="XRL-p8-r7I">
-                                            <font key="font" metaFont="system" size="14"/>
+                                            <font key="font" metaFont="menu" size="14"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="editor-background-color"/>
                                         </textFieldCell>
@@ -475,7 +475,7 @@
                                             <constraint firstAttribute="width" constant="70" id="l2i-Ea-wbs"/>
                                         </constraints>
                                         <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="center" title="09:30 PM" id="m0O-Wy-5Cq">
-                                            <font key="font" metaFont="system" size="14"/>
+                                            <font key="font" metaFont="menu" size="14"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="editor-background-color"/>
                                         </textFieldCell>

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/IdleNotificationTouchBar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/IdleNotificationTouchBar.swift
@@ -15,6 +15,7 @@ import Foundation
 }
 
 @available(OSX 10.12.2, *)
+@objcMembers
 final class IdleNotificationTouchBar: NSObject {
 
     @objc enum Action: Int {

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/LoginSignupTouchBar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/LoginSignupTouchBar.swift
@@ -15,6 +15,7 @@ import Foundation
 }
 
 @available(OSX 10.12.2, *)
+@objcMembers
 final class LoginSignupTouchBar: NSObject {
 
     @objc enum LoginSignupAction: Int {

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -44,7 +44,8 @@ final class TouchBarService: NSObject {
 
     // MARK: Variables
 
-    lazy var touchBar = NSTouchBar()
+    var isEnabled = true
+    private var touchBar: NSTouchBar?
     weak var delegate: TouchBarServiceDelegate?
     private var timeEntries: [TimeEntryViewItem] = []
     private var displayState = DisplayState.normal { didSet { updateDisplayState() }}
@@ -69,11 +70,19 @@ final class TouchBarService: NSObject {
     override init() {
         super.init()
         initCommon()
-        setup()
         initNotification()
     }
 
     // MARK: Public
+
+    func makeTouchBar() -> NSTouchBar? {
+        guard isEnabled else { return nil }
+        touchBar = NSTouchBar()
+        touchBar?.delegate = self
+        touchBar?.customizationIdentifier = .mainTouchBar
+        touchBar?.defaultItemIdentifiers = [.timeEntryItem, .startStopItem]
+        return touchBar
+    }
 
     func updateRunningItem(_ timeEntry: TimeEntryViewItem) {
         runningTimeEntryBtn.title = timeEntry.touchBarTitle
@@ -124,12 +133,6 @@ extension TouchBarService {
         NSApplication.shared.isAutomaticCustomizeTouchBarMenuItemEnabled = false
     }
 
-    fileprivate func setup() {
-        touchBar.delegate = self
-        touchBar.customizationIdentifier = .mainTouchBar
-        touchBar.defaultItemIdentifiers = [.timeEntryItem, .startStopItem]
-    }
-
     fileprivate func initNotification() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(self.stateButtonTimerBarChangeNotification(_:)),
@@ -146,6 +149,7 @@ extension TouchBarService {
     }
 
     private func updateDisplayState() {
+        guard let touchBar = touchBar else { return }
         switch displayState {
         case .normal:
             touchBar.defaultItemIdentifiers.removeAll(where: { $0 == .runningTimeEntry })

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -301,15 +301,6 @@ extern void *ctx;
 
 #pragma mark - Touch Bar
 
-- (NSTouchBar *)makeTouchBar
-{
-	if (self.loginViewController.view.superview != nil)
-	{
-		return nil;
-	}
-	return [[TouchBarService shared] touchBar];
-}
-
 - (void)touchBarServiceStartTimeEntryOnTap
 {
 	[self.timeEntryListViewController.timerEditViewController startButtonClicked:self];

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -148,6 +148,10 @@ extern void *ctx;
 											 selector:@selector(windowDidBecomeKeyNotification:)
 												 name:NSWindowDidBecomeKeyNotification
 											   object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(touchBarSettingChangedNotification:)
+												 name:kTouchBarSettingChanged
+											   object:nil];
 }
 
 - (void)initCollectionView
@@ -728,6 +732,16 @@ extern void *ctx;
 		return;
 	}
 	[self.timerEditViewController focusTimer];
+}
+
+- (NSTouchBar *)makeTouchBar
+{
+	return [[TouchBarService shared] makeTouchBar];
+}
+
+- (void)touchBarSettingChangedNotification:(NSNotification *)noti
+{
+	self.touchBar = nil;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -109,6 +109,10 @@ NSString *kInactiveTimerColor = @"#999999";
 												 selector:@selector(startTimerNotification:)
 													 name:kStartTimer
 												   object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self
+												 selector:@selector(touchBarSettingChangedNotification:)
+													 name:kTouchBarSettingChanged
+												   object:nil];
 
 		self.time_entry = [[TimeEntryViewItem alloc] init];
 
@@ -788,6 +792,16 @@ NSString *kInactiveTimerColor = @"#999999";
 	{
 		[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
 	}
+}
+
+- (NSTouchBar *)makeTouchBar
+{
+	return [[TouchBarService shared] makeTouchBar];
+}
+
+- (void)touchBarSettingChangedNotification:(NSNotification *)noti
+{
+	self.touchBar = nil;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		3C1E013F19D2DAE300DBF9A5 /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 3C1E013E19D2DAE300DBF9A5 /* dsa_pub.pem */; };
 		3C2F239D21A7B43400CBE6BC /* UnsupportedNotice.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2F239C21A7B43300CBE6BC /* UnsupportedNotice.m */; };
 		3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C3AF64D20ACC6280088A3A6 /* CountryViewItem.m */; };
-		3C50BCAC1C1F0574004BAE9E /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		3C50BCAC1C1F0574004BAE9E /* (null) in Resources */ = {isa = PBXBuildFile; };
 		3C6B2486203E01D90063FC08 /* AutoCompleteTableCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B2480203E01D60063FC08 /* AutoCompleteTableCell.m */; };
 		3C6B2487203E01D90063FC08 /* AutoCompleteInput.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B2483203E01D90063FC08 /* AutoCompleteInput.m */; };
 		3C6B2488203E01D90063FC08 /* AutoCompleteTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B2484203E01D90063FC08 /* AutoCompleteTable.m */; };
@@ -30,7 +30,7 @@
 		3CE30E022052BD8B00AF2E2A /* AutoCompleteTableContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE30E012052BD8B00AF2E2A /* AutoCompleteTableContainer.m */; };
 		3CFE547E201781A7006B673A /* libcrypto.1.1.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3CFE546D201781A5006B673A /* libcrypto.1.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3CFE547F201781A7006B673A /* libssl.1.1.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3CFE547D201781A5006B673A /* libssl.1.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		5B29B9409F01EC0E842DE86D /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		5B29B9409F01EC0E842DE86D /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		622BBF654A6A958692A4633B /* Pods_TogglDesktop.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 776525112125F6AD81DF4DEF /* Pods_TogglDesktop.framework */; };
 		69FC17F517E6534400B96425 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69FC17F417E6534400B96425 /* Cocoa.framework */; };
 		69FC17FF17E6534400B96425 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 69FC17FD17E6534400B96425 /* InfoPlist.strings */; };
@@ -437,7 +437,7 @@
 		BAE64E1E2368334000244D2B /* ClientCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA412C22224E11AC003CA17A /* ClientCellView.xib */; };
 		BAE64E1F2368334000244D2B /* FloatingErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA276A132240F5B500810C51 /* FloatingErrorView.xib */; };
 		BAE64E202368334000244D2B /* TimeEntryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74D1D25517EB713F00E709B0 /* TimeEntryListViewController.xib */; };
-		BAE64E212368334000244D2B /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		BAE64E212368334000244D2B /* (null) in Resources */ = {isa = PBXBuildFile; };
 		BAE64E222368334000244D2B /* TagCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA0140472257080F000E5B91 /* TagCellView.xib */; };
 		BAE64E232368334000244D2B /* ProjectCreationView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA9C2DF9224C7E77002AD2A1 /* ProjectCreationView.xib */; };
 		BAE64E242368334000244D2B /* NoClientCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA412C28224E196D003CA17A /* NoClientCellView.xib */; };
@@ -622,7 +622,6 @@
 		3C8979C819235EA2007061E0 /* NSTextFieldClickablePointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextFieldClickablePointer.h; sourceTree = "<group>"; };
 		3C8979C919235EA2007061E0 /* NSTextFieldClickablePointer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSTextFieldClickablePointer.m; sourceTree = "<group>"; };
 		3CB7CFD92222033B00A9C806 /* DFRFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DFRFoundation.framework; path = ../../../../../../../../System/Library/PrivateFrameworks/DFRFoundation.framework; sourceTree = "<group>"; };
-		3CB7CFF92222047C00A9C806 /* TouchBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TouchBar.h; sourceTree = "<group>"; };
 		3CC450E71A31ED540012440B /* NSTextFieldDuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextFieldDuration.h; sourceTree = "<group>"; };
 		3CC450E81A31ED540012440B /* NSTextFieldDuration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSTextFieldDuration.m; sourceTree = "<group>"; };
 		3CD30F401F58B02C006FAA0D /* OverlayViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OverlayViewController.h; sourceTree = "<group>"; };
@@ -807,6 +806,7 @@
 		BA412C26224E195C003CA17A /* NoClientCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoClientCellView.swift; sourceTree = "<group>"; };
 		BA412C28224E196D003CA17A /* NoClientCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoClientCellView.xib; sourceTree = "<group>"; };
 		BA46E09E2226707F00C25763 /* Collection+Safe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Safe.swift"; sourceTree = "<group>"; };
+		BA4A7D502375527B00A42095 /* TouchBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TouchBar.h; path = test2/TouchBar.h; sourceTree = SOURCE_ROOT; };
 		BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizablePopover.swift; sourceTree = "<group>"; };
 		BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarFlowLayout.swift; sourceTree = "<group>"; };
 		BA5B0E4D2330E1C6008D1DED /* GoogleAuthenticationServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthenticationServer.swift; sourceTree = "<group>"; };
@@ -932,7 +932,7 @@
 				74E3CDD717FBAE0800C3ADD3 /* SystemConfiguration.framework in Frameworks */,
 				74033C9717EC1DE100CA53D3 /* libc++.dylib in Frameworks */,
 				69FC17F517E6534400B96425 /* Cocoa.framework in Frameworks */,
-				5B29B9409F01EC0E842DE86D /* BuildFile in Frameworks */,
+				5B29B9409F01EC0E842DE86D /* (null) in Frameworks */,
 				622BBF654A6A958692A4633B /* Pods_TogglDesktop.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1365,7 +1365,6 @@
 				BA3E75D722293576009AD291 /* SystemMessageView.xib */,
 				BA276A122240F5B500810C51 /* FloatingErrorView.swift */,
 				BA276A132240F5B500810C51 /* FloatingErrorView.xib */,
-				3CB7CFF92222047C00A9C806 /* TouchBar.h */,
 			);
 			path = SystemMessage;
 			sourceTree = "<group>";
@@ -1569,6 +1568,7 @@
 		BAF3ACCA2341F86300E41B33 /* TouchBar */ = {
 			isa = PBXGroup;
 			children = (
+				BA4A7D502375527B00A42095 /* TouchBar.h */,
 				BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */,
 				BAF3ACD22343325A00E41B33 /* TouchBarService.swift */,
 				BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */,
@@ -1800,7 +1800,7 @@
 				BA412C23224E11AC003CA17A /* ClientCellView.xib in Resources */,
 				BAF38FEF2241FF20009147D7 /* FloatingErrorView.xib in Resources */,
 				74D1D25817EB713F00E709B0 /* TimeEntryListViewController.xib in Resources */,
-				3C50BCAC1C1F0574004BAE9E /* BuildFile in Resources */,
+				3C50BCAC1C1F0574004BAE9E /* (null) in Resources */,
 				BA0140482257080F000E5B91 /* TagCellView.xib in Resources */,
 				BA9C2DFA224C7E77002AD2A1 /* ProjectCreationView.xib in Resources */,
 				BA412C29224E196D003CA17A /* NoClientCellView.xib in Resources */,
@@ -1851,7 +1851,7 @@
 				BAE64E1E2368334000244D2B /* ClientCellView.xib in Resources */,
 				BAE64E1F2368334000244D2B /* FloatingErrorView.xib in Resources */,
 				BAE64E202368334000244D2B /* TimeEntryListViewController.xib in Resources */,
-				BAE64E212368334000244D2B /* BuildFile in Resources */,
+				BAE64E212368334000244D2B /* (null) in Resources */,
 				BAE64E222368334000244D2B /* TagCellView.xib in Resources */,
 				BAE64E232368334000244D2B /* ProjectCreationView.xib in Resources */,
 				BAE64E242368334000244D2B /* NoClientCellView.xib in Resources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -159,6 +159,12 @@
 		BA412C27224E195C003CA17A /* NoClientCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA412C26224E195C003CA17A /* NoClientCellView.swift */; };
 		BA412C29224E196D003CA17A /* NoClientCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA412C28224E196D003CA17A /* NoClientCellView.xib */; };
 		BA46E09F2226707F00C25763 /* Collection+Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46E09E2226707F00C25763 /* Collection+Safe.swift */; };
+		BA4A7D5123755A3700A42095 /* TimeEntryScrubberFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9F2234C7BB80011A703 /* TimeEntryScrubberFlowLayout.swift */; };
+		BA4A7D5223755A3D00A42095 /* TimeEntryScrubberItem.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA00E9F4234C848A0011A703 /* TimeEntryScrubberItem.xib */; };
+		BA4A7D5323755A4200A42095 /* GlobalTouchbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */; };
+		BA4A7D5423755A4200A42095 /* TouchBarService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACD22343325A00E41B33 /* TouchBarService.swift */; };
+		BA4A7D5523755A4200A42095 /* TouchBarService+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */; };
+		BA4A7D5623755A4200A42095 /* TimeEntryScrubberItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9EF234C73990011A703 /* TimeEntryScrubberItem.swift */; };
 		BA4AEB9C22C217A4001A898D /* ResizablePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */; };
 		BA50ED8522705F9E008323FA /* CalendarFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */; };
 		BA5B0E4E2330E1C6008D1DED /* GoogleAuthenticationServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B0E4D2330E1C6008D1DED /* GoogleAuthenticationServer.swift */; };
@@ -1819,6 +1825,7 @@
 				BAE64DFE2368334000244D2B /* ProjectHeaderCellView.xib in Resources */,
 				BAE64DFF2368334000244D2B /* ProjectWorksapceCellView.xib in Resources */,
 				BAE64E002368334000244D2B /* Images.xcassets in Resources */,
+				BA4A7D5223755A3D00A42095 /* TimeEntryScrubberItem.xib in Resources */,
 				BAE64E012368334000244D2B /* EditorViewController.xib in Resources */,
 				BAE64E022368334000244D2B /* cacert.pem in Resources */,
 				BAE64E032368334000244D2B /* DescriptionContentCellView.xib in Resources */,
@@ -2317,6 +2324,7 @@
 				BAE64D7F2368334000244D2B /* LoadMoreCell.m in Sources */,
 				BAE64D802368334000244D2B /* PreferencesWindowController.m in Sources */,
 				BAE64D812368334000244D2B /* NSTextFieldVerticallyAligned.m in Sources */,
+				BA4A7D5623755A4200A42095 /* TimeEntryScrubberItem.swift in Sources */,
 				BAE64D822368334000244D2B /* DayLabel.swift in Sources */,
 				BAE64D832368334000244D2B /* NSSecureTextFieldVerticallyAligned.m in Sources */,
 				BAE64D842368334000244D2B /* TimeEntryCell+Ext.swift in Sources */,
@@ -2337,6 +2345,7 @@
 				BAE64D932368334000244D2B /* EditorViewController.swift in Sources */,
 				BAE64D942368334000244D2B /* AutoCompleteTableCell+Ext.swift in Sources */,
 				BAE64D952368334000244D2B /* LiteAutoCompleteDataSource.m in Sources */,
+				BA4A7D5323755A4200A42095 /* GlobalTouchbarButton.swift in Sources */,
 				BAE64D962368334000244D2B /* DescriptionDataSource.swift in Sources */,
 				BAE64D972368334000244D2B /* TagDataSource.swift in Sources */,
 				BAE64D982368334000244D2B /* ColorGraphicsView.swift in Sources */,
@@ -2378,6 +2387,7 @@
 				BAE64DBC2368334000244D2B /* NSView+LayoutConstraint.swift in Sources */,
 				BAE64DBD2368334000244D2B /* ProjectDataSource.swift in Sources */,
 				BAE64DBE2368334000244D2B /* AutoCompleteRowView.swift in Sources */,
+				BA4A7D5523755A4200A42095 /* TouchBarService+Name.swift in Sources */,
 				BAE64DBF2368334000244D2B /* NSView+Shadow+Border.swift in Sources */,
 				BAE64DC02368334000244D2B /* ResizablePopover.swift in Sources */,
 				BAE64DC12368334000244D2B /* UndoManager.swift in Sources */,
@@ -2410,6 +2420,7 @@
 				BAE64DDC2368334000244D2B /* DotImageView.swift in Sources */,
 				BAE64DDD2368334000244D2B /* TagAutoCompleteTextField.swift in Sources */,
 				BAE64DDE2368334000244D2B /* ProjectAutoCompleteTextField.swift in Sources */,
+				BA4A7D5423755A4200A42095 /* TouchBarService.swift in Sources */,
 				BAE64DDF2368334000244D2B /* HSBGen.swift in Sources */,
 				BAE64DE02368334000244D2B /* GoogleAuthenticationServer.swift in Sources */,
 				BAE64DE12368334000244D2B /* WorkspaceCellView.swift in Sources */,
@@ -2429,6 +2440,7 @@
 				BAE64DEF2368334000244D2B /* FloatingErrorView.swift in Sources */,
 				BAE64DF02368334000244D2B /* LoginViewController.m in Sources */,
 				BAE64DF12368334000244D2B /* IdleEvent.m in Sources */,
+				BA4A7D5123755A3700A42095 /* TimeEntryScrubberFlowLayout.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		BA50ED8522705F9E008323FA /* CalendarFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */; };
 		BA5B0E4E2330E1C6008D1DED /* GoogleAuthenticationServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B0E4D2330E1C6008D1DED /* GoogleAuthenticationServer.swift */; };
 		BA5B0E502330EA92008D1DED /* GoogleAuthenticationServer+Objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B0E4F2330EA92008D1DED /* GoogleAuthenticationServer+Objc.swift */; };
+		BA63ABEE238284D9004C70CF /* IdleNotificationTouchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32134B236C1E1400D33367 /* IdleNotificationTouchBar.swift */; };
+		BA63ABEF238284DB004C70CF /* LoginSignupTouchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA133ABF23740EA6003A6A3A /* LoginSignupTouchBar.swift */; };
 		BA6572A6224DFA6F00BA4C60 /* RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A0224DFA6E00BA4C60 /* RGB.swift */; };
 		BA6572A7224DFA6F00BA4C60 /* HSBGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A1224DFA6E00BA4C60 /* HSBGen.swift */; };
 		BA6572A8224DFA6F00BA4C60 /* CurrentColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A2224DFA6F00BA4C60 /* CurrentColorView.swift */; };
@@ -2318,6 +2320,7 @@
 				BAE64D792368334000244D2B /* SystemMessage.swift in Sources */,
 				BAE64D7A2368334000244D2B /* WorkspaceAutoCompleteTextField.swift in Sources */,
 				BAE64D7B2368334000244D2B /* NSTextFieldClickablePointer.m in Sources */,
+				BA63ABEE238284D9004C70CF /* IdleNotificationTouchBar.swift in Sources */,
 				BAE64D7C2368334000244D2B /* DisplayCommand.m in Sources */,
 				BAE64D7D2368334000244D2B /* ColorViewItem.swift in Sources */,
 				BAE64D7E2368334000244D2B /* MenuItemTags.m in Sources */,
@@ -2406,6 +2409,7 @@
 				BAE64DCE2368334000244D2B /* Theme+Notification.swift in Sources */,
 				BAE64DCF2368334000244D2B /* AboutWindowController.m in Sources */,
 				BAE64DD02368334000244D2B /* TimerEditViewController.m in Sources */,
+				BA63ABEF238284DB004C70CF /* LoginSignupTouchBar.swift in Sources */,
 				BAE64DD12368334000244D2B /* UnsupportedNotice.m in Sources */,
 				BAE64DD22368334000244D2B /* NSTextFieldWithBackground.m in Sources */,
 				BAE64DD32368334000244D2B /* Array+ByGroup.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -55,6 +55,7 @@ extern NSString *const kDisplayCountries;
 extern NSString *const kUpdateIconTooltip;
 extern NSString *const kUserHasBeenSignup;
 extern NSString *const kDeselectAllTimeEntryList;
+extern NSString *const kTouchBarSettingChanged;
 
 const char *kFocusedFieldNameDuration;
 const char *kFocusedFieldNameDescription;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -51,6 +51,7 @@ NSString *const kToggleGroup = @"ToggleGroup";
 NSString *const kDisplayCountries = @"kDisplayCountries";
 NSString *const kUpdateIconTooltip = @"kUpdateIconTooltip";
 NSString *const kUserHasBeenSignup = @"kUserHasBeenSignup";
+NSString *const kTouchBarSettingChanged = @"kTouchBarSettingChanged";
 
 NSString *const kDeselectAllTimeEntryList = @"kDeselectAllTimeEntryList";
 

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1804,6 +1804,7 @@ void on_countries(TogglCountryView *first)
 
 - (void)handleTouchBarWithSettings:(Settings *)settings
 {
+#ifndef APP_STORE
 	if (@available(macOS 10.12.2, *))
 	{
 		// Show/Hide
@@ -1837,6 +1838,7 @@ void on_countries(TogglCountryView *first)
 			DFRElementSetControlStripPresenceForIdentifier([GlobalTouchbarButton ID], NO);
 		}
 	}
+#endif
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1804,6 +1804,9 @@ void on_countries(TogglCountryView *first)
 
 - (void)handleTouchBarWithSettings:(Settings *)settings
 {
+	[TouchBarService shared].isEnabled = settings.showTouchBar;
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kTouchBarSettingChanged object:@(settings.showTouchBar)];
+
 #ifndef APP_STORE
 	if (@available(macOS 10.12.2, *))
 	{

--- a/src/ui/osx/TogglDesktop/test2/TouchBar.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar.h
@@ -9,6 +9,7 @@
 #ifndef TouchBar_h
 #define TouchBar_h
 
+#ifndef APP_STORE
 #import <AppKit/AppKit.h>
 
 extern void DFRElementSetControlStripPresenceForIdentifier(NSString *, BOOL);
@@ -26,5 +27,6 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
 + (void)presentSystemModalFunctionBar:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSString *)identifier;
 
 @end
+#endif
 
 #endif /* TouchBar_h */


### PR DESCRIPTION
### 📒 Description
This PR introduce 2 things:
+ No Private TouchBar APIs in AppStore Scheme
+ Improve how the "Show Toggl in TouchBar" in Preference -> Show/Hide all touch bar, not just the Global Toggl Button (in the Stripe Touch Bar)

### ⚠️ Warning
This branch is branched off from #3458, so make sure that we review it before starting on this PR. 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Disable Private APIs in AppStore
- [x] Refactor how we handle "Show Toggl in Touch Bar" -> Show/Hide all touch bars

### 👫 Relationships
Closes #3370

### 🔎 Review hints
#### AppStore version has no Global Toggl Button
1. Select AppStore Scheme in Xcode
2. There is no Global Touch Bar -> 💯 

#### Normal version has Global Toggl Button
1. Select Normal Scheme in Xcode
2. Global Touch Bar presents properly (depend on Preference) -> 💯 

#### Touch Bar presents or dismiss properly
1. Select normal scheme or AppStore
2. Toggl "Show Toggl in Touch Bar" in Preference
3. Back to TimeEntry List
4. Time Entry Touch Bar + Global Button would be presented or dismissed properly.
