### PR TITLE
Fix Tag AutoComplete jump issues

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/TagDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/TagDataSource.swift
@@ -30,6 +30,13 @@ final class TagDataSource: AutoCompleteViewDataSource {
 
     // MARK: Override
 
+    override func render(with items: [Any]) {
+        let selection = tableView.selectedRowIndexes
+        super.render(with: items)
+        // Re-select previous selection because reloadData causes lost the user selection
+        tableView.selectRowIndexes(selection, byExtendingSelection: false)
+    }
+
     override func setup(with textField: AutoCompleteTextField) {
         super.setup(with: textField)
         tableView.allowsEmptySelection = true


### PR DESCRIPTION
### 📒 Description
This PR fixes the Tag Jump issues when selecting a tag.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Re-select the selection after the table view is reloaded

### 👫 Relationships
Closes #3485
Closes #3334

### 🔎 Review hints
1. Select a tag
2. Make sure the selection is still remained and not jump to top anymore


