### PR TITLE
Timeline Timezone issues

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -490,10 +490,11 @@ void GUI::DisplayTimeline(
         TimelineDateAt().year(),
         TimelineDateAt().month(),
         TimelineDateAt().day());
+    int tzd = datetime.tzd();
 
     // Get all entires in this day (no chunk, no overlap)
     TogglTimeEntryView *first_entry = nullptr;
-    time_t start_day = datetime.timestamp().epochTime();
+    time_t start_day = datetime.timestamp().epochTime() - tzd;
     time_t end_day = start_day + 86400; // one day
     for (unsigned int i = 0; i < entries_list.size(); i++) {
         view::TimeEntry te = entries_list.at(i);
@@ -510,7 +511,7 @@ void GUI::DisplayTimeline(
     while (datetime.year() == TimelineDateAt().year()
             && datetime.month() == TimelineDateAt().month()
             && datetime.day() == TimelineDateAt().day()) {
-        time_t epoch_time = datetime.timestamp().epochTime();
+        time_t epoch_time = datetime.timestamp().epochTime() - tzd;
         time_t epoch_time_end = epoch_time + 900;
 
         // Create new chunk

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -145,7 +145,7 @@ extension TimelineData {
             times.append(current)
             current += span
         }
-        return times.map { TimelineTimestamp($0) }
+        return times.map { TimelineTimestamp($0) }.dropLast() // don't render the last hour of next day
     }
 
     fileprivate func calculateColumnsPositionForTimeline() {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -69,7 +69,8 @@ final class TimelineTimeEntry: TimelineBaseTimeEntry {
         } else {
             self.color = TimeEntryViewItem.defaultProjectColor()
         }
-        super.init(start: timeEntry.started.timeIntervalSince1970,
-                   end: timeEntry.ended.timeIntervalSince1970)
+        let tzd = Double(TimeZone.current.secondsFromGMT())
+        super.init(start: timeEntry.started.timeIntervalSince1970 + tzd,
+                   end: timeEntry.ended.timeIntervalSince1970 + tzd)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -69,8 +69,7 @@ final class TimelineTimeEntry: TimelineBaseTimeEntry {
         } else {
             self.color = TimeEntryViewItem.defaultProjectColor()
         }
-        let tzd = Double(TimeZone.current.secondsFromGMT())
-        super.init(start: timeEntry.started.timeIntervalSince1970 + tzd,
-                   end: timeEntry.ended.timeIntervalSince1970 + tzd)
+        super.init(start: timeEntry.started.timeIntervalSince1970,
+                   end: timeEntry.ended.timeIntervalSince1970)
     }
 }

--- a/src/ui/osx/TogglDesktop/test2/Date+Extension.swift
+++ b/src/ui/osx/TogglDesktop/test2/Date+Extension.swift
@@ -13,7 +13,7 @@ extension Date {
     static func startOfDay(from timestamp: TimeInterval) -> TimeInterval {
         let date = Date(timeIntervalSince1970: timestamp)
         var calendar = Calendar.current
-        calendar.timeZone = TimeZone(abbreviation: "UTC")!
+        calendar.timeZone = TimeZone.current
         return calendar.startOfDay(for: date).timeIntervalSince1970
     }
 }

--- a/src/ui/osx/TogglDesktop/test2/TimelineDisplayCommand.m
+++ b/src/ui/osx/TogglDesktop/test2/TimelineDisplayCommand.m
@@ -65,8 +65,7 @@
 	self = [super init];
 	if (self)
 	{
-        NSInteger tzd = [NSTimeZone localTimeZone].secondsFromGMT;
-		self.started = view->Started + tzd;
+		self.started = view->Started;
 		if (view->StartTimeString)
 		{
 			self.startedTimeString = [NSString stringWithUTF8String:view->StartTimeString];

--- a/src/ui/osx/TogglDesktop/test2/TimelineDisplayCommand.m
+++ b/src/ui/osx/TogglDesktop/test2/TimelineDisplayCommand.m
@@ -135,11 +135,10 @@
 			[activities addObject:activity];
 			_activity = _activity->Next;
 		}
-        NSInteger tzd = [NSTimeZone localTimeZone].secondsFromGMT;
 		self.open = open;
 		self.timelineDate = date;
-		self.start = startDay - tzd;
-		self.end = endDay - tzd;
+		self.start = startDay;
+		self.end = endDay;
 		self.timeEntries = [[timeEntries reverseObjectEnumerator] allObjects];
 		self.activities = [[activities reverseObjectEnumerator] allObjects];
 	}

--- a/src/ui/osx/TogglDesktop/test2/TimelineDisplayCommand.m
+++ b/src/ui/osx/TogglDesktop/test2/TimelineDisplayCommand.m
@@ -65,7 +65,8 @@
 	self = [super init];
 	if (self)
 	{
-		self.started = view->Started;
+        NSInteger tzd = [NSTimeZone localTimeZone].secondsFromGMT;
+		self.started = view->Started + tzd;
 		if (view->StartTimeString)
 		{
 			self.startedTimeString = [NSString stringWithUTF8String:view->StartTimeString];
@@ -134,11 +135,11 @@
 			[activities addObject:activity];
 			_activity = _activity->Next;
 		}
-
+        NSInteger tzd = [NSTimeZone localTimeZone].secondsFromGMT;
 		self.open = open;
 		self.timelineDate = date;
-		self.start = startDay;
-		self.end = endDay;
+		self.start = startDay - tzd;
+		self.end = endDay - tzd;
 		self.timeEntries = [[timeEntries reverseObjectEnumerator] allObjects];
 		self.activities = [[activities reverseObjectEnumerator] allObjects];
 	}


### PR DESCRIPTION
### 📒 Description
This PR will fix the timezone issues, which is described in #3635

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Fix the timezone in library when calculating the Start - End time in order to fetch the TimeEntry and Event properly
- Fix the timeline convert func in Timeline Flow Layout

### 👫 Relationships
Close #3635
Fix "Change the start Time of TE make it moves to yesterday" in https://github.com/toggl-open-source/toggldesktop/issues/3380#issuecomment-538887226

### 🔎 Review hints
- Reproduce the Steps in https://github.com/toggl-open-source/toggldesktop/issues/3635#issue-539525212 and make sure that it works
- Observe that the TimeEntry and Event date (start/end) should be rendered properly in the Timeline View
- Make sure the start of the current day is at 00 (current timezone)
- Make sure that we can see the TimeEntry & event from 00:00 -> current Timezone. In the latest build, they are vanished.

<img width="628" alt="Screen Shot 2019-12-18 at 15 09 24" src="https://user-images.githubusercontent.com/5878421/71069015-789e0400-21aa-11ea-974e-6f4f49701cb7.png">