### PR TITLE
Zoom hotkey in Timeline

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -41,7 +41,7 @@
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oEw-Jd-lIP">
                             <rect key="frame" x="8" y="55" width="101" height="18"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" title="Record activity" id="x0y-gM-oPn">
-                                <font key="font" metaFont="system" size="14"/>
+                                <font key="font" metaFont="menu" size="14"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -100,7 +100,7 @@
                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="xXU-Yr-nTf">
+                                <customView toolTip="Zoom In (⌘+)" translatesAutoresizingMaskIntoConstraints="NO" id="xXU-Yr-nTf">
                                     <rect key="frame" x="0.0" y="0.0" width="54" height="30"/>
                                     <subviews>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CK9-W6-FLX">
@@ -113,7 +113,7 @@
                                                 <action selector="zoomLevelIncreaseOnChange:" target="-2" id="QsV-0i-5La"/>
                                             </connections>
                                         </button>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rZq-Fq-a8f">
+                                        <button toolTip="Zoom Out (⌘-)" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rZq-Fq-a8f">
                                             <rect key="frame" x="10" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="kr9-Ry-BUy">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -323,4 +323,15 @@ extern void *ctx;
 	[self.timeEntryListViewController.timerEditViewController startButtonClicked:self];
 }
 
+#pragma mark - Timeline Menu
+
+- (IBAction)zoomInBtnOnTap:(id)sender
+{
+    [self.mainDashboardViewController.timelineController zoomLevelIncreaseOnChange:sender];
+}
+
+- (IBAction)zoomOutBtnOnTap:(id)sender
+{
+    [self.mainDashboardViewController.timelineController zoomLevelDecreaseOnChange:sender];
+}
 @end

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -220,6 +220,23 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="Timeline" id="YHj-AQ-2TJ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Timeline" id="8ah-bF-5q6">
+                        <items>
+                            <menuItem title="Zoom In" tag="3" keyEquivalent="+" id="XUZ-S2-QCm">
+                                <connections>
+                                    <action selector="zoomInBtnOnTap:" target="-1" id="RZ3-A4-bxc"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom Out" tag="3" keyEquivalent="-" id="zgY-fo-tDy">
+                                <connections>
+                                    <action selector="zoomOutBtnOnTap:" target="-1" id="Q5Y-dr-37M"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
                 <menuItem title="Window" id="19">
                     <menu key="submenu" title="Window" systemMenu="window" id="24">
                         <items>
@@ -284,7 +301,7 @@
             <rect key="frame" x="0.0" y="0.0" width="164" height="23"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="selectOne" id="1459">
-                <font key="font" metaFont="miniSystem"/>
+                <font key="font" metaFont="menu" size="9"/>
                 <segments>
                     <segment label="Weekly log" width="81"/>
                     <segment label="Quick selection" width="81" selected="YES" tag="1"/>


### PR DESCRIPTION
### 📒 Description
This PR introduce the Timeline Menu Item and able to trigger zoom in, out with Cmd + / - 

### Why Timeline Menu?
I decided to follow the official keyboard-menu approach from Apple in oder to support Hotkey in certain tasks. Moreover, we could add more Timeline shortcut later.

### 🕶️ Types of changes
 **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add Timeline menu with Zoom Out / In Item

### 👫 Relationships
Closes #3563

### 🔎 Review hints
- Able to zoom out / in by keyboard or select on the menu

<img width="172" alt="Screen Shot 2019-12-02 at 15 51 23" src="https://user-images.githubusercontent.com/5878421/69945264-c87a9b00-151b-11ea-915e-a906f5174151.png">


