### PR TITLE
Add in-app message fetching to library

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -1984,6 +1984,17 @@ int64_t Context::GetWindowEditSizeWidth() {
     return value;
 }
 
+void Context::SetMessageSeen(
+    const int64_t value) {
+    displayError(db()->SetSettingsMessageSeen(value));
+}
+
+int64_t Context::GetMessageSeen() {
+    Poco::Int64 value(0);
+    displayError(db()->GetMessageSeen(&value));
+    return value;
+}
+
 void Context::SetKeyStart(
     const std::string &value) {
     displayError(db()->SetKeyStart(value));

--- a/src/context.cc
+++ b/src/context.cc
@@ -297,6 +297,8 @@ error Context::StartEvents() {
             analytics_.TrackOs(db_->AnalyticsClientID(), os_info.str());
             analytics_.TrackOSDetails(db_->AnalyticsClientID());
         }
+
+        fetchMessage();
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {

--- a/src/context.h
+++ b/src/context.h
@@ -577,6 +577,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error downloadUpdate();
 
+    error fetchMessage();
+
     void stopActivities();
 
     error offerBetaChannel(bool *did_offer);

--- a/src/context.h
+++ b/src/context.h
@@ -222,6 +222,11 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     int64_t GetWindowEditSizeWidth();
 
+    void SetMessageSeen(
+        const int64_t value);
+
+    int64_t GetMessageSeen();
+
     void SetKeyStart(
         const std::string &value);
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -720,6 +720,10 @@ error Database::GetKeyModifierStart(std::string *result) {
     return getSettingsValue("key_modifier_start", result);
 }
 
+error Database::GetMessageSeen(Poco::Int64 *result) {
+    return getSettingsValue("message_seen", result);
+}
+
 error Database::SetSettingsRemindTimes(
     const std::string &remind_starts,
     const std::string &remind_ends) {
@@ -791,6 +795,11 @@ error Database::SetSettingsRemindDays(
 
 error Database::SetSettingsHasSeenBetaOffering(const bool &value) {
     return setSettingsValue("has_seen_beta_offering", value);
+}
+
+error Database::SetSettingsMessageSeen(
+    const Poco::UInt64 message_id) {
+    return setSettingsValue("message_seen",message_id);
 }
 
 error Database::SetSettingsUseIdleDetection(

--- a/src/database.h
+++ b/src/database.h
@@ -88,6 +88,8 @@ class TOGGL_INTERNAL_EXPORT Database {
 
     error SetSettingsHasSeenBetaOffering(const bool &value);
 
+    error SetSettingsMessageSeen(const Poco::UInt64 message_id);
+
     error SetSettingsUseIdleDetection(const bool &use_idle_detection);
 
     error SetSettingsAutotrack(const bool &value);
@@ -196,6 +198,8 @@ class TOGGL_INTERNAL_EXPORT Database {
         const std::string &value);
 
     error GetKeyModifierStart(std::string *result);
+
+    error GetMessageSeen(Poco::Int64 *result);
 
     error LoadProxySettings(
         bool *use_proxy,

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -573,6 +573,29 @@ void GUI::DisplayUpdateDownloadState(
     free(version_string);
 }
 
+void GUI::DisplayMessage(const std::string &title,
+                         const std::string &text,
+                         const std::string &button,
+                         const std::string &url) {
+    logger().debug("DisplayMessage: " + title);
+
+    char_t *tmp_title = copy_string(title);
+    char_t *tmp_text = copy_string(text);
+    char_t *tmp_button = copy_string(button);
+    char_t *tmp_url = copy_string(url);
+    on_display_message_(
+        tmp_title,
+        tmp_text,
+        tmp_button,
+        tmp_url);
+
+    free(tmp_title);
+    free(tmp_text);
+    free(tmp_button);
+    free(tmp_url);
+}
+
+
 void GUI::DisplaySettings(const bool open,
                           const bool record_timeline,
                           const Settings &settings,

--- a/src/gui.h
+++ b/src/gui.h
@@ -371,6 +371,7 @@ class TOGGL_INTERNAL_EXPORT GUI : public SyncStateMonitor {
     , on_display_unsynced_items_(nullptr)
     , on_display_update_(nullptr)
     , on_display_update_download_state_(nullptr)
+    , on_display_message_(nullptr)
     , on_display_autotracker_rules_(nullptr)
     , on_display_autotracker_notification_(nullptr)
     , on_display_promotion_(nullptr)
@@ -477,10 +478,20 @@ class TOGGL_INTERNAL_EXPORT GUI : public SyncStateMonitor {
         const std::string &version,
         const Poco::Int64 download_state);
 
+    void DisplayMessage(
+        const std::string &title,
+        const std::string &text,
+        const std::string &button,
+        const std::string &url);
+
     error VerifyCallbacks();
 
     void OnDisplayUpdate(TogglDisplayUpdate cb) {
         on_display_update_ = cb;
+    }
+
+    void OnDisplayMessage(TogglDisplayMessage cb) {
+        on_display_message_ = cb;
     }
 
     void OnDisplayHelpArticles(TogglDisplayHelpArticles cb) {
@@ -612,6 +623,10 @@ class TOGGL_INTERNAL_EXPORT GUI : public SyncStateMonitor {
         return !!on_display_update_download_state_;
     }
 
+    bool CanDisplayMessage() const {
+        return !!on_display_message_;
+    }
+
     bool CanDisplayAutotrackerRules() const {
         return !!on_display_autotracker_rules_;
     }
@@ -666,6 +681,7 @@ class TOGGL_INTERNAL_EXPORT GUI : public SyncStateMonitor {
     TogglDisplayUnsyncedItems on_display_unsynced_items_;
     TogglDisplayUpdate on_display_update_;
     TogglDisplayUpdateDownloadState on_display_update_download_state_;
+    TogglDisplayMessage on_display_message_;
     TogglDisplayAutotrackerRules on_display_autotracker_rules_;
     TogglDisplayAutotrackerNotification on_display_autotracker_notification_;
     TogglDisplayPromotion on_display_promotion_;

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -1297,6 +1297,14 @@ error Migrations::migrateSettings() {
         return err;
     }
 
+    err = db_->Migrate(
+        "settings.message_seen",
+        "ALTER TABLE settings "
+        "ADD COLUMN message_seen INTEGER NOT NULL DEFAULT 0;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1017,6 +1017,12 @@ void toggl_on_update_download_state(
     app(context)->UI()->OnDisplayUpdateDownloadState(cb);
 }
 
+void toggl_on_message(
+    void *context,
+    TogglDisplayMessage cb) {
+    app(context)->UI()->OnDisplayMessage(cb);
+}
+
 void toggl_on_url(
     void *context,
     TogglDisplayURL cb) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -287,6 +287,12 @@ extern "C" {
         const char_t *version,
         const int64_t download_state);
 
+    typedef void (*TogglDisplayMessage)(
+        const char_t *title,
+        const char_t *text,
+        const char_t *button,
+        const char_t *url);
+
     typedef char_t * string_list_t[];
 
     typedef void (*TogglDisplayAutotrackerRules)(
@@ -393,6 +399,10 @@ extern "C" {
     TOGGL_EXPORT void toggl_on_update_download_state(
         void *context,
         TogglDisplayUpdateDownloadState cb);
+
+    TOGGL_EXPORT void toggl_on_message(
+        void *context,
+        TogglDisplayMessage cb);
 
     TOGGL_EXPORT void toggl_on_online_state(
         void *context,


### PR DESCRIPTION
### 📒 Description
Adds logic to fetch in-app messages from json files

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes

- [x] Added field to settings database table 3e560da
- [x] Save and fetch value form database table 232e96a
- [x] Connections between lib and ui 594c940
- [x] Added message fetching logic 60377c3
- [x] Trigger message fetch on app start 60377c3
- [ ] Periodic message fetching (every4 hrs) _[not done]_

### 👫 Relationships

Closes #3412

### 🔎 Review hints

Currently, I used a temporary location for JSON file to test the logic.

Message parameters should be checked correctly:
- id in database is older -> show message
- 3 scenarios of app version validation
- days and datetime logic

