### PR TITLE
Fix blurred icon app in 10.12

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppIconFactory.m
+++ b/src/ui/osx/TogglDesktop/test2/AppIconFactory.m
@@ -20,9 +20,9 @@
 			icon = [NSImage imageNamed:@"AppIconActive"];
 			break;
 		case AppIconTypeDefault :
-            if (@available(macOS 10.12.0, *))
+            if (@available(macOS 10.13.0, *))
             {
-                icon = [NSImage imageNamed:@"AppIcon"];
+                icon = [NSImage imageNamed:@"AppIcon"]; // NSImageNameApplicationIcon causes lost icon app in NSAlert in 10.13+
             } else {
                 icon = [NSImage imageNamed:NSImageNameApplicationIcon];
             }


### PR DESCRIPTION
### 📒 Description
This PR introduce a tiny change on AppIconFactory, which fixes the blurred icon in macOS 10.12

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Use app icon properly

### 👫 Relationships
Closes #3633

### 🔎 Review hints
- Check the icon app in two states: Stop or Running in all macOS from 10.11 -> 10.15
![Screen Shot 2019-12-18 at 13 42 46](https://user-images.githubusercontent.com/5878421/71062407-f824d680-219c-11ea-961e-182b43650224.png)
![Screen Shot 2019-12-18 at 13 44 54](https://user-images.githubusercontent.com/5878421/71062409-f8bd6d00-219c-11ea-815c-cd355a0890d3.png)
![Screen Shot 2019-12-18 at 13 43 44](https://user-images.githubusercontent.com/5878421/71062410-f8bd6d00-219c-11ea-852c-32bcb12ca23e.png)
 

