### PR TITLE
Fix tagging so the main build workflow actually runs on a new release

### DIFF
--- a/.github/workflows/pr_tagger.yml
+++ b/.github/workflows/pr_tagger.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@master
     - name: Bump version and push tag
       run: |
-        ./dist/tag-and-release.sh github_api_token=${{ secrets.GITHUB_TOKEN }} PATCH=1
+        ./dist/tag-and-release.sh github_api_token=${{ secrets.TAGGING_SECRET }} PATCH=1


### PR DESCRIPTION
### 📒 Description
For reasons that are not entirely clear to me using just `GITHUB_TOKEN` doesn't quite cut it for the workflow to be able to create a release that will in turn be registered by the other (`main.yml`) workflow we have in place to actually compose the releases.
Before we have a better solution (like triggering one workflow from another), the way to go is using a `TAGGING_SECRET` in Secrets containing a github token that can create tags in this repo...

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Pretty hard to review without actually merging a PR so let's just hope everything will be fine after merging this.

