### PR TITLE
UI constrains issues when the list is empty

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -81,6 +81,7 @@ final class AutoCompleteView: NSView {
 
     @IBOutlet weak var tableView: KeyboardTableView!
     @IBOutlet weak var tableViewHeight: NSLayoutConstraint!
+    @IBOutlet weak var tableScrollView: NSScrollView!
     @IBOutlet weak var createNewItemBtn: CursorButton!
     @IBOutlet weak var createNewItemContainerView: NSBox!
     @IBOutlet weak var horizontalLine: NSBox!
@@ -128,8 +129,11 @@ final class AutoCompleteView: NSView {
         // Make sure >= 0
         height = CGFloat.maximum(height, 0)
 
-        // Overriden
-        tableViewHeight.constant = height
+        // Hide or show the ScrollView to prevent UI Constraints ambiguous
+        tableScrollView.isHidden = height == 0
+        if height > 0 {
+            tableViewHeight.constant = height
+        }
     }
 
     func setCreateButtonSectionHidden(_ isHidden: Bool) {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -53,14 +53,14 @@
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" viewBased="YES" id="HmX-fe-ZLW" customClass="KeyboardTableView" customModule="TogglDesktop" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="240" height="150"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="0.0"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                     <tableColumns>
                                                         <tableColumn width="237" minWidth="40" maxWidth="1000" id="oJU-jg-bNN">
                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <font key="font" metaFont="message" size="11"/>
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                             </tableHeaderCell>
@@ -102,7 +102,7 @@
                                                     <rect key="frame" x="4" y="6" width="238" height="36"/>
                                                     <buttonCell key="cell" type="bevel" title=" Create a new Project" bezelStyle="rounded" image="add-icon" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" imageScaling="proportionallyDown" inset="2" id="thJ-D8-tYu">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="system" size="14"/>
+                                                        <font key="font" metaFont="menu" size="14"/>
                                                     </buttonCell>
                                                     <color key="contentTintColor" name="grey-text-color"/>
                                                     <connections>
@@ -170,6 +170,7 @@
                 <outlet property="placeholderBox" destination="p5b-iT-O8A" id="xwL-fP-30A"/>
                 <outlet property="placeholderBoxContainerView" destination="beQ-V1-NYT" id="AIi-01-oac"/>
                 <outlet property="stackView" destination="GoP-8R-z9o" id="WsH-Dy-JAF"/>
+                <outlet property="tableScrollView" destination="ozk-6N-fZL" id="FOE-1w-XbO"/>
                 <outlet property="tableView" destination="HmX-fe-ZLW" id="av0-YS-nIR"/>
                 <outlet property="tableViewHeight" destination="nCT-aH-EfR" id="LFE-wE-2Yq"/>
             </connections>


### PR DESCRIPTION
### 📒 Description
During investigating https://github.com/toggl/toggldesktop/issues/3324, there is an UI-related issues when the AutoComplete List is empty

<img width="355" alt="Screen Shot 2019-11-11 at 18 03 23" src="https://user-images.githubusercontent.com/5878421/68582627-c9388800-04ad-11ea-8028-e95fc86f73a8.png">
<img width="327" alt="Screen Shot 2019-11-11 at 18 03 14" src="https://user-images.githubusercontent.com/5878421/68582629-c9388800-04ad-11ea-8d8f-22fac60d53bf.png">
 
Since I couldn't reproduce the host issue and the code looks good, so I suppose this PR could resolve it.

https://github.com/toggl/toggldesktop/blob/eb7230765c7ba77940cd35f7062d93548422c20d/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift#L112-L133

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Hide the Scroller of the TableView when the height is 0

### 👫 Relationships
Could fix #3324

### 🔎 Review hints
1. Open Editor
2. Search or open the Description/Project/Client, ...
3. Try to type and make sure there is no UI Constrain anymore (The Purple view)

![2019-11-11 17 44 19](https://user-images.githubusercontent.com/5878421/68582761-1b79a900-04ae-11ea-9d08-3804ab45bc4d.gif)


