### PR TITLE
Remove old logic and make it focus on Description Editor by default (…

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -54,11 +54,7 @@ final class EditorViewController: NSViewController {
         didSet {
             fillData(oldValue)
             registerUndoForAllFields()
-
-            // Check if the Editor has update with new TimeEntry -> Reset focus to Description TextField
-            // If not, just keep focus on current textfield
-            let defaultFocus = checkShouldFocusByDefault(for: oldValue, newValue: timeEntry)
-            setFocusOnTextField(shouldFocusByDefault: defaultFocus)
+            setFocusOnTextField()
         }
     }
     private var selectedProjectItem: ProjectContentItem?
@@ -446,7 +442,7 @@ extension EditorViewController {
         return oldValueGuid != newValueGuid
     }
 
-    fileprivate func setFocusOnTextField(shouldFocusByDefault: Bool) {
+    fileprivate func setFocusOnTextField() {
         guard let timeEntry = timeEntry,
             let focusedFieldName = timeEntry.focusedFieldName else { return }
 
@@ -464,9 +460,7 @@ extension EditorViewController {
                 view.window?.makeFirstResponder(firstTag.actionButton)
             }
         default:
-            if shouldFocusByDefault {
-                view.window?.makeFirstResponder(descriptionTextField)
-            }
+            view.window?.makeFirstResponder(descriptionTextField)
         }
     }
 }


### PR DESCRIPTION
### 📒 Description
This PR would improve the logic to focus on Description whenever we open Time Entry Editor.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Remove old focus code
- [x] Make sure it focus on the Description whenever the Editor open

### 👫 Relationships
Closes #3234

### 🔎 Review hints
### The editor focus on description if we create TimeEntry from Idle Notification
1. Set Idle detection as 1 minutes
2. Start any TE and keep idle for 1 min to make sure the Idle notification appears
3. Select "Add Idle time as a new Time Entry"
4. New TE is running and the Editor is opening 
5. Make sure the description is focus, so the user could start typing without "Click to focus"

