### PR TITLE
Create Zero Time Entry Issues

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -275,6 +275,9 @@ NSString *kInactiveTimerColor = @"#999999";
 
 		self.durationTextField.toolTip = [NSString stringWithFormat:@"Started: %@", self.time_entry.startTimeString];
 		self.descriptionLabel.editable = NO;
+
+        // Switch to timer mode in setting
+        toggl_set_settings_manual_mode(ctx, false);
 	}
 	else
 	{


### PR DESCRIPTION
### 📒 Description
There are plenty of users complain that the app creates Zero TimeEntry when clicking on Continue Button on particular TE. (See conversations)

However there are two type of report users:

1. First type of users claimed this bug when Layout is correct (Add Time Entry button) and `"manual_mode" : true`
![Screen Shot 2019-12-04 at 20 54 08](https://user-images.githubusercontent.com/5878421/70148184-41beed00-16d8-11ea-960e-619ff83ef4d5.png)
Ex: https://app.intercom.io/a/apps/ayixs927/conversations/24310892078?redirectTo=feed

=> It's correct behavior.
=> When in Manual Mode => Hit Continue button will create Zero TimeEntry

2. Second type of users stated this bug when the layout is in Timer, but the `"manual_mode" : true`.
=> It is definitely a **bug** 🐛  that this PR would fix 
Ex: https://toggl.intercom-attachments-3.com/i/o/167615786/26fbbff8e8c5e6c19f9c5e02/Screen+Recording+2019-12-03+at+11.34.24.mov

### How to reproduce
#### 1. Start new TE (CMD+N) when it's in the Manual Mode.
1. Switch to Manual mode 
2. Start new Entry by (CMD + N) or New menu
3. Hit Stop button
4. Click on Continue button of any TE
5. The app create Empty TE but the layout is mismatched -> 🐛 

#### 2. Start TE in web when it's in manual mode in desktop
1. Open TogglDesktop and switch to Manual Mode
2. Open Web and start any TE
3. The app start syncing and get the running TE
4. Stop in app or stop in the web
5. Click on Continue button of any TE
6. The app create Empty TE but the layout is mismatched -> 🐛 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] When creating new TE from New Menu -> Check the current mode and create properly
- [x] When updating the TE to Running TimeEntry mode -> Explicitly switch to Manual mode in Setting.

### 👫 Relationships
Closes https://github.com/toggl-open-source/toggldesktop/pull/3580

### 🔎 Review hints
- Reproduce the bug and make sure that it won't happen again 👍 

