### PR TITLE
Fix the edit popup closing right after open when clicking on projec tlabel

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
@@ -33,7 +33,11 @@
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
-	[self sendAction:@selector(textFieldClicked:) to:[self delegate]];
+    if ([self.delegate respondsToSelector:@selector(textFieldClicked:)]) {
+        [self sendAction:@selector(textFieldClicked:) to:[self delegate]];
+    } else {
+        [super mouseDown:theEvent];
+    }
 }
 
 - (void)setAttributedStringValue:(NSAttributedString *)attributedStringValue

--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
@@ -34,7 +34,6 @@
 - (void)mouseDown:(NSEvent *)theEvent
 {
 	[self sendAction:@selector(textFieldClicked:) to:[self delegate]];
-	[super mouseDown:theEvent];
 }
 
 - (void)setAttributedStringValue:(NSAttributedString *)attributedStringValue


### PR DESCRIPTION
### 📒 Description
Fixes the issue where edit popup would close second after opening.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3532

### 🔎 Review hints
- Start timer with project
- Click on project label to open the edit view
- Edit view should be successfully opened and project field focused


