### PR TITLE
AutoCompleteView doesn't show in External monitor

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -116,10 +116,20 @@ final class AutoCompleteView: NSView {
 
         var height = height
         let screenFrame = window.convertToScreen(frame)
-        let topLeftY = screenFrame.origin.y + screenFrame.size.height
+
+        // Get the top left
+        // As screenFrame.origin.y is a bottom-left
+        var topLeftY = screenFrame.origin.y + screenFrame.size.height
+
+        // Add the offset in external monitor
+        // Because there is only one origin coordinate system, so in some external screen, the bottom-left origin could be negative value
+        // https://github.com/toggl-open-source/toggldesktop/issues/3524
+        topLeftY -= screen.frame.origin.y
+
+        // Exclude the system bar height
         let dockBarHeight = abs(screen.frame.height - screen.visibleFrame.height)
         var offset: CGFloat = createNewItemContainerView.isHidden ? 0 : Constants.CreateButtonHeight
-        offset += dockBarHeight // Exclude the bar height
+        offset += dockBarHeight
 
         // Reduce the size if the height is greater than screen
         if (height + offset) > topLeftY {


### PR DESCRIPTION
### 📒 Description
This PR fixes the issues that the AutoCompleteView has invalid height when expanding in an external monitor (270 degree)

## Why?
![Blank](https://user-images.githubusercontent.com/5878421/70889615-9be37a80-2015-11ea-8040-3f858c1b6f9a.png)

It turns out that when we have multiple monitors, the origin system coordinate is still the bottom-left point of the main screen. Therefore, if the app in the external screen and it positions below the origin point -> the logic is broken -> Cause the height is 0 

## How to fix it
- Just do simple translation to get the bottom-left point of the current screen.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue

### 🤯 List of changes
- [x] Fix the logic to calculate the suitable height for the AutoCompleteView

### 👫 Relationships
Closes #3524

### 🔎 Review hints
### Case 1: The original case
Must have an external monitor.
Drop-down lists are not expanded when:

1. The external monitor is rotated by 270 degrees (from Displays settings)
2. Toggl is on that monitor
3. Toggl is positioned at the bottom right corner
4. Make sure that it appears properly => 💯 

### Case 2: Different screen arrangement 
1. The external monitor is rotated by 270 degrees (from Displays settings)
2. Open Display Preference -> Arrangement tab
3. For each possible arrangement, test whether the AutoComplete appears properly.

![Screen Shot 2019-12-16 at 15 14 58](https://user-images.githubusercontent.com/5878421/70890384-84a58c80-2017-11ea-9fe6-73013c2aae7c.png)
![Screen Shot 2019-12-16 at 15 15 21](https://user-images.githubusercontent.com/5878421/70890386-84a58c80-2017-11ea-8fef-d744933dca73.png)
![Screen Shot 2019-12-16 at 15 16 14](https://user-images.githubusercontent.com/5878421/70890388-853e2300-2017-11ea-90db-9fd1d312842b.png)

### Case 3: Normal external monitor
1. The external monitor isn't rotated (Default value) 
2. Open Display Preference -> Arrangement tab
3. For each possible arrangement, test whether the AutoComplete appears properly.

![Screen Shot 2019-12-16 at 15 12 44 (2)](https://user-images.githubusercontent.com/5878421/70890472-ba4a7580-2017-11ea-903f-756dd009fc5c.png)


