### PR TITLE
Touch Bar Crash in OSX 10.11

### DIFF
--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -55,7 +55,7 @@ typedef NS_ENUM (NSUInteger, UserAction)
 @property (nonatomic, assign) NSInteger selectedCountryID;
 @property (nonatomic, assign) TabViewType currentTab;
 @property (nonatomic, assign) UserAction userAction;
-@property (nonatomic, strong) LoginSignupTouchBar *loginTouchBar;
+@property (nonatomic, strong) LoginSignupTouchBar *loginTouchBar __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
 - (IBAction)clickLoginButton:(id)sender;
 - (IBAction)clickSignupButton:(id)sender;
@@ -114,8 +114,11 @@ extern void *ctx;
 
 	self.userAction = UserActionAccountLogin;
 
-	self.loginTouchBar = [[LoginSignupTouchBar alloc] init];
-	self.loginTouchBar.delegate = self;
+    if (@available(macOS 10.12.2, *))
+    {
+        self.loginTouchBar = [[LoginSignupTouchBar alloc] init];
+        self.loginTouchBar.delegate = self;
+    }
 }
 
 - (void)initCountryAutocomplete {
@@ -539,15 +542,18 @@ extern void *ctx;
 
 - (NSTouchBar *)makeTouchBar
 {
-	switch (self.currentTab)
-	{
-		case TabViewTypeLogin :
-			return [self.loginTouchBar makeTouchBarFor:LoginSignupModeLogin];
+    if (@available(macOS 10.12.2, *))
+    {
+        switch (self.currentTab)
+        {
+            case TabViewTypeLogin :
+                return [self.loginTouchBar makeTouchBarFor:LoginSignupModeLogin];
 
-		case TabViewTypeSingup :
-			return [self.loginTouchBar makeTouchBarFor:LoginSignupModeSignUp];
-	}
-	return nil;
+            case TabViewTypeSingup :
+                return [self.loginTouchBar makeTouchBarFor:LoginSignupModeSignUp];
+        }
+    }
+    return nil;
 }
 
 - (void)loginSignupTouchBarOn:(enum LoginSignupAction)action

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -232,7 +232,10 @@ extern void *ctx;
 	}
 
 	// Reset touchbar
-	self.touchBar = nil;
+    if (@available(macOS 10.12.2, *))
+    {
+        self.touchBar = nil;
+    }
 }
 
 - (void)startGoogleAuthentication

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -362,17 +362,24 @@ extern void *ctx;
 
 -(void)windowDidBecomeMain:(NSNotification *)notification
 {
-    if ([self.timeEntryListViewController.view superview] != nil)
-    {
-        [[TouchBarService shared] present];
-    }
+     if (@available(macOS 10.12.2, *))
+     {
+         if ([self.timeEntryListViewController.view superview] != nil)
+         {
+             [[TouchBarService shared] present];
+         }
+     }
+
 }
 
 - (void)windowDidResignMain:(NSNotification *)notification
 {
-    if ([self.timeEntryListViewController.view superview] != nil)
+    if (@available(macOS 10.12.2, *))
     {
-        [[TouchBarService shared] minimize];
+        if ([self.timeEntryListViewController.view superview] != nil)
+        {
+            [[TouchBarService shared] minimize];
+        }
     }
 }
 

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -100,7 +100,9 @@ extern void *ctx;
 
 - (void)initTouchBar
 {
-	[TouchBarService shared].delegate = self;
+    if (@available(macOS 10.12.2, *)) {
+        [TouchBarService shared].delegate = self;
+    }
 }
 
 - (void)initErrorView {
@@ -146,9 +148,12 @@ extern void *ctx;
 		[self.timeEntryListViewController.view removeFromSuperview];
 		[self.overlayViewController.view removeFromSuperview];
 
-		// Reset the data
-		[[TouchBarService shared] resetContent];
-        [[TouchBarService shared] minimize];
+		// Reset
+        if (@available(macOS 10.12.2, *)) 
+		{
+            [[TouchBarService shared] resetContent];
+        	[[TouchBarService shared] minimize];
+        }
 	}
 }
 
@@ -180,8 +185,10 @@ extern void *ctx;
 																		object:nil];
 
 			// Prepare the Touch bar
-			[[TouchBarService shared] prepareContent];
-            [[TouchBarService shared] present];
+            if (@available(macOS 10.12.2, *)) {
+                [[TouchBarService shared] prepareContent];
+            	[[TouchBarService shared] present];
+            }
 		}
 	}
 }

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -741,7 +741,10 @@ extern void *ctx;
 
 - (void)touchBarSettingChangedNotification:(NSNotification *)noti
 {
-	self.touchBar = nil;
+    if (@available(macOS 10.12.2, *))
+    {
+        self.touchBar = nil;
+    }
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -813,7 +813,10 @@ NSString *kInactiveTimerColor = @"#999999";
 
 - (void)touchBarSettingChangedNotification:(NSNotification *)noti
 {
-	self.touchBar = nil;
+    if (@available(macOS 10.12.2, *))
+    {
+        self.touchBar = nil;
+    }
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -306,10 +306,14 @@ NSString *kInactiveTimerColor = @"#999999";
 	// Hide
 	self.cancelBtn.hidden = YES;
 
-	if (self.time_entry != nil && self.time_entry.isRunning)
-	{
-		[[TouchBarService shared] updateRunningItem:self.time_entry];
-	}
+    if (@available(macOS 10.12.2, *))
+    {
+        if (self.time_entry != nil && self.time_entry.isRunning)
+        {
+            [[TouchBarService shared] updateRunningItem:self.time_entry];
+        }
+    }
+
 }
 
 - (void)startDisplayTimeEntryEditor:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		3C7B4E8D190FA6D200627DC3 /* NSTextFieldVerticallyAligned.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C7B4E8C190FA6D200627DC3 /* NSTextFieldVerticallyAligned.m */; };
 		3C7B4EB3190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C7B4EB2190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m */; };
 		3C8979CA19235EA2007061E0 /* NSTextFieldClickablePointer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C8979C919235EA2007061E0 /* NSTextFieldClickablePointer.m */; };
-		3CB7CFF82222033B00A9C806 /* DFRFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CB7CFD92222033B00A9C806 /* DFRFoundation.framework */; };
+		3CB7CFF82222033B00A9C806 /* DFRFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CB7CFD92222033B00A9C806 /* DFRFoundation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		3CC450E91A31ED540012440B /* NSTextFieldDuration.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CC450E81A31ED540012440B /* NSTextFieldDuration.m */; };
 		3CD30F431F58B02C006FAA0D /* OverlayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CD30F411F58B02C006FAA0D /* OverlayViewController.m */; };
 		3CD30F441F58B02C006FAA0D /* OverlayViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3CD30F421F58B02C006FAA0D /* OverlayViewController.xib */; };

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -2707,6 +2707,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
+				WARNING_CFLAGS = "-Wpartial-availability";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -52,7 +52,7 @@
 @property (nonatomic, strong) ConsoleViewController *consoleWindowController;
 
 // Touch Bar items
-@property (nonatomic, strong) GlobalTouchbarButton *touchItem;
+@property (nonatomic, strong) GlobalTouchbarButton *touchItem __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 @property (nonatomic, assign) BOOL isAddedTouchBar;
 
 // Remember some app state
@@ -855,7 +855,9 @@ void *ctx;
 	if (image != self.statusItem.image)
 	{
 		[self.statusItem setImage:image];
-		[self.touchItem update:image];
+        if (@available(macOS 10.12.2, *)) {
+            [self.touchItem update:image];
+        }
 	}
 }
 
@@ -1819,7 +1821,9 @@ void on_countries(TogglCountryView *first)
 
 - (void)handleTouchBarWithSettings:(Settings *)settings
 {
-	[TouchBarService shared].isEnabled = settings.showTouchBar;
+    if (@available(macOS 10.12.2, *)) {
+        [TouchBarService shared].isEnabled = settings.showTouchBar;
+    }
 	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kTouchBarSettingChanged object:@(settings.showTouchBar)];
 
 #ifndef APP_STORE

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1156,7 +1156,9 @@ void *ctx;
 	ctx = 0;
 
 #ifndef APP_STORE
-    [[TouchBarService shared] dismiss];
+    if (@available(macOS 10.12.2, *)) {
+        [[TouchBarService shared] dismiss];
+    }
 #endif
 
 	if (self.aboutWindowController.restart == YES)

--- a/src/ui/osx/TogglDesktop/test2/AppIconFactory.m
+++ b/src/ui/osx/TogglDesktop/test2/AppIconFactory.m
@@ -20,7 +20,13 @@
 			icon = [NSImage imageNamed:@"AppIconActive"];
 			break;
 		case AppIconTypeDefault :
-			icon = [NSImage imageNamed:@"AppIcon"];
+            if (@available(macOS 10.12.0, *))
+            {
+                icon = [NSImage imageNamed:@"AppIcon"];
+            } else {
+                icon = [NSImage imageNamed:NSImageNameApplicationIcon];
+            }
+
 			break;
 	}
 

--- a/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
+++ b/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
@@ -36,7 +36,6 @@ static NSString *const upArrow = @"\u25B2";
 	self = [super initWithCoder:coder];
 	if (self)
 	{
-		self.automaticTextCompletionEnabled = NO;
 		self.posY = 0;
 		self.constraintsActive = NO;
 		self.itemHeight = 30.0;
@@ -46,6 +45,10 @@ static NSString *const upArrow = @"\u25B2";
 		self.layer.masksToBounds = NO;
 		self.displayMode = AutoCompleteDisplayModeCompact;
 		[self initBackgroundView];
+        if (@available(macOS 10.12.2, *))
+        {
+            self.automaticTextCompletionEnabled = NO;
+        }
 	}
 	return self;
 }

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -207,11 +207,15 @@ extern void *ctx;
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
-    [[TouchBarService shared] dismiss];
+    if (@available(macOS 10.12.2, *)) {
+        [[TouchBarService shared] dismiss];
+    }
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification
 {
-    [[TouchBarService shared] present];
+    if (@available(macOS 10.12.2, *)) {
+        [[TouchBarService shared] present];
+    }
 }
 @end

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -57,8 +57,11 @@ extern void *ctx;
 												 name:NSWindowDidBecomeKeyNotification
 											   object:nil];
 
-	self.touchbar = [[IdleNotificationTouchBar alloc] init];
-	self.touchbar.delegate = self;
+    if (@available(macOS 10.12.2, *))
+    {
+        self.touchbar = [[IdleNotificationTouchBar alloc] init];
+        self.touchbar.delegate = self;
+    }
 }
 
 - (void)dealloc

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -21,7 +21,7 @@
 @property (weak) IBOutlet NSButton *cancelButton;
 @property (weak) IBOutlet FlatButton *discardAndContinueButton;
 @property (weak) IBOutlet FlatButton *keepIdleTimeButton;
-@property (strong, nonatomic) IdleNotificationTouchBar *touchbar;
+@property (strong, nonatomic) IdleNotificationTouchBar *touchbar __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
 @property (assign, nonatomic) BOOL isWaiting;
 

--- a/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
@@ -29,6 +29,7 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL) __OSX_AVAILABLE_START
 + (void)dismissSystemModal:(NSTouchBar *)touchBar;
 
 + (void)minimizeSystemModal:(NSTouchBar *)touchBar;
++ (void)presentSystemModalFunctionBar:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSString *)identifier __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
 @end
 

--- a/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
@@ -12,13 +12,13 @@
 #ifndef APP_STORE
 #import <AppKit/AppKit.h>
 
-extern void DFRElementSetControlStripPresenceForIdentifier(NSString *, BOOL);
-extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
+extern void DFRElementSetControlStripPresenceForIdentifier(NSString *, BOOL) __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
+extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL) __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
 @interface NSTouchBarItem ()
 
-+ (void)addSystemTrayItem:(NSTouchBarItem *)item;
-+ (void)removeSystemTrayItem:(NSTouchBarItem *)item;
++ (void)addSystemTrayItem:(NSTouchBarItem *)item __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
++ (void)removeSystemTrayItem:(NSTouchBarItem *)item __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
 @end
 
@@ -34,3 +34,4 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
 
 #endif
 #endif /* TouchBar_h */
+

--- a/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar+PrivateAPIs.h
@@ -24,12 +24,11 @@ extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL) __OSX_AVAILABLE_START
 
 @interface NSTouchBar (PrivateAPIs)
 
-+ (BOOL)presentSystemModal:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
++ (BOOL)presentSystemModal:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
-+ (void)dismissSystemModal:(NSTouchBar *)touchBar;
++ (void)dismissSystemModal:(NSTouchBar *)touchBar __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
-+ (void)minimizeSystemModal:(NSTouchBar *)touchBar;
-+ (void)presentSystemModalFunctionBar:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSString *)identifier __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
++ (void)minimizeSystemModal:(NSTouchBar *)touchBar __OSX_AVAILABLE_STARTING(__MAC_10_12_2,__IPHONE_NA);
 
 @end
 


### PR DESCRIPTION
### 📒 Description
This PR will exclude the Private Touch Bar APIs in 10.11

### Why?
There are some reasons causes the crash:
- Hard import DFRfoundation, which is absent in OS 10.11
- Unknown selector (Touch Bar) in runtime 10.11

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### Changelogs
- [x] Add safe #if for all Touch Bar in source code
- [x] Make Private Framework as an optional import
- [x] Fix blur app icon in 10.11
- [x] Add warning flag in to Xcode to warning if the APIs is unavailable for old OSX

### 🔎 Review hints
- Run on 10.11 machine and make sure it works
Download PR's build at
[TogglDesktop 2019-12-10 19-58-38.zip](https://github.com/toggl-open-source/toggldesktop/files/3944939/TogglDesktop.2019-12-10.19-58-38.zip)

![Screen Shot 2019-12-10 at 19 54 20](https://user-images.githubusercontent.com/5878421/70531769-33fde180-1b88-11ea-8b1b-c1cca4d43e41.png)
