### PR TITLE
Reduce workspace/preferences and preferences/desktop fetches (lib)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2451,12 +2451,12 @@ error Context::Login(
             return displayError(err);
         }
 
-        err = pullWorkspacePreferences(&client);
+        err = pullWorkspacePreferences(client);
         if (err != noError) {
             return displayError(err);
         }
 
-        err = pullUserPreferences(&client);
+        err = pullUserPreferences(client);
         if (err != noError) {
             return displayError(err);
         }
@@ -4743,7 +4743,7 @@ void Context::syncerActivity() {
                 }
 
                 if (trigger_full_sync_) {
-                    err = pullAllPreferencesData(&client);
+                    err = pullAllPreferencesData(client);
                     if (err != noError) {
                         displayError(err);
                     }
@@ -4915,7 +4915,7 @@ void Context::SetLogPath(const std::string &path) {
 }
 
 error Context::pullAllPreferencesData(
-    TogglClient* toggl_client) {
+    const TogglClient& toggl_client) {
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
@@ -5318,7 +5318,7 @@ error Context::pushEntries(
 
             // if time entry is locked pull the updated info about locked reports in the workspaces
             if ((*it)->isLocked(resp.body)) {
-                pullWorkspacePreferences(&toggl_client);
+                pullWorkspacePreferences(toggl_client);
                 displayError(save(false));
             }
 
@@ -5631,7 +5631,7 @@ error Context::pullWorkspaces(TogglClient* toggl_client) {
     return noError;
 }
 
-error Context::pullWorkspacePreferences(TogglClient* toggl_client) {
+error Context::pullWorkspacePreferences(const TogglClient& toggl_client) {
     std::vector<Workspace*> workspaces;
     {
         Poco::Mutex::ScopedLock lock(user_m_);
@@ -5671,7 +5671,7 @@ error Context::pullWorkspacePreferences(TogglClient* toggl_client) {
 }
 
 error Context::pullWorkspacePreferences(
-    TogglClient* toggl_client,
+    const TogglClient& toggl_client,
     Workspace* workspace,
     std::string* json) {
 
@@ -5693,7 +5693,7 @@ error Context::pullWorkspacePreferences(
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client->Get(req);
+        HTTPSResponse resp = toggl_client.Get(req);
         if (resp.err != noError) {
             return resp.err;
         }
@@ -5713,7 +5713,7 @@ error Context::pullWorkspacePreferences(
 }
 
 error Context::pullUserPreferences(
-    TogglClient* toggl_client) {
+    const TogglClient& toggl_client) {
     std::string api_token = user_->APIToken();
 
     if (api_token.empty()) {
@@ -5729,7 +5729,7 @@ error Context::pullUserPreferences(
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client->Get(req);
+        HTTPSResponse resp = toggl_client.Get(req);
         if (resp.err != noError) {
             return resp.err;
         }

--- a/src/context.h
+++ b/src/context.h
@@ -622,7 +622,6 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error applySettingsSaveResultToUI(const error &err);
 
     error pullAllUserData(TogglClient *https_client);
-    error pullChanges(TogglClient *https_client);
     error pullUserPreferences(
         const TogglClient& toggl_client);
     error pullAllPreferencesData(const TogglClient& toggl_client);

--- a/src/context.h
+++ b/src/context.h
@@ -621,13 +621,13 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error applySettingsSaveResultToUI(const error &err);
 
-    error pullAllUserData(TogglClient *https_client);
+    error pullAllUserData(const TogglClient &https_client);
     error pullUserPreferences(
-        const TogglClient& toggl_client);
-    error pullAllPreferencesData(const TogglClient& toggl_client);
+        const TogglClient &toggl_client);
+    error pullAllPreferencesData(const TogglClient &toggl_client);
 
     error pushChanges(
-        TogglClient *https_client,
+        const TogglClient &https_client,
         bool *had_something_to_push);
     error pushClients(
         const std::vector<Client *> &clients,
@@ -647,17 +647,17 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const std::vector<Project *> &projects,
         const std::vector<TimeEntry *> &time_entries);
     error signup(
-        TogglClient *https_client,
+        const TogglClient &https_client,
         const std::string &email,
         const std::string &password,
         std::string *user_data_json,
         const uint64_t country_id);
     error signupGoogle(
-        TogglClient *toggl_client,
+        const TogglClient &toggl_client,
         const std::string &access_token,
         std::string *user_data_json,
         const uint64_t country_id);
-    static error me(TogglClient *https_client,
+    static error me(const TogglClient &https_client,
                     const std::string &email,
                     const std::string &password,
                     std::string *user_data,
@@ -670,10 +670,10 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error logAndDisplayUserTriedEditingLockedEntry();
 
-    error pullWorkspaces(TogglClient* toggl_client);
+    error pullWorkspaces(const TogglClient &toggl_client);
 
-    error pullWorkspacePreferences(const TogglClient& https_client);
-    error pullWorkspacePreferences(const TogglClient& toggl_client,
+    error pullWorkspacePreferences(const TogglClient &https_client);
+    error pullWorkspacePreferences(const TogglClient &toggl_client,
                                    Workspace *workspace, std::string* json);
 
     error pushObmAction();

--- a/src/context.h
+++ b/src/context.h
@@ -625,6 +625,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pullChanges(TogglClient *https_client);
     error pullUserPreferences(
         TogglClient* toggl_client);
+    error pullAllPreferencesData(TogglClient* toggl_client);
 
     error pushChanges(
         TogglClient *https_client,
@@ -734,6 +735,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     bool trigger_sync_;
     bool trigger_push_;
+    bool trigger_full_sync_;
 
     Poco::LocalDateTime last_time_entry_list_render_at_;
 

--- a/src/context.h
+++ b/src/context.h
@@ -624,8 +624,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pullAllUserData(TogglClient *https_client);
     error pullChanges(TogglClient *https_client);
     error pullUserPreferences(
-        TogglClient* toggl_client);
-    error pullAllPreferencesData(TogglClient* toggl_client);
+        const TogglClient& toggl_client);
+    error pullAllPreferencesData(const TogglClient& toggl_client);
 
     error pushChanges(
         TogglClient *https_client,
@@ -673,8 +673,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error pullWorkspaces(TogglClient* toggl_client);
 
-    error pullWorkspacePreferences(TogglClient* https_client);
-    error pullWorkspacePreferences(TogglClient* https_client,
+    error pullWorkspacePreferences(const TogglClient& https_client);
+    error pullWorkspacePreferences(const TogglClient& toggl_client,
                                    Workspace *workspace, std::string* json);
 
     error pushObmAction();

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -78,6 +78,10 @@ bool TimeEntry::isNotFound(const error &err) const {
     return std::string::npos != std::string(err).find(
         "Time entry not found");
 }
+bool TimeEntry::isLocked(const error& err) const {
+    return std::string::npos != std::string(err).find(
+        "Entries can't be added or edited in this period");
+}
 bool TimeEntry::isMissingCreatedWith(const error &err) const {
     return std::string::npos != std::string(err).find(
         "created_with needs to be provided an a valid string");

--- a/src/time_entry.h
+++ b/src/time_entry.h
@@ -141,6 +141,8 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
 
     bool isNotFound(const error &err) const;
 
+    bool isLocked(const error& err) const;
+
     const std::string GroupHash() const;
 
  private:


### PR DESCRIPTION
### 📒 Description
Reduce workspace/preferences and preferences/desktop fetches

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- Perform workspace/preferences fetches only on locked time entry errors, login, and full sync.
- Perform preferences/desktop fetches only on login and full sync.
- `TogglClient` is now passed as a const reference instead of a pointer. I had to fix a few methods due to conflicts with #3344, then went on and fixed all the other ones.

### 👫 Relationships
Closes #3417 

### 🔎 Review hints
1. Test that `preferences/desktop` fetch is performed on full sync and on login:
- Open the desktop app
- Open the web app, go to Profile settings -> Group similar time entries -> Check or uncheck the checkbox
- Trigger sync manually in the desktop app / Log out and log back into the desktop app
- Make sure the time entry grouping setting was applied

2. Test that `workspace/preferences` fetch is performed on full sync and on login:
- Open the desktop app
- Open the web app, lock time entries (https://support.toggl.com/en/articles/2206898-locking-time-entries)
- Trigger sync manually in the desktop app / Log out and log back into the desktop app
- Make sure the entries are displayed as locked

3. Test that `workspace/preferences` fetch is performed when the locked time entry error is received.
- Open the desktop app
- Open the web app, lock time entries (https://support.toggl.com/en/articles/2206898-locking-time-entries)
- Try editing an entry that is supposed to be locked
- The entries are displayed as locked without the need to manually trigger the sync.
Unfortunately, this leads to a bad state, caused by #3513 and #3512. I suggest fixing these issues is out of scope of this PR as they can happen now as well.