### PR TITLE
No duplication TimeEntry in Touch Bar

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -103,7 +103,12 @@ final class TouchBarService: NSObject {
             if timeEntry.groupOpen && !timeEntry.group {
                 continue
             }
-            touchBarEntries.append(timeEntry)
+
+            // Only add unique TE
+            if touchBarEntries.first(where: { $0.isSameContent(with: timeEntry)}) == nil {
+                touchBarEntries.append(timeEntry)
+            }
+
             if touchBarEntries.count >= Constants.NumberTimeEntry {
                 break
             }

--- a/src/ui/osx/TogglDesktop/TimeEntryViewItem.h
+++ b/src/ui/osx/TogglDesktop/TimeEntryViewItem.h
@@ -65,5 +65,5 @@
 - (BOOL)confirmlessDelete;
 - (BOOL)isRunning;
 - (void)load:(TogglTimeEntryView *)data;
-
+- (BOOL) isSameContentWithTimeEntryViewItem:(TimeEntryViewItem *) item;
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
@@ -213,4 +213,10 @@
 	return self.duration_in_seconds < 0;
 }
 
+- (BOOL) isSameContentWithTimeEntryViewItem:(TimeEntryViewItem *) item
+{
+    return [self.descriptionName isEqualToString:item.descriptionName] &&
+    [self.ProjectAndTaskLabel isEqualToString:item.ProjectAndTaskLabel] &&
+    [self.ProjectColor isEqualToString:item.ProjectColor];
+}
 @end


### PR DESCRIPTION
### 📒 Description
This PR add the fix to make sure there is no duplicated TimeEntry.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Double check content and make sure there is no duplication, even in different days

### 👫 Relationships
Closes #3575 

### 🔎 Review hints
Try to start some existing TE in couple days ago and make sure there is no duplicated.

<img width="1139" alt="Screen Shot 2019-12-03 at 14 04 21" src="https://user-images.githubusercontent.com/5878421/70028225-a7c34b80-15d6-11ea-8529-9354249f19bd.png">
