### PR TITLE
Make sure syncing is performed after coming back from sleep (lib)

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -27,6 +27,7 @@
 #define kMinimumAllowedYear 2006
 #define kMaximumAllowedYear 2030
 #define kMaximumDescriptionLength 3000
+#define kTimeComparisonEpsilonMicroSeconds 100000 // 100 ms
 
 #define kLostPasswordURL "https://toggl.com/forgot-password?desktop=true"
 #define kGeneralSupportURL "https://support.toggl.com/toggl-on-my-desktop/"

--- a/src/context.cc
+++ b/src/context.cc
@@ -949,7 +949,10 @@ bool Context::isPostponed(
     const Poco::Timestamp value,
     const Poco::Timestamp::TimeDiff throttleMicros) const {
     Poco::Timestamp now;
-    if (now > value) {
+    
+    // if `value` is only slighly smaller than `now` it's probably the same task and not postponed
+    // hence perform comparison using epsilon = `kTimeComparisonEpsilonMicroSeconds`
+    if (now > value + kTimeComparisonEpsilonMicroSeconds) {
         return false;
     }
     Poco::Timestamp::TimeDiff diff = value - now;


### PR DESCRIPTION
### 📒 Description
The library has `isPostponed` method to determine whether the function has been scheduled to run again in the future so that it doesn't have to run now.
It assumes that if the scheduled function is running before the timestamp for which it was scheduled, it means it is scheduled to run again in the future and so, cancels the current function.
In reality, POCO Timer doesn't guarantee to run exactly after the timestamp with microseconds precision. According to my tests, scheduled function often runs up to 30 ms before the timestamp, for which it was scheduled.
Therefore, I've added a 100 ms precision threshold when comparing timestamps. I find it high enough to get rid of these rounding errors (the biggest I've experienced in 10 tries was 33.5 ms) and low enough so that the user can hardly perform some operation several times during the 100 ms interval.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3537.

### 🔎 Review hints
See STR in #3537.

