### PR TITLE
Fix linux update notifications (linux)

### DIFF
--- a/dist/linux/debian/rules
+++ b/dist/linux/debian/rules
@@ -11,7 +11,7 @@ override_dh_shlibdeps:
 	export LD_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)/toggldesktop:$LD_LIBRARY_PATH dh_shlibdeps
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DTOGGL_VERSION=$(VERSION) -DTOGGL_PRODUCTION_BUILD=ON -DUSE_BUNDLED_LIBRARIES=ON -DCMAKE_INSTALL_RPATH="/usr/lib;/usr/lib/toggldesktop"
+	dh_auto_configure -- -DTOGGL_BUILD_TYPE="deb" -DTOGGL_VERSION=$(VERSION) -DTOGGL_PRODUCTION_BUILD=ON -DUSE_BUNDLED_LIBRARIES=ON -DCMAKE_INSTALL_RPATH="/usr/lib;/usr/lib/toggldesktop"
 
 override_dh_auto_install:
 	dh_auto_install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_CXX_FLAGS
 if(TOGGL_PRODUCTION_BUILD)
     add_definitions(
         -DAPP_ENVIRONMENT="production"
+        -DTOGGL_BUILD_TYPE="${TOGGL_BUILD_TYPE}"
         -DTOGGL_PRODUCTION_BUILD=1
     )
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,11 +3,11 @@ set(CMAKE_CXX_FLAGS
 )
 if(TOGGL_PRODUCTION_BUILD)
     add_definitions(
-        -DAPP_ENVIRONMENT="\\\"production\\\""
+        -DAPP_ENVIRONMENT="production"
         -DTOGGL_PRODUCTION_BUILD=1
     )
 else()
-    add_definitions(-DAPP_ENVIRONMENT="\\\"development\\\"")
+    add_definitions(-DAPP_ENVIRONMENT="development")
 endif()
 
 if(TOGGL_ALLOW_UPDATE_CHECK)

--- a/src/const.h
+++ b/src/const.h
@@ -3,6 +3,11 @@
 #ifndef SRC_CONST_H_
 #define SRC_CONST_H_
 
+// used later in the file
+#ifndef TOGGL_BUILD_TYPE
+#define TOGGL_BUILD_TYPE ""
+#endif
+
 #define kOneSecondInMicros 1000000
 
 #define kMaxTimeEntryDurationSeconds 3596400
@@ -19,7 +24,7 @@
 #define kBetaChannelPercentage 25
 #define kTimelineChunkSeconds 900
 #define kEnterpriseInstall false
-#define kDebianPackage false
+#define kDebianPackage (TOGGL_BUILD_TYPE == std::string("deb"))
 #define kTimelineUploadIntervalSeconds 60
 #define kTimelineUploadMaxBackoffSeconds (kTimelineUploadIntervalSeconds * 10)  // NOLINT
 #define kMaxFileSize 5242880  // 5MB

--- a/src/context.cc
+++ b/src/context.cc
@@ -1674,9 +1674,9 @@ error Context::fetchMessage(const bool periodic) {
 
 const std::string Context::linuxPlatformName() {
     if (kDebianPackage) {
-        return "deb64";
+        return "linux_deb64";
     }
-    return std::string("linux");
+    return std::string("linux_tar.gz");
 }
 
 const std::string Context::windowsPlatformName() {


### PR DESCRIPTION
### 📒 Description
This PR fixes how updates are handled in the Linux app. Due to the changes in the build process and JSON parsing, they stopped working. Handling this on the server side doesn't wouldn't help.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Updates are now actually offered in the Linux applications

### 🔎 Review hints
Build a production build of the Linux app with an older version than 7.4.528 (or 7.4.1102 for beta and dev) with update check enabled and observe if you get offered an update.
