### PR TITLE
Updated gh api token reference in workflow

### DIFF
--- a/.github/workflows/pr_tagger.yml
+++ b/.github/workflows/pr_tagger.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@master
     - name: Bump version and push tag
       run: |
-        ./dist/tag-and-release.sh github_api_token=${{ secrets.TAGGING_SECRET }} PATCH=1
+        ./dist/tag-and-release.sh github_api_token=${{ secrets.GITHUB_TOKEN }} PATCH=1


### PR DESCRIPTION
### 📒 Description
Change TAGGING_SECRET reference to GITHUB_TOKEN

Broken build with failing Bump action
https://github.com/toggl-open-source/toggldesktop/commit/c6c57cf3d52c560d62dfb6129fb83a52bdefd029/checks

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
GH actions build's Bump action should pass.

