### PR TITLE
Increase how the Overlap of Two TEs are

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -10,6 +10,10 @@ import Foundation
 
 class TimelineBaseTimeEntry {
 
+    struct Constant {
+        static let MinimumSecondOverlap: Double = 60 // seconds
+    }
+
     let start: TimeInterval
     let end: TimeInterval
     var group: Int = -1 // Group of overlap entries -> Help to resolve the overlap later
@@ -28,9 +32,17 @@ class TimelineBaseTimeEntry {
     }
 
     func isIntersected(with entry: TimelineBaseTimeEntry) -> Bool {
-        return (start >= entry.start && start <= entry.end)
-            || (end >= entry.start && end <= entry.end)
-            || (start >= entry.start && end <= entry.end)
+
+        // Skip overlap if the diff is less than 60s
+        if abs(entry.start - end) <= Constant.MinimumSecondOverlap ||
+            abs(entry.end - start) <= Constant.MinimumSecondOverlap {
+            return false
+        }
+
+        // Convert to rect to easier check intersects
+        let currentRect = CGRect(x: 1, y: start, width: 1, height: abs(end - start))
+        let entryRect = CGRect(x: 1, y: entry.start, width: 1, height: abs(entry.end - entry.start))
+        return currentRect.intersects(entryRect)
     }
 }
 


### PR DESCRIPTION
### 📒 Description
This PR improves the basic logic how we consider whether two TEs are overlapped or not. We increase the padding to 60 seconds.

### 🕶️ Types of changes
- Bug

### 🤯 List of changes
- [x] Improve the logic by converting the TE as a CGRect and check a intersect
- [x] Add padding 60s

### 👫 Relationships
Closes #3564

### 🔎 Review hints
#### Two TEs are in 60 seconds are not overlap
1. Create two TEs in app. Each for 1 min (Call as A and B)
2. Quit the app
3. Open the database and update start/end whether the A's end time == B's start time
See the screenshot (last two columns are start and end time)
<img width="1244" alt="Screen Shot 2019-12-09 at 19 38 40" src="https://user-images.githubusercontent.com/5878421/70436542-20854480-1abc-11ea-894a-951b32a9d223.png">

4. Open the app and check the Timeline
5. If they are not renders as a overlap (The B is in the second col) -> Correct 💯 
6. Quit and update the value in the database
7. Change the value that (B's start time < A's end time) && (A's endtime - B's start time <= 60)
8. Open the app and Timeline
9. If they are not renders as a overlap (The B is in the second col) -> Correct 💯 

#### Two TEs are > 60 seconds are overlap
1. Create 2 TEs, which A's endtime > B's startime and greater than 60s
2. Timeline renders them as a overlap -> 💯 

### Two scenarios
- The following pictures visualize how we consider if 2 TEs are overlap or not.
- The last case in NOT Overlap scenario, it's what this PR is for (Padding 60s)

<img width="1349" alt="Screen Shot 2019-12-09 at 19 59 00" src="https://user-images.githubusercontent.com/5878421/70437526-62af8580-1abe-11ea-94a0-f3920b9deda7.png">
<img width="494" alt="Screen Shot 2019-12-09 at 19 59 03" src="https://user-images.githubusercontent.com/5878421/70437528-63481c00-1abe-11ea-8ca1-141312bf5fef.png">
