### PR TITLE
Change Duration setting enables by default

### DIFF
--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -1212,7 +1212,7 @@ error Migrations::migrateSettings() {
     err = db_->Migrate(
         "settings.keep_end_time_fixed",
         "ALTER TABLE settings "
-        "ADD COLUMN keep_end_time_fixed INTEGER NOT NULL DEFAULT 0;");
+        "ADD COLUMN keep_end_time_fixed INTEGER NOT NULL DEFAULT 1;");
     if (err != noError) {
         return err;
     }


### PR DESCRIPTION
### 📒 Description
When the user changes the start time in Time Entry Editor -> The user would expect that only the Start Time would be changed, not the End Time.

This PR will enable the "Change duration when changing the start time" in Preference by default because it's natural action.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Set default ON in keep_end_time_fixed for new users

### 👫 Relationships
Closes #3472

### 🔎 Review hints
- This setting should be enabled by default for news users
