### PR TITLE
Make to_char_t thread-safe (win)

### DIFF
--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -225,7 +225,7 @@ std::string trim_whitespace(const std::string &str)
 
 const char_t *to_char_t(const std::string &s) {
 #if defined(_WIN32) || defined(WIN32)
-    std::wstring ws;
+    static thread_local std::wstring ws;
     Poco::UnicodeConverter::toUTF16(s, ws);
     return ws.c_str();
 #else


### PR DESCRIPTION
### 📒 Description
This creates a local "cache" by having a thread-local static variable containing the reformatted copy of the string.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3531

### 🔎 Review hints
Testing this will be pretty hard I assume so let's just read the code, it's a oneliner and if the build on Windows passes, everything should be fine.

