### PR TITLE
Fix Blur text in non-retina screen

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -134,6 +134,9 @@ final class AutoCompleteView: NSView {
         if height > 0 {
             tableViewHeight.constant = height
         }
+
+        // Hack to workaround the blur text
+        fixBlurTextOnNonRetinaScreen()
     }
 
     func setCreateButtonSectionHidden(_ isHidden: Bool) {
@@ -193,6 +196,19 @@ extension AutoCompleteView {
         createNewItemBtn.didPressKey = { key in
             if key == .tab {
                 self.delegate?.shouldClose()
+            }
+        }
+    }
+
+    private func fixBlurTextOnNonRetinaScreen() {
+        // Ref: https://github.com/toggl-open-source/toggldesktop/issues/3313
+        if #available(OSX 10.12, *) {
+            if let screenScale = NSScreen.main?.backingScaleFactor, screenScale == 1.0 {
+                createNewItemBtn.image = nil
+                createNewItemBtn.imageHugsTitle = false
+            } else {
+                createNewItemBtn.image = NSImage(named: "add-icon")
+                createNewItemBtn.imageHugsTitle = true
             }
         }
     }


### PR DESCRIPTION
### 📒 Description
This PR introduce a hack to workaround a blur text issue on Non-Retina screen

## Why?
After some experiments, it turns out that if the button is full width and the `imageHugTitle` is enabled, the Button render incorrectly in non-retina screen.

<img width="308" alt="Screen Shot 2019-12-10 at 15 31 47" src="https://user-images.githubusercontent.com/5878421/70512645-8debb080-1b62-11ea-95b1-38b844dc87e1.png">

- This issue is resolved if we disable the imageHugTitle and image.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Disable ImageHugTitles and image in non-retina screen

### 👫 Relationships
Closes #3313 

### 🔎 Review hints
#### No blur text in retina and non-retina monitors
- Open Project, Client, Tag AutoComplete and make sure the Create button is not blur text in both type of monitor.

### Non-retina monitor
![Screen Shot 2019-12-10 at 15 28 18](https://user-images.githubusercontent.com/5878421/70512746-cb503e00-1b62-11ea-8ba7-e1b2fb55abe1.png)

### Retina monitor
<img width="292" alt="Screen Shot 2019-12-10 at 15 28 33" src="https://user-images.githubusercontent.com/5878421/70512764-d4410f80-1b62-11ea-8cb3-488dded9e8ef.png">
mac
