### PR TITLE
The Client Creator view is dismissed when the TE is running 

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -531,7 +531,11 @@ NSString *kInactiveTimerColor = @"#999999";
 {
 	[self.mainBox setHidden:NO];
 	[self.manualBox setHidden:YES];
-	[self.view.window makeFirstResponder:self.autoCompleteInput];
+
+    // Don't focus if the timer is running
+    if (![self.time_entry isRunning]) {
+        [self.view.window makeFirstResponder:self.autoCompleteInput];
+    }
 }
 
 - (void)toggleManual:(NSNotification *)notification


### PR DESCRIPTION
### 📒 Description
This PR resolves the issue that the Project Creator / Client Creator are often dismissed as well as the Description losts the focus when editing on the Running TE.

### Why it happens
There is a bug in library that the Setting notification ofter triggers when the TE is running or editing the TE -> Which cause the Timer focus on the Timer Text Field -> Lose focus -> The Popup would be dismiss.

This would be resolved later in separated ticket (Will link here after creating later)

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Don't focus on the Timer when the TE is running

### 👫 Relationships
Closes #3594

### 🔎 Review hints
1. Start any TimeEntry
2. Open the Editor on this running TE
3. Try to edit some text field -> If there is no lost focus -> Correct
4. Try to create Project or Client -> If the popup won't close -> Correct

![2019-12-06 17 20 26](https://user-images.githubusercontent.com/5878421/70316259-e3b41600-184d-11ea-812f-addfe29fb33d.gif)
