### PR TITLE
Fix wrong duration value when compressing the events

### DIFF
--- a/src/timeline_event.cc
+++ b/src/timeline_event.cc
@@ -38,6 +38,7 @@ void TimelineEvent::SetTitle(const std::string &value) {
 void TimelineEvent::SetStart(const Poco::Int64 value) {
     if (start_time_ != value) {
         start_time_ = value;
+        updateDuration();
         SetDirty();
     }
 }
@@ -45,13 +46,8 @@ void TimelineEvent::SetStart(const Poco::Int64 value) {
 void TimelineEvent::SetEndTime(const Poco::Int64 value) {
     if (end_time_ != value) {
         end_time_ = value;
+        updateDuration();
         SetDirty();
-    }
-}
-
-void TimelineEvent::SetDuration(const Poco::UInt64 value) {
-    if (duration_ != value) {
-        duration_ = value;
     }
 }
 
@@ -92,6 +88,11 @@ Json::Value TimelineEvent::SaveToJSON() const {
     n["end_time"] = Json::Int64(EndTime());
     n["created_with"] = "timeline";
     return n;
+}
+
+void TimelineEvent::updateDuration() {
+    Poco::Int64 value = end_time_ - start_time_;
+    duration_ = value < 0 ? 0 : value;
 }
 
 }   // namespace toggl

--- a/src/timeline_event.h
+++ b/src/timeline_event.h
@@ -46,7 +46,6 @@ class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent 
     const Poco::Int64 &Duration() const {
         return duration_;
     }
-    void SetDuration(const Poco::UInt64 value);
 
     const bool &Idle() const {
         return idle_;
@@ -88,6 +87,8 @@ class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent 
     bool idle_;
     bool chunked_;
     bool uploaded_;
+
+    void updateDuration();
 };
 
 }  // namespace toggl

--- a/src/user.cc
+++ b/src/user.cc
@@ -1382,7 +1382,7 @@ void User::CompressTimeline() {
         std::string key = ss.str();
 
         // Calculate positive value of timeline event duration
-        time_t duration = event->Duration();
+        time_t duration = event->EndTime() - event->Start();
         if (duration < 0) {
             duration = 0;
         }

--- a/src/user.cc
+++ b/src/user.cc
@@ -1382,7 +1382,7 @@ void User::CompressTimeline() {
         std::string key = ss.str();
 
         // Calculate positive value of timeline event duration
-        time_t duration = event->EndTime() - event->Start();
+        time_t duration = event->Duration();
         if (duration < 0) {
             duration = 0;
         }
@@ -1442,8 +1442,6 @@ std::vector<TimelineEvent> User::CompressedTimeline(
                     event_date.day() != date->day()) {
                 continue;
             }
-            // Set Event Duration
-            event->SetDuration(event->EndTime() - event->Start());
         }
         // Make a copy of the timeline event
         list.push_back(*event);


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix when the compression Timeline accidentally update the end_time in the database.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Calculate the real duration whenever updating the start_time and end_time in TimelineEvent 

### 👫 Relationships
Closes #3500 

### 🔎 Review hints
1. Checkout this branch
2. Cherry pick the "Pre-Populate Data" from https://github.com/toggl/toggldesktop/pull/3333/commits/67023b2cc65e1e44054d048b77516d98bd168026 in https://github.com/toggl/toggldesktop/pull/3333
3. Open the app -> Help Menu -> Import Data
4. Restart the app and open the Timeline Tab
5. Able to see the past events properly -> 💯 

<img width="1032" alt="Screen Shot 2019-11-11 at 14 07 41" src="https://user-images.githubusercontent.com/5878421/68569432-a64bab00-0490-11ea-88c2-d3decc7c298f.png">


