### PR TITLE
Fix the AutoComplete appears unexpectedly when editing the TimeEntry

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.h
+++ b/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.h
@@ -19,7 +19,14 @@ typedef NS_ENUM (NSUInteger, AutoCompleteDisplayMode)
 	AutoCompleteDisplayModeFullscreen,
 };
 
+@protocol AutoCompleteInputDelegate <NSObject>
+
+- (void)autoCompleteInputShouldResetFilter;
+
+@end
+
 @interface AutoCompleteInput : UndoTextField
+@property (weak, nonatomic) id<AutoCompleteInputDelegate> inputDelegate;
 @property (strong, nonatomic, readonly) AutoCompleteTable *autocompleteTableView;
 @property (strong, nonatomic, readonly) AutoCompleteTableContainer *autocompleteTableContainer;
 @property (assign, nonatomic, readonly) CGFloat itemHeight;

--- a/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
+++ b/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
@@ -222,6 +222,7 @@ static NSString *const upArrow = @"\u25B2";
 
 - (void)resetTable
 {
+	[self.inputDelegate autoCompleteInputShouldResetFilter];
 	[self showAutoComplete:NO];
 	[self.autocompleteTableView resetSelected];
 }

--- a/src/ui/osx/TogglDesktop/test2/LiteAutoCompleteDataSource.m
+++ b/src/ui/osx/TogglDesktop/test2/LiteAutoCompleteDataSource.m
@@ -13,7 +13,7 @@
 #import "AutoCompleteInput.h"
 #import "AutocompleteItem.h"
 
-@interface LiteAutoCompleteDataSource () <NSTableViewDataSource>
+@interface LiteAutoCompleteDataSource () <NSTableViewDataSource, AutoCompleteInputDelegate>
 @property (assign, nonatomic) CGFloat itemHeight;
 @property (assign, nonatomic) CGFloat worksapceItemHeight;
 @property (nonatomic, strong) NSMutableArray *orderedKeys;
@@ -401,6 +401,19 @@ extern void *ctx;
 	NSLog(@"----- ROWS: %lu", (unsigned long)result);
 
 	return result;
+}
+
+- (void)setInput:(AutoCompleteInput *)input
+{
+	_input = input;
+	_input.inputDelegate = self;
+}
+
+#pragma mark - AutoCompleteInputDelegate
+
+- (void)autoCompleteInputShouldResetFilter
+{
+	[self clearFilter];
 }
 
 @end


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix to prevent the AutoComplete in the Timer bar appears unexpectedly during editing the TE.

### How to reproduce
It's difficult to reproduce, please make sure you're doing precisely the following steps:

1. Open Toggl app and expand all TE (Click on Load More) to get all AutoComplete as possible
2. Type some text -> make sure the AutoComplete List is short and there is a empty space below.
3. Click on the TE underneath -> The AutoCompleteView will be dismissed
4. Start any TE
5. Edit any TE (start / end time)
6. Observe the bug

![2019-11-12 16 25 31](https://user-images.githubusercontent.com/5878421/68660538-f0558f00-056b-11ea-976e-485933804fc2.gif)

### Problem?
1. Whenever we update the TimeEntry data, the Library will trigger the notification to render the AutoComplete again

https://github.com/toggl/toggldesktop/blob/eb7230765c7ba77940cd35f7062d93548422c20d/src/ui/osx/TogglDesktop/test2/AppDelegate.m#L1548-L1552

2. LiteAutoCompleteDataSource will calculate the AutoComplete again
https://github.com/toggl/toggldesktop/blob/eb7230765c7ba77940cd35f7062d93548422c20d/src/ui/osx/TogglDesktop/test2/LiteAutoCompleteDataSource.m#L82

3. If the filter != nil -> It cause reloading the AutoCompleteView and cause the bug.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Reset the filter then the AutoCompleteView is dismiss by clicking on the dark Background

### 👫 Relationships
Closes #3506

### 🔎 Review hints
Follow the "How to reproduce" section and make sure it's gone 💯 

