### PR TITLE
Improve in-app message logic 

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -56,6 +56,30 @@ void Analytics::TrackOSDetails(const std::string &client_id) {
     Track(client_id, "osdetails", ss.str());
 }
 
+void Analytics::TrackInAppMessage(const std::string &client_id,
+                                  const std::string &id,
+                                  const Poco::Int64 type) {
+    std::stringstream ss;
+    ss << "message/" << id << "/";
+
+    if (type == 0) {
+        // in-app message shown on app start
+        ss << "show/appstart";
+    } else if (type == 1) {
+        // in-app message shown with periodic trigger
+        ss << "show/periodic";
+    } else if (type == 2) {
+        // in-app message close clicked
+        ss << "click/close";
+    } else {
+        // in-app message cta clicked
+        ss << "click/cta";
+    }
+
+    Track(client_id, "in-app-message", ss.str());
+}
+
+
 void Analytics::TrackWindowSize(const std::string &client_id,
                                 const std::string &os,
                                 const toggl::Rectangle rect) {

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -38,6 +38,11 @@ class Analytics : public Poco::TaskManager {
     void TrackOSDetails(
         const std::string &client_id);
 
+    void TrackInAppMessage(
+        const std::string &client_id,
+        const std::string &id,
+        const Poco::Int64 type);
+
     void TrackSettings(
         const std::string &client_id,
         const bool record_timeline,

--- a/src/const.h
+++ b/src/const.h
@@ -10,6 +10,7 @@
 #define kSyncIntervalRangeSeconds 900
 #define kWebsocketRestartRangeSeconds 45
 #define kCheckUpdateIntervalSeconds 86400
+#define kCheckInAppMessageIntervalSeconds 14400
 #define kRequestThrottleSeconds 2
 #define kTimerStartInterval 10
 #define kTimelineSecondsToKeep 604800

--- a/src/context.cc
+++ b/src/context.cc
@@ -1530,8 +1530,8 @@ error Context::fetchMessage() {
                 return error("Error parsing update check response body");
             }
             auto messageID = root["id"].asInt64();
-            auto type = root["type"].asInt64();
-            auto days = root["days"].asInt64();
+            auto type = stoi(root["type"].asString());
+            auto days = stoi(root["days"].asString());
             version_number = root["appversion"].asString();
 
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -1516,12 +1516,10 @@ error Context::fetchMessage(const bool periodic) {
         }
 
         // To test in-app message fetch in development, comment this block out:
-        /* Remove this before merge
         if ("production" != environment_) {
             logger().debug("Not in production, will not fetch in-app messages");
             return noError;
         }
-         */
 
         // Load last showed message id
         Poco::Int64 old_id(0);

--- a/src/context.cc
+++ b/src/context.cc
@@ -1510,7 +1510,7 @@ error Context::fetchMessage(const bool periodic) {
     try {
 
         // Check if in-app messaging is supported and show
-        if (UI()->CanDisplayMessage()) {
+        if (!UI()->CanDisplayMessage()) {
             logger().debug("In-app messages not supported on this platform");
             return noError;
         }

--- a/src/context.cc
+++ b/src/context.cc
@@ -1604,19 +1604,25 @@ error Context::fetchMessage(const bool periodic) {
                 }
             }
 
-            // check date (if certain days have passed since timestamp)
-            if (days != 0) {
-                Poco::LocalDateTime dt(
-                    Poco::Timestamp::fromEpochTime(root["datetime"].asInt64()));
+            // check if message is active (current time is between from and to)
+            Poco::LocalDateTime now;
 
-                Poco::LocalDateTime now;
+            if (root.isMember("from")) {
+                Poco::LocalDateTime from(
+                    Poco::Timestamp::fromEpochTime(root["from"].asInt64()));
 
-                Poco::LocalDateTime until_date =
-                    dt + Poco::Timespan(days * Poco::Timespan::DAYS);
+                // message is not active yet
+                if (from.utcTime() > now.utcTime()) {
+                    return noError;
+                }
+            }
 
+            if (root.isMember("to")) {
+                Poco::LocalDateTime to(
+                    Poco::Timestamp::fromEpochTime(root["to"].asInt64()));
 
-                // check if more days has passed than allowed by the message
-                if (until_date.utcTime() > now.utcTime()) {
+                // message is alread out dated
+                if (now.utcTime() > to.utcTime()) {
                     return noError;
                 }
             }

--- a/src/context.cc
+++ b/src/context.cc
@@ -1509,7 +1509,13 @@ error Context::downloadUpdate() {
 error Context::fetchMessage(const bool periodic) {
     try {
 
-        // To test updater in development, comment this block out:
+        // Check if in-app messaging is supported and show
+        if (UI()->CanDisplayMessage()) {
+            logger().debug("In-app messages not supported on this platform");
+            return noError;
+        }
+
+        // To test in-app message fetch in development, comment this block out:
         /* Remove this before merge
         if ("production" != environment_) {
             logger().debug("Not in production, will not fetch in-app messages");
@@ -1629,23 +1635,17 @@ error Context::fetchMessage(const bool periodic) {
             last_message_id_ = root["id"].asString();
         }
 
-        // Check if in-app messaging is supported and show
-        if (UI()->CanDisplayMessage()) {
-            if ("production" == environment_) {
-                analytics_.TrackInAppMessage(db_->AnalyticsClientID(),
-                                             last_message_id_,
-                                             periodic);
-            }
+        analytics_.TrackInAppMessage(db_->AnalyticsClientID(),
+                                     last_message_id_,
+                                     periodic);
 
-            startPeriodicInAppMessageCheck();
+        startPeriodicInAppMessageCheck();
 
-            UI()->DisplayMessage(
-                title,
-                text,
-                button,
-                url);
-            return noError;
-        }
+        UI()->DisplayMessage(
+            title,
+            text,
+            button,
+            url);
     } catch(const Poco::Exception& exc) {
         return exc.displayText();
     } catch(const std::exception& ex) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1559,8 +1559,7 @@ error Context::fetchMessage(const bool periodic) {
                 return error("Error parsing update check response body");
             }
             auto messageID = root["id"].asInt64();
-            auto type = stoi(root["type"].asString());
-            auto days = stoi(root["days"].asString());
+            auto type = root["type"].asInt64();
             version_number = root["appversion"].asString();
 
 

--- a/src/context.h
+++ b/src/context.h
@@ -490,6 +490,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void TrackEditSize(const Poco::Int64 width,
                        const Poco::Int64 height);
 
+    void TrackInAppMessage(const Poco::Int64 type);
+
  protected:
     void uiUpdaterActivity();
     void checkReminders();
@@ -577,7 +579,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error downloadUpdate();
 
-    error fetchMessage();
+    error fetchMessage(const bool periodic);
 
     void stopActivities();
 
@@ -734,6 +736,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     std::map<std::string, bool_t> entry_groups;
 
     bool overlay_visible_;
+
+    std::string last_message_id_;
 
     const bool handleStopRunningEntry();
 };

--- a/src/context.h
+++ b/src/context.h
@@ -522,6 +522,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void onSwitchTimelineOn(Poco::Util::TimerTask& task);  // NOLINT
     void onFetchUpdates(Poco::Util::TimerTask& task);  // NOLINT
     void onPeriodicUpdateCheck(Poco::Util::TimerTask& task);  // NOLINT
+    void onPeriodicInAppMessageCheck(Poco::Util::TimerTask& task);  // NOLINT
     void onTimelineUpdateServerSettings(Poco::Util::TimerTask& task);  // NOLINT
     void onSendFeedback(Poco::Util::TimerTask& task);  // NOLINT
     void onPeriodicSync(Poco::Util::TimerTask& task);  // NOLINT
@@ -535,6 +536,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     void startPeriodicUpdateCheck();
     void executeUpdateCheck();
+
+    void startPeriodicInAppMessageCheck();
 
     void startPeriodicSync();
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1428,3 +1428,11 @@ void track_edit_size(void *context,
     }
     app(context)->TrackEditSize(width, height);
 }
+
+void toggl_iam_click(void *context,
+                     const uint64_t type) {
+    if (!context) {
+        return;
+    }
+    app(context)->TrackInAppMessage(type);
+}

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1294,6 +1294,7 @@ const NSString *appName = @"osx_native_app";
 	toggl_on_promotion(ctx, on_promotion);
 	toggl_on_project_colors(ctx, on_project_colors);
 	toggl_on_countries(ctx, on_countries);
+    toggl_on_message(ctx, on_display_message);
 
 	NSLog(@"Version %@", self.version);
 
@@ -1850,6 +1851,16 @@ void on_countries(TogglCountryView *first)
 		}
 	}
 #endif
+}
+
+#pragma mark - In app message
+
+void on_display_message(const char *title,
+                        const char *text,
+                        const char *button,
+                        const char *url)
+{
+
 }
 
 @end


### PR DESCRIPTION
### 📒 Description
Adds periodic fetch and user analytics, improves message logic and format.

### 🕶️ Types of changes

**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add periodic message check (every 4 hrs)
- [x] Add analytics `show (appstart/periodic), click (close/cta)`
- [x] Change the date logic. Drop `datetime` and `days` and go for from and to

`from`- is start day from which the message is active
`to` -  is the end date after which this message is not active anymore

### 👫 Relationships

Closes #3583

### 🔎 Review hints

**Prep**
- Move `fetchMessage(0)` out of the `production` env check (line 300 in `context.cc`)
- All production checks or `CanDisplayMessage` checks should be commented out so `fetchMessage` executes until the end

**Periodic sync**

- Do **Prep**
- Update the `kCheckInAppMessageIntervalSeconds` (inside `const.h`) to `2` (2seconds)
- Move `startPeriodicInAppMessageCheck();` to be the first row of `fechMessage` function.
- Set breakpoint in `fetchMessage` function and see if it triggers every 2 seconds

**Analytics**

all production checks should be commented out so `fetchMessage` executes until the analytics and triggers analytics request

**New message format**

- Do **Prep**
The from datestamp is 2 yesterday and to timestamp is Dec 10

Change the now date to create situations where it is invalid. (outside `from` and `to` range)