### PR TITLE
Touch Bar Improvement

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBar+PrivateAPIs.m
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBar+PrivateAPIs.m
@@ -68,4 +68,19 @@
     }
 }
 
++ (void)minimizeSystemModal:(NSTouchBar *)touchBar
+{
+    if ([NSTouchBar respondsToSelector:
+         @selector(minimizeSystemModalFunctionBar:)])
+    {
+        [NSTouchBar
+         minimizeSystemModalFunctionBar:touchBar];
+    }
+    else if ([NSTouchBar respondsToSelector:
+              @selector(minimizeSystemModalTouchBar:)])
+    {
+        [NSTouchBar
+         minimizeSystemModalTouchBar:touchBar];
+    }
+}
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBar+PrivateAPIs.m
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBar+PrivateAPIs.m
@@ -29,25 +29,22 @@
 @end
 
 @implementation NSTouchBar (PrivateAPIs)
-+ (BOOL)presentSystemModal:(NSTouchBar *)touchBar
-                 placement:(long long)placement
-  systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier
+
++ (BOOL)presentSystemModal:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier
 {
     if ([NSTouchBar respondsToSelector:
-         @selector(presentSystemModalFunctionBar:placement:systemTrayItemIdentifier:)])
+         @selector(presentSystemModalFunctionBar:systemTrayItemIdentifier:)])
     {
         [NSTouchBar
          presentSystemModalFunctionBar:touchBar
-         placement:placement
          systemTrayItemIdentifier:identifier];
         return YES;
     }
     else if ([NSTouchBar respondsToSelector:
-              @selector(presentSystemModalTouchBar:placement:systemTrayItemIdentifier:)])
+              @selector(presentSystemModalTouchBar:systemTrayItemIdentifier:)])
     {
         [NSTouchBar
          presentSystemModalTouchBar:touchBar
-         placement:placement
          systemTrayItemIdentifier:identifier];
         return YES;
     }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBar+PrivateAPIs.m
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBar+PrivateAPIs.m
@@ -1,0 +1,74 @@
+//
+//  TouchBar+PrivateAPIs.m
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 11/22/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+#import "TouchBar+PrivateAPIs.h"
+
+@interface NSTouchBar ()
+/* macOS 10.13 */
++ (void)presentSystemModalFunctionBar:(NSTouchBar *)touchBar
+                            placement:(long long)placement
+             systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
++ (void)presentSystemModalFunctionBar:(NSTouchBar *)touchBar
+             systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
++ (void)dismissSystemModalFunctionBar:(NSTouchBar *)touchBar;
++ (void)minimizeSystemModalFunctionBar:(NSTouchBar *)touchBar;
+
+/* macOS 10.14 */
++ (void)presentSystemModalTouchBar:(NSTouchBar *)touchBar
+                         placement:(long long)placement
+          systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
++ (void)presentSystemModalTouchBar:(NSTouchBar *)touchBar
+          systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
++ (void)dismissSystemModalTouchBar:(NSTouchBar *)touchBar;
++ (void)minimizeSystemModalTouchBar:(NSTouchBar *)touchBar;
+@end
+
+@implementation NSTouchBar (PrivateAPIs)
++ (BOOL)presentSystemModal:(NSTouchBar *)touchBar
+                 placement:(long long)placement
+  systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier
+{
+    if ([NSTouchBar respondsToSelector:
+         @selector(presentSystemModalFunctionBar:placement:systemTrayItemIdentifier:)])
+    {
+        [NSTouchBar
+         presentSystemModalFunctionBar:touchBar
+         placement:placement
+         systemTrayItemIdentifier:identifier];
+        return YES;
+    }
+    else if ([NSTouchBar respondsToSelector:
+              @selector(presentSystemModalTouchBar:placement:systemTrayItemIdentifier:)])
+    {
+        [NSTouchBar
+         presentSystemModalTouchBar:touchBar
+         placement:placement
+         systemTrayItemIdentifier:identifier];
+        return YES;
+    }
+    else
+        return NO;
+}
+
++ (void)dismissSystemModal:(NSTouchBar *)touchBar
+{
+    if ([NSTouchBar respondsToSelector:
+         @selector(dismissSystemModalFunctionBar:)])
+    {
+        [NSTouchBar
+         dismissSystemModalFunctionBar:touchBar];
+    }
+    else if ([NSTouchBar respondsToSelector:
+              @selector(dismissSystemModalTouchBar:)])
+    {
+        [NSTouchBar
+         dismissSystemModalTouchBar:touchBar];
+    }
+}
+
+@end

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -79,7 +79,6 @@ final class TouchBarService: NSObject {
         super.init()
         initCommon()
         initNotification()
-        windowDidBecomeKey()
     }
 
     // MARK: Public
@@ -129,27 +128,40 @@ final class TouchBarService: NSObject {
         scrubberView.reloadData()
     }
 
-    func reset() {
+    func resetContent() {
         self.timeEntries = []
         scrubberView.reloadData()
         startButton.isHidden = true
     }
 
-    func prepareForPresent() {
+    func prepareContent() {
         scrubberView.reloadData()
         startButton.isHidden = false
     }
+}
 
-    func windowDidBecomeKey() {
+// MARK: Action
+
+@available(OSX 10.12.2, *)
+extension TouchBarService {
+
+    func present() {
         guard isEnabled && !isPresented else { return }
         if NSTouchBar.presentSystemModal(touchBar, systemTrayItemIdentifier: nil) {
             isPresented = true
         }
     }
 
-    func windowDidResignKey() {
+    func minimize() {
+        guard isEnabled && isPresented else { return }
+        NSTouchBar.minimizeSystemModal(touchBar)
+        isPresented = false
+    }
+
+    func dismiss() {
         guard isEnabled && isPresented else { return }
         NSTouchBar.dismissSystemModal(touchBar)
+        isPresented = false
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -45,6 +45,7 @@ final class TouchBarService: NSObject {
     // MARK: Variables
 
     var isEnabled = true
+    private var isPresented = false
     private lazy var touchBar: NSTouchBar = {
         let touchBar = NSTouchBar()
         touchBar.delegate = self
@@ -78,6 +79,7 @@ final class TouchBarService: NSObject {
         super.init()
         initCommon()
         initNotification()
+        windowDidBecomeKey()
     }
 
     // MARK: Public
@@ -136,6 +138,18 @@ final class TouchBarService: NSObject {
     func prepareForPresent() {
         scrubberView.reloadData()
         startButton.isHidden = false
+    }
+
+    func windowDidBecomeKey() {
+        guard isEnabled && !isPresented else { return }
+        if NSTouchBar.presentSystemModal(touchBar, systemTrayItemIdentifier: nil) {
+            isPresented = true
+        }
+    }
+
+    func windowDidResignKey() {
+        guard isEnabled && isPresented else { return }
+        NSTouchBar.dismissSystemModal(touchBar)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -146,22 +146,28 @@ final class TouchBarService: NSObject {
 extension TouchBarService {
 
     func present() {
+        #if !APP_STORE
         guard isEnabled && !isPresented else { return }
         if NSTouchBar.presentSystemModal(touchBar, systemTrayItemIdentifier: nil) {
             isPresented = true
         }
+        #endif
     }
 
     func minimize() {
+        #if !APP_STORE
         guard isEnabled && isPresented else { return }
         NSTouchBar.minimizeSystemModal(touchBar)
         isPresented = false
+        #endif
     }
 
     func dismiss() {
+        #if !APP_STORE
         guard isEnabled && isPresented else { return }
         NSTouchBar.dismissSystemModal(touchBar)
         isPresented = false
+        #endif
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -185,10 +185,6 @@ extension TouchBarService {
                                                selector: #selector(self.stateButtonTimerBarChangeNotification(_:)),
                                                name: NSNotification.Name(kStartButtonStateChange),
                                                object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(self.touchbarSettingChangedNoti(_:)),
-                                               name: NSNotification.Name(kTouchBarSettingChanged),
-                                               object: nil)
     }
 
     @objc private func stateButtonTimerBarChangeNotification(_ noti: Notification) {
@@ -197,10 +193,6 @@ extension TouchBarService {
         }
         startButton.state = NSControl.StateValue(rawValue: value.intValue)
         displayState = startButton.state == .on ? .tracking : .normal
-    }
-
-    @objc private func touchbarSettingChangedNoti(_ noti: Notification) {
-
     }
 
     private func updateDisplayState() {

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -18,7 +18,11 @@
 #import "TogglDesktop-Swift.h"
 #import "TimerEditViewController.h"
 
+<<<<<<< HEAD
 @interface MainWindowController () <TouchBarServiceDelegate, InAppMessageViewControllerDelegate>
+=======
+@interface MainWindowController () <TouchBarServiceDelegate, NSWindowDelegate>
+>>>>>>> c3800c241... Present the TimeEntry Touchbar by using private API (mac)
 @property (weak) IBOutlet NSView *contentView;
 @property (weak) IBOutlet NSView *mainView;
 @property (nonatomic, strong) LoginViewController *loginViewController;
@@ -85,6 +89,7 @@ extern void *ctx;
 - (void)windowDidLoad
 {
 	[super windowDidLoad];
+    self.window.delegate = self;
 
 	// Tracking the size of window after loaded
 	[self trackWindowSize];
@@ -346,6 +351,18 @@ extern void *ctx;
 - (void)InAppMessageViewControllerShouldDismiss
 {
     [self.inappMessageView.view removeFromSuperview];
+}
+
+#pragma mark - NSWindowDelegate
+
+-(void)windowDidBecomeKey:(NSNotification *)notification
+{
+//    [[TouchBarService shared] windowDidBecomeKey];
+}
+
+- (void)windowDidResignKey:(NSNotification *)notification
+{
+//    [[TouchBarService shared] windowDidResignKey];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -18,11 +18,7 @@
 #import "TogglDesktop-Swift.h"
 #import "TimerEditViewController.h"
 
-<<<<<<< HEAD
-@interface MainWindowController () <TouchBarServiceDelegate, InAppMessageViewControllerDelegate>
-=======
-@interface MainWindowController () <TouchBarServiceDelegate, NSWindowDelegate>
->>>>>>> c3800c241... Present the TimeEntry Touchbar by using private API (mac)
+@interface MainWindowController () <TouchBarServiceDelegate, NSWindowDelegate, InAppMessageViewControllerDelegate>
 @property (weak) IBOutlet NSView *contentView;
 @property (weak) IBOutlet NSView *mainView;
 @property (nonatomic, strong) LoginViewController *loginViewController;
@@ -359,15 +355,16 @@ extern void *ctx;
 
 -(void)windowDidBecomeMain:(NSNotification *)notification
 {
-    if ([self.timeEntryListViewController.view superview] != nil) {
+    if ([self.timeEntryListViewController.view superview] != nil)
+    {
         [[TouchBarService shared] present];
     }
-
 }
 
 - (void)windowDidResignMain:(NSNotification *)notification
 {
-    if ([self.timeEntryListViewController.view superview] != nil) {
+    if ([self.timeEntryListViewController.view superview] != nil)
+    {
         [[TouchBarService shared] minimize];
     }
 }

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -152,6 +152,7 @@ extern void *ctx;
 
 		// Reset the data
 		[[TouchBarService shared] resetContent];
+        [[TouchBarService shared] minimize];
 	}
 }
 
@@ -184,6 +185,7 @@ extern void *ctx;
 
 			// Prepare the Touch bar
 			[[TouchBarService shared] prepareContent];
+            [[TouchBarService shared] present];
 		}
 	}
 }
@@ -357,12 +359,17 @@ extern void *ctx;
 
 -(void)windowDidBecomeMain:(NSNotification *)notification
 {
-    [[TouchBarService shared] present];
+    if ([self.timeEntryListViewController.view superview] != nil) {
+        [[TouchBarService shared] present];
+    }
+
 }
 
 - (void)windowDidResignMain:(NSNotification *)notification
 {
-    [[TouchBarService shared] minimize];
+    if ([self.timeEntryListViewController.view superview] != nil) {
+        [[TouchBarService shared] minimize];
+    }
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -151,7 +151,7 @@ extern void *ctx;
 		[self.overlayViewController.view removeFromSuperview];
 
 		// Reset the data
-		[[TouchBarService shared] reset];
+		[[TouchBarService shared] resetContent];
 	}
 }
 
@@ -183,7 +183,7 @@ extern void *ctx;
 																		object:nil];
 
 			// Prepare the Touch bar
-			[[TouchBarService shared] prepareForPresent];
+			[[TouchBarService shared] prepareContent];
 		}
 	}
 }
@@ -355,14 +355,14 @@ extern void *ctx;
 
 #pragma mark - NSWindowDelegate
 
--(void)windowDidBecomeKey:(NSNotification *)notification
+-(void)windowDidBecomeMain:(NSNotification *)notification
 {
-//    [[TouchBarService shared] windowDidBecomeKey];
+    [[TouchBarService shared] present];
 }
 
-- (void)windowDidResignKey:(NSNotification *)notification
+- (void)windowDidResignMain:(NSNotification *)notification
 {
-//    [[TouchBarService shared] windowDidResignKey];
+    [[TouchBarService shared] minimize];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/Other/TogglDesktop-Bridging-Header.h
+++ b/src/ui/osx/TogglDesktop/Other/TogglDesktop-Bridging-Header.h
@@ -15,3 +15,4 @@
 #import "TimeEntryCollectionView.h"
 #import "ConvertHexColor.h"
 #import "AppDelegate.h"
+#import "TouchBar+PrivateAPIs.h"

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		BA6572A8224DFA6F00BA4C60 /* CurrentColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A2224DFA6F00BA4C60 /* CurrentColorView.swift */; };
 		BA6572A9224DFA6F00BA4C60 /* ColorGraphicsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A3224DFA6F00BA4C60 /* ColorGraphicsView.swift */; };
 		BA6572AA224DFA6F00BA4C60 /* HSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A4224DFA6F00BA4C60 /* HSV.swift */; };
+		BA6D554A2387912C004D068B /* TouchBar+PrivateAPIs.m in Sources */ = {isa = PBXBuildFile; fileRef = BA6D55492387912C004D068B /* TouchBar+PrivateAPIs.m */; };
 		BA6EB8402248CBE3003BB8EF /* ProjectStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6EB83F2248CBE3003BB8EF /* ProjectStorage.swift */; };
 		BA6EB8942249DB33003BB8EF /* VerticallyCenteredTextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6EB8752249DB33003BB8EF /* VerticallyCenteredTextFieldCell.swift */; };
 		BA6F1B1A21EEE258009265E4 /* NSColor+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */; };
@@ -826,6 +827,7 @@
 		BA47DEB123966F9C005216AD /* InAppMessageViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InAppMessageViewController.xib; sourceTree = "<group>"; };
 		BA47DEB723969EAC005216AD /* InAppMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessage.swift; sourceTree = "<group>"; };
 		BA4A7D502375527B00A42095 /* TouchBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TouchBar.h; path = test2/TouchBar.h; sourceTree = SOURCE_ROOT; };
+		BA4A7D502375527B00A42095 /* TouchBar+PrivateAPIs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "TouchBar+PrivateAPIs.h"; path = "test2/TouchBar+PrivateAPIs.h"; sourceTree = SOURCE_ROOT; };
 		BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizablePopover.swift; sourceTree = "<group>"; };
 		BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarFlowLayout.swift; sourceTree = "<group>"; };
 		BA5B0E4D2330E1C6008D1DED /* GoogleAuthenticationServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthenticationServer.swift; sourceTree = "<group>"; };
@@ -835,6 +837,7 @@
 		BA6572A2224DFA6F00BA4C60 /* CurrentColorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentColorView.swift; sourceTree = "<group>"; };
 		BA6572A3224DFA6F00BA4C60 /* ColorGraphicsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorGraphicsView.swift; sourceTree = "<group>"; };
 		BA6572A4224DFA6F00BA4C60 /* HSV.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HSV.swift; sourceTree = "<group>"; };
+		BA6D55492387912C004D068B /* TouchBar+PrivateAPIs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "TouchBar+PrivateAPIs.m"; sourceTree = "<group>"; };
 		BA6EB83F2248CBE3003BB8EF /* ProjectStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectStorage.swift; sourceTree = "<group>"; };
 		BA6EB8752249DB33003BB8EF /* VerticallyCenteredTextFieldCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticallyCenteredTextFieldCell.swift; sourceTree = "<group>"; };
 		BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+Utils.swift"; sourceTree = "<group>"; };
@@ -1610,7 +1613,8 @@
 		BAF3ACCA2341F86300E41B33 /* TouchBar */ = {
 			isa = PBXGroup;
 			children = (
-				BA4A7D502375527B00A42095 /* TouchBar.h */,
+				BA4A7D502375527B00A42095 /* TouchBar+PrivateAPIs.h */,
+				BA6D55492387912C004D068B /* TouchBar+PrivateAPIs.m */,
 				BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */,
 				BAF3ACD22343325A00E41B33 /* TouchBarService.swift */,
 				BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */,
@@ -2255,6 +2259,7 @@
 				BA7D335722489BD000B953A8 /* AutoCompleteViewDataSource.swift in Sources */,
 				BA01404C22570967000E5B91 /* TagStorage.swift in Sources */,
 				74BAD31E18BD7D83002FD4CF /* ViewItem.m in Sources */,
+				BA6D554A2387912C004D068B /* TouchBar+PrivateAPIs.m in Sources */,
 				BA35B21F22E6E95200FA560E /* CalendarCollectionView.swift in Sources */,
 				3CD7AD6F19ED579700372797 /* NSResize.m in Sources */,
 				BA08E012222E32C90075F68E /* NSView+LayoutConstraint.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -237,6 +237,8 @@
 		BAB818E5228D5A17008C2367 /* DescriptionDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB818E4228D5A16008C2367 /* DescriptionDataSource.swift */; };
 		BAB818E9228D5A97008C2367 /* DescriptionContentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB818E8228D5A97008C2367 /* DescriptionContentCellView.swift */; };
 		BAB818EB228D5AA8008C2367 /* DescriptionContentCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BAB818EA228D5AA8008C2367 /* DescriptionContentCellView.xib */; };
+		BABB85A923882CEE0084DEAC /* ObjcSystemPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB508E3237EA54500D3D468 /* ObjcSystemPermissionManager.swift */; };
+		BABB85AA23882D7C0084DEAC /* SystemPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB508E1237E8FBC00D3D468 /* SystemPermissionManager.swift */; };
 		BAC4D399225470DA00254DAD /* AutoCompleteRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC4D398225470DA00254DAD /* AutoCompleteRowView.swift */; };
 		BAD15FFC223A52D600A8CCC9 /* TimeEntryEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD15FFB223A52D600A8CCC9 /* TimeEntryEmptyView.swift */; };
 		BAD15FFE223A530600A8CCC9 /* TimeEntryEmptyView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BAD15FFD223A530600A8CCC9 /* TimeEntryEmptyView.xib */; };
@@ -2412,6 +2414,7 @@
 				BAE64DA32368334000244D2B /* ProjectColor.swift in Sources */,
 				BAE64DA42368334000244D2B /* TagCellView.swift in Sources */,
 				BAE64DA52368334000244D2B /* AutoCompleteView.swift in Sources */,
+				BABB85AA23882D7C0084DEAC /* SystemPermissionManager.swift in Sources */,
 				BAE64DA62368334000244D2B /* NoInteractionView.swift in Sources */,
 				BAE64DA72368334000244D2B /* NSView+Xib.swift in Sources */,
 				BAE64DA82368334000244D2B /* DesktopLibraryBridge.m in Sources */,
@@ -2490,6 +2493,7 @@
 				BAE64DEE2368334000244D2B /* ColorPickerView.swift in Sources */,
 				BAE64DEF2368334000244D2B /* FloatingErrorView.swift in Sources */,
 				BAE64DF02368334000244D2B /* LoginViewController.m in Sources */,
+				BABB85A923882CEE0084DEAC /* ObjcSystemPermissionManager.swift in Sources */,
 				BAE64DF12368334000244D2B /* IdleEvent.m in Sources */,
 				BA4A7D5123755A3700A42095 /* TimeEntryScrubberFlowLayout.swift in Sources */,
 			);

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -7,8 +7,6 @@
 //
 
 #import "AppDelegate.h"
-
-#import "TouchBar.h"
 #import "AboutWindowController.h"
 #import "AutocompleteItem.h"
 #import "AutotrackerRuleItem.h"
@@ -39,6 +37,10 @@
 
 #ifdef SPARKLE
 #import <Sparkle/Sparkle.h>
+#endif
+
+#ifndef APP_STORE
+#import "TouchBar+PrivateAPIs.h"
 #endif
 
 @interface AppDelegate ()

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1153,6 +1153,10 @@ void *ctx;
 	toggl_context_clear(ctx);
 	ctx = 0;
 
+#ifndef APP_STORE
+    [[TouchBarService shared] dismiss];
+#endif
+
 	if (self.aboutWindowController.restart == YES)
 	{
 		float seconds = 1.0;

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -12,7 +12,7 @@
 #import "IdleEvent.h"
 #import "UserNotificationCenter.h"
 
-@interface IdleNotificationWindowController () <IdleNotificationTouchBarDelegate>
+@interface IdleNotificationWindowController () <IdleNotificationTouchBarDelegate, NSWindowDelegate>
 
 @property (weak) IBOutlet NSTextField *idleSinceTextField;
 @property (weak) IBOutlet NSTextField *idleAmountTextField;
@@ -45,6 +45,8 @@ extern void *ctx;
 
 - (void)initCommon
 {
+    self.window.delegate = self;
+
 	// Style buttons
 	[self styleTransparentButton:self.addIdleTimeButton];
 	[self styleTransparentButton:self.discardAndContinueButton];
@@ -200,4 +202,13 @@ extern void *ctx;
 	}
 }
 
+- (void)windowDidBecomeKey:(NSNotification *)notification
+{
+    [[TouchBarService shared] dismiss];
+}
+
+- (void)windowDidResignKey:(NSNotification *)notification
+{
+    [[TouchBarService shared] present];
+}
 @end

--- a/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
@@ -22,11 +22,16 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
 
 @end
 
-@interface NSTouchBar ()
+@interface NSTouchBar (PrivateAPIs)
 
-+ (void)presentSystemModalFunctionBar:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSString *)identifier;
++ (BOOL)presentSystemModal:(NSTouchBar *)touchBar
+                 placement:(long long)placement
+  systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
+
++ (void)dismissSystemModal:(NSTouchBar *)touchBar;
+
+#endif
 
 @end
-#endif
 
 #endif /* TouchBar_h */

--- a/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
@@ -24,9 +24,7 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
 
 @interface NSTouchBar (PrivateAPIs)
 
-+ (BOOL)presentSystemModal:(NSTouchBar *)touchBar
-                 placement:(long long)placement
-  systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
++ (BOOL)presentSystemModal:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
 
 + (void)dismissSystemModal:(NSTouchBar *)touchBar;
 

--- a/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
@@ -28,6 +28,8 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
 
 + (void)dismissSystemModal:(NSTouchBar *)touchBar;
 
++ (void)minimizeSystemModal:(NSTouchBar *)touchBar;
+
 #endif
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
@@ -30,8 +30,7 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
 
 + (void)minimizeSystemModal:(NSTouchBar *)touchBar;
 
-#endif
-
 @end
 
+#endif
 #endif /* TouchBar_h */


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix to solve the known-issues in known-issues on Touch bar. Read more at https://github.com/toggl-open-source/toggldesktop/pull/3424#issuecomment-540995289

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Adopt new Private API to keep the Touch Bar on the screen regardless of the change when the TextField becomes a first responder.
- [x] Refactor who we use new API
- [x] Refactor the AppStore version -> Make sure no Private API
- [x] Improve how the TimeEntry Touch Bar presents/dismisses depend on the Login or Idle Notification.

### 👫 Relationships
Close #3520

### 🔎 Review hints
### Make sure the AppStore works
- Able to build the AppStore scheme version

#### The TimeEntry Touch Bar present properly
- The TimeEntry Touch bar won't dismiss during the Start / Stop / Edit the Time Entry.
- Don't focus on the app -> The Touch bar is replaced with the default system properly
- Login / Sign Up / Idle notification presents usual.
- Show Touch Bar setting in Preference should work
