### PR TITLE
Make working with the autocomplete text field more natural (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -14,6 +14,7 @@ AutocompleteComboBox::AutocompleteComboBox(QWidget *parent)
     completer->installEventFilter(this);
     listView->installEventFilter(this);
     lineEdit()->installEventFilter(this);
+    lineEdit()->setFrame(false);
     completer->setModel(proxyModel);
     setCompleter(completer);
     disconnect(completer, SIGNAL(highlighted(QString)), lineEdit(), nullptr);
@@ -33,8 +34,13 @@ void AutocompleteComboBox::showPopup() {
 bool AutocompleteComboBox::eventFilter(QObject *o, QEvent *e) {
     // this is an ugly hack, this SHOULD happen in the FocusIn event but that actually never occurs
     if (o == lineEdit()) {
-        QComboBox::eventFilter(o, e);
+        auto retval = QComboBox::eventFilter(o, e);
         disconnect(completer, SIGNAL(highlighted(QString)), lineEdit(), nullptr);
+        // there were text rendering glitches, this fixes the issue by forcing a repaint on every keypress
+        if (e->type() == QEvent::KeyPress) {
+            lineEdit()->repaint();
+        }
+        return retval;
     }
     else if (e->type() == QEvent::KeyPress) {
         auto ke = reinterpret_cast<QKeyEvent*>(e);

--- a/src/ui/linux/TogglDesktop/autocompletecombobox.h
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.h
@@ -45,8 +45,6 @@ private:
     AutocompleteCompleter *completer;
     AutocompleteProxyModel *proxyModel;
     AutocompleteListView *listView;
-
-    QString oldLabel {};
 };
 
 class AutocompleteCompleter : public QCompleter {

--- a/src/ui/linux/TogglDesktop/timerwidget.ui
+++ b/src/ui/linux/TogglDesktop/timerwidget.ui
@@ -113,7 +113,7 @@
          <string/>
         </property>
         <property name="frame">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
### 📒 Description
No longer it will eat the input when working with the dropdown. Also, the End and Home keys work the same as before.

This is a work in progress, it especially requires more testing if everything still works as expected and also if issues reported in #3384 are actually fixed.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Linux: Autocomplete now works more deterministically

### 👫 Relationships
Closes #3384

### 🔎 Review hints
This is mostly about keyboard control so check if navigation keys work as expected with autocomplete and its dropdown

There's also a test build in this release in my fork: https://github.com/MartinBriza/toggldesktop/releases/tag/v7.4.600