### PR TITLE
Show the UI briefly before hiding it to start syncing data (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -107,10 +107,9 @@ int main(int argc, char *argv[]) try {
 
     a.w = w;
 
+    w->show();
     if (parser.isSet(forceOption)) {
-        w->hide();
-    } else {
-        w->show();
+        QTimer::singleShot(1, w, &MainWindowController::hide);
     }
     return a.exec();
 } catch (std::exception &e) {  // NOLINT


### PR DESCRIPTION
### 📒 Description
When used with the `-b` argument (run in the background), this PR makes the Linux app show the UI before hiding it basically immediately after. This starts background sync events properly so everything runs as expected.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- Linux: When started in the background, sync works properly now

### 👫 Relationships
Fixes #3437

### 🔎 Review hints
Check if using the `-b` argument works as expected and regular app functionality is retained. For more information consult the original issue.

