### PR TITLE
Modernize Running Process APIs 

### DIFF
--- a/src/get_focused_window_mac.cc
+++ b/src/get_focused_window_mac.cc
@@ -7,85 +7,14 @@
 
 #include "get_focused_window.h"
 
-static const int kTitleBufferSize = 255;
-static const int kFilenameBufferSize = 255;
+#if defined(__APPLE__)
+int macOSGetActiveWindowInfo(std::string *title, std::string *filename);
+#endif
 
 int getFocusedWindowInfo(
     std::string *title,
     std::string *filename,
     bool *idle) {
-    *title = "";
-    *filename = "";
     *idle = false;
-
-    // get pid
-    ProcessSerialNumber front_process_serial_number;
-    OSStatus err = GetFrontProcess(&front_process_serial_number);
-    if (err) {
-        return err;
-    }
-
-    // window title
-    CFArrayRef windows = CGWindowListCopyWindowInfo(
-        kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
-    for (int i = 0; i < CFArrayGetCount(windows); i++) {
-        CFDictionaryRef dict = (CFDictionaryRef)CFArrayGetValueAtIndex(
-            windows, i);
-
-        CFNumberRef window_layer = (CFNumberRef)CFDictionaryGetValue(
-            dict, kCGWindowLayer);
-        int window_layer_int;
-        CFNumberGetValue(window_layer, kCFNumberIntType, &window_layer_int);
-
-        if (window_layer_int != 0) {
-            continue;
-        }
-
-        CFNumberRef window_owner_pid = (CFNumberRef)CFDictionaryGetValue(
-            dict, kCGWindowOwnerPID);
-        int window_owner_pid_int;
-        CFNumberGetValue(window_owner_pid, kCFNumberIntType,
-                         &window_owner_pid_int);
-
-        ProcessSerialNumber owner_serial_number;
-        GetProcessForPID(window_owner_pid_int, &owner_serial_number);
-
-        Boolean are_same;
-        OSStatus err = SameProcess(
-            &front_process_serial_number, &owner_serial_number, &are_same);
-        if (err) {
-            continue;
-        }
-
-        if (TRUE == are_same) {
-            CFStringRef window_name = (CFStringRef)CFDictionaryGetValue(
-                dict, kCGWindowName);
-            if (window_name) {
-                char title_buffer[kTitleBufferSize];
-                CFStringGetCString(window_name, title_buffer,
-                                   kTitleBufferSize, kCFStringEncodingUTF8);
-                *title = std::string(title_buffer);
-                // If the title we got is emtpy, keep looking.
-                // This is needed to get the actual tab title.
-                if (!title->empty()) {
-                    break;
-                }
-            }
-        }
-    }
-    CFRelease(windows);
-
-    // get application filename
-    CFStringRef processName = NULL;
-    err = CopyProcessName(&front_process_serial_number, &processName);
-    if (err) {
-        return err;
-    }
-    char filename_buffer[kFilenameBufferSize];
-    CFStringGetCString(processName, filename_buffer,
-                       kFilenameBufferSize, kCFStringEncodingUTF8);
-    CFRelease(processName);
-    *filename = std::string(filename_buffer);
-
-    return 0;
+    return macOSGetActiveWindowInfo(title, filename);
 }

--- a/src/lib/osx/Kopsik/MacOSApplicationInfo.mm
+++ b/src/lib/osx/Kopsik/MacOSApplicationInfo.mm
@@ -1,0 +1,111 @@
+//
+//  MacOSApplicationInfo.m
+//  TogglDesktopLibrary
+//
+//  Created by Nghia Tran on 12/23/19.
+//  Copyright © 2019 Toggl. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSProcessInfo.h>
+#import <AppKit/AppKit.h>
+#include <string.h>
+#include <iostream>
+
+static const int kTitleBufferSize = 255;
+static const int kFilenameBufferSize = 255;
+
+int macOSGetWindowInfo(
+    std::string *title,
+    std::string *filename,
+    bool *idle) {
+    *title = "";
+    *filename = "";
+    *idle = false;
+
+    // get pid
+    NSRunningApplication *frontApp;
+    NSArray<NSRunningApplication *> *runningApps = [[NSWorkspace sharedWorkspace] runningApplications];
+    for (NSRunningApplication *app in runningApps) {
+        if (app.isActive) {
+            frontApp = app;
+            break;
+        }
+    }
+
+    if (frontApp == nil) {
+        return -1;
+    }
+
+    // window title
+    CFArrayRef windows = CGWindowListCopyWindowInfo(
+        kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+    for (int i = 0; i < CFArrayGetCount(windows); i++) {
+        CFDictionaryRef dict = (CFDictionaryRef)CFArrayGetValueAtIndex(
+            windows, i);
+
+        CFNumberRef window_layer = (CFNumberRef)CFDictionaryGetValue(
+            dict, kCGWindowLayer);
+        int window_layer_int;
+        CFNumberGetValue(window_layer, kCFNumberIntType, &window_layer_int);
+
+        if (window_layer_int != 0) {
+            continue;
+        }
+
+        CFNumberRef window_owner_pid = (CFNumberRef)CFDictionaryGetValue(
+            dict, kCGWindowOwnerPID);
+        int window_owner_pid_int;
+        CFNumberGetValue(window_owner_pid, kCFNumberIntType,
+                         &window_owner_pid_int);
+
+        ProcessSerialNumber owner_serial_number;
+        GetProcessForPID(window_owner_pid_int, &owner_serial_number);
+
+        Boolean are_same;
+        OSStatus err = SameProcess(
+            &front_process_serial_number, &owner_serial_number, &are_same);
+        if (err) {
+            continue;
+        }
+
+        NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:window_owner_pid_int];
+        if (app == nil) {
+            continue;
+        }
+        if ([app isEqual:frontApp]) {
+
+        }
+
+        if (TRUE == are_same) {
+            CFStringRef window_name = (CFStringRef)CFDictionaryGetValue(
+                dict, kCGWindowName);
+            if (window_name) {
+                char title_buffer[kTitleBufferSize];
+                CFStringGetCString(window_name, title_buffer,
+                                   kTitleBufferSize, kCFStringEncodingUTF8);
+                *title = std::string(title_buffer);
+                // If the title we got is emtpy, keep looking.
+                // This is needed to get the actual tab title.
+                if (!title->empty()) {
+                    break;
+                }
+            }
+        }
+    }
+    CFRelease(windows);
+
+    // get application filename
+    CFStringRef processName = NULL;
+    err = CopyProcessName(&front_process_serial_number, &processName);
+    if (err) {
+        return err;
+    }
+    char filename_buffer[kFilenameBufferSize];
+    CFStringGetCString(processName, filename_buffer,
+                       kFilenameBufferSize, kCFStringEncodingUTF8);
+    CFRelease(processName);
+    *filename = std::string(filename_buffer);
+
+    return 0;
+}

--- a/src/lib/osx/Kopsik/MacOSApplicationInfo.mm
+++ b/src/lib/osx/Kopsik/MacOSApplicationInfo.mm
@@ -6,8 +6,6 @@
 //  Copyright © 2019 Toggl. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import <Foundation/NSProcessInfo.h>
 #import <AppKit/AppKit.h>
 #include <string.h>
 #include <iostream>

--- a/src/lib/osx/Kopsik/MacOSApplicationInfo.mm
+++ b/src/lib/osx/Kopsik/MacOSApplicationInfo.mm
@@ -13,42 +13,47 @@
 #include <iostream>
 
 static const int kTitleBufferSize = 255;
-static const int kFilenameBufferSize = 255;
 
-int macOSGetWindowInfo(
-    std::string *title,
-    std::string *filename,
-    bool *idle) {
-    *title = "";
-    *filename = "";
-    *idle = false;
+@interface MacOSApplicationUtility : NSObject
 
-    // get pid
-    NSRunningApplication *frontApp;
++ (NSRunningApplication *) getFrontApplication;
+@end
+
+@implementation MacOSApplicationUtility
+
++ (NSRunningApplication *) getFrontApplication
+{
     NSArray<NSRunningApplication *> *runningApps = [[NSWorkspace sharedWorkspace] runningApplications];
     for (NSRunningApplication *app in runningApps) {
         if (app.isActive) {
-            frontApp = app;
-            break;
+            return app;
         }
     }
+    return nil;
+}
 
+@end
+
+int macOSGetActiveWindowInfo(std::string *title, std::string *filename) {
+    *title = "";
+    *filename = "";
+
+    // Get front app
+    NSRunningApplication *frontApp = [MacOSApplicationUtility getFrontApplication];
     if (frontApp == nil) {
         return -1;
     }
 
     // window title
-    CFArrayRef windows = CGWindowListCopyWindowInfo(
-        kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+    CFArrayRef windows = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
     for (int i = 0; i < CFArrayGetCount(windows); i++) {
         CFDictionaryRef dict = (CFDictionaryRef)CFArrayGetValueAtIndex(
             windows, i);
 
-        CFNumberRef window_layer = (CFNumberRef)CFDictionaryGetValue(
-            dict, kCGWindowLayer);
+        // Get window layer and skip the background
+        CFNumberRef window_layer = (CFNumberRef)CFDictionaryGetValue(dict, kCGWindowLayer);
         int window_layer_int;
         CFNumberGetValue(window_layer, kCFNumberIntType, &window_layer_int);
-
         if (window_layer_int != 0) {
             continue;
         }
@@ -59,27 +64,17 @@ int macOSGetWindowInfo(
         CFNumberGetValue(window_owner_pid, kCFNumberIntType,
                          &window_owner_pid_int);
 
-        ProcessSerialNumber owner_serial_number;
-        GetProcessForPID(window_owner_pid_int, &owner_serial_number);
-
-        Boolean are_same;
-        OSStatus err = SameProcess(
-            &front_process_serial_number, &owner_serial_number, &are_same);
-        if (err) {
-            continue;
-        }
-
+        // Get app with pid
         NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:window_owner_pid_int];
         if (app == nil) {
             continue;
         }
+
+        // Compare if it's the same process
+        // We don't compare pid, we use -isEqual
+        // Ref: https://developer.apple.com/documentation/appkit/nsrunningapplication/1526998-processidentifier
         if ([app isEqual:frontApp]) {
-
-        }
-
-        if (TRUE == are_same) {
-            CFStringRef window_name = (CFStringRef)CFDictionaryGetValue(
-                dict, kCGWindowName);
+            CFStringRef window_name = (CFStringRef)CFDictionaryGetValue(dict, kCGWindowName);
             if (window_name) {
                 char title_buffer[kTitleBufferSize];
                 CFStringGetCString(window_name, title_buffer,
@@ -96,16 +91,11 @@ int macOSGetWindowInfo(
     CFRelease(windows);
 
     // get application filename
-    CFStringRef processName = NULL;
-    err = CopyProcessName(&front_process_serial_number, &processName);
-    if (err) {
-        return err;
+    NSString *appName = frontApp.localizedName;
+    if (appName == nil) {
+        return -1;
     }
-    char filename_buffer[kFilenameBufferSize];
-    CFStringGetCString(processName, filename_buffer,
-                       kFilenameBufferSize, kCFStringEncodingUTF8);
-    CFRelease(processName);
-    *filename = std::string(filename_buffer);
+    *filename = std::string(appName.UTF8String);
 
     return 0;
 }

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		74F7CDDC18199FA300630BD0 /* window_change_recorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F7CDDA18199FA300630BD0 /* window_change_recorder.h */; };
 		B8470E4C2334C377000D88CE /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = B8470E4A2334C377000D88CE /* random.h */; };
 		B8470E4D2334C377000D88CE /* random.cc in Sources */ = {isa = PBXBuildFile; fileRef = B8470E4B2334C377000D88CE /* random.cc */; };
+		BA063C0123B0AF2F003A96FE /* MacOSApplicationInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = BA063BFF23B0AF2F003A96FE /* MacOSApplicationInfo.mm */; };
 		BA1AB53E235DEAD4000433AE /* MacOSVersionChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */; };
 		BA2DA11C21A6864D0027B7A5 /* rectangle.h in Headers */ = {isa = PBXBuildFile; fileRef = BA2DA11A21A6864D0027B7A5 /* rectangle.h */; };
 		BA2DA11D21A6864D0027B7A5 /* rectangle.cc in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11B21A6864D0027B7A5 /* rectangle.cc */; };
@@ -213,6 +214,7 @@
 		74F7CDDA18199FA300630BD0 /* window_change_recorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = window_change_recorder.h; path = ../../../window_change_recorder.h; sourceTree = "<group>"; };
 		B8470E4A2334C377000D88CE /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = random.h; path = ../../../random.h; sourceTree = "<group>"; };
 		B8470E4B2334C377000D88CE /* random.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = random.cc; path = ../../../random.cc; sourceTree = "<group>"; };
+		BA063BFF23B0AF2F003A96FE /* MacOSApplicationInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MacOSApplicationInfo.mm; sourceTree = "<group>"; };
 		BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MacOSVersionChecker.mm; sourceTree = "<group>"; };
 		BA2DA11A21A6864D0027B7A5 /* rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rectangle.h; path = ../../../rectangle.h; sourceTree = "<group>"; };
 		BA2DA11B21A6864D0027B7A5 /* rectangle.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rectangle.cc; path = ../../../rectangle.cc; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 				BA2DA11A21A6864D0027B7A5 /* rectangle.h */,
 				BA2DA11B21A6864D0027B7A5 /* rectangle.cc */,
 				BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */,
+				BA063BFF23B0AF2F003A96FE /* MacOSApplicationInfo.mm */,
 			);
 			name = lib;
 			path = Kopsik;
@@ -566,6 +569,7 @@
 				74B587C818BBC77E00E9F6CE /* task.cc in Sources */,
 				74CAAD20181860F7001B77BB /* timeline_uploader.cc in Sources */,
 				745E84F5194953A70065E49A /* gui.cc in Sources */,
+				BA063C0123B0AF2F003A96FE /* MacOSApplicationInfo.mm in Sources */,
 				7484A2AC18887BEE0025A88B /* toggl_api_private.cc in Sources */,
 				7426535E1BEAD91900F0944C /* help_article.cc in Sources */,
 				74DF24E51B414BD8000179AE /* timeline_event.cc in Sources */,

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		B8470E4C2334C377000D88CE /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = B8470E4A2334C377000D88CE /* random.h */; };
 		B8470E4D2334C377000D88CE /* random.cc in Sources */ = {isa = PBXBuildFile; fileRef = B8470E4B2334C377000D88CE /* random.cc */; };
 		BA063C0123B0AF2F003A96FE /* MacOSApplicationInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = BA063BFF23B0AF2F003A96FE /* MacOSApplicationInfo.mm */; };
+		BA063C0423B0B761003A96FE /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA063C0323B0B761003A96FE /* AppKit.framework */; };
 		BA1AB53E235DEAD4000433AE /* MacOSVersionChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */; };
 		BA2DA11C21A6864D0027B7A5 /* rectangle.h in Headers */ = {isa = PBXBuildFile; fileRef = BA2DA11A21A6864D0027B7A5 /* rectangle.h */; };
 		BA2DA11D21A6864D0027B7A5 /* rectangle.cc in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11B21A6864D0027B7A5 /* rectangle.cc */; };
@@ -215,6 +216,7 @@
 		B8470E4A2334C377000D88CE /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = random.h; path = ../../../random.h; sourceTree = "<group>"; };
 		B8470E4B2334C377000D88CE /* random.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = random.cc; path = ../../../random.cc; sourceTree = "<group>"; };
 		BA063BFF23B0AF2F003A96FE /* MacOSApplicationInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MacOSApplicationInfo.mm; sourceTree = "<group>"; };
+		BA063C0323B0B761003A96FE /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MacOSVersionChecker.mm; sourceTree = "<group>"; };
 		BA2DA11A21A6864D0027B7A5 /* rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rectangle.h; path = ../../../rectangle.h; sourceTree = "<group>"; };
 		BA2DA11B21A6864D0027B7A5 /* rectangle.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rectangle.cc; path = ../../../rectangle.cc; sourceTree = "<group>"; };
@@ -270,6 +272,9 @@
 				BAA842322403DAE000BCCB67 /* libssl.1.1.dylib in Frameworks */,
 				BA43B33523F680B00007DD99 /* libPocoUtil.60.dylib in Frameworks */,
 				BA43B33123F680B00007DD99 /* libPocoNet.60.dylib in Frameworks */,
+				BA063C0423B0B761003A96FE /* AppKit.framework in Frameworks */,
+				C5DA1F9317F18CBB001C4565 /* libcrypto.a in Frameworks */,
+				C5DA1F9117F18CB6001C4565 /* libssl.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -279,6 +284,7 @@
 		BAD233D921D60A4D0039C742 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BA063C0323B0B761003A96FE /* AppKit.framework */,
 				BAD233DE21D60A4D0039C742 /* libPocoCrypto.dylib */,
 				BA43B34F23F681D60007DD99 /* liblua.a */,
 				BAA8422E2403DAE000BCCB67 /* libcrypto.1.1.dylib */,


### PR DESCRIPTION
### 📒 Description
This PR modernize some deprecated APIs to fetch the running Process, Title and Running process for a Timeline Recording feature.

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Introduce MacOSApplicationInfo.mm (obj-c++) for calling some objc code
- [x] Replace deprecated APIs with the new one

### 👫 Relationships
Closes #2690

### 🔎 Review hints
#### Able to get the Title and Filename if ScreenRecording is granted (Catalina)
1. Enable Timeline Recording in Preference
2. Grant Screen Recording Permission in Security
3. Play around and check whether it's able to get the Title name + FileName of other apps

<img width="1104" alt="Screen Shot 2019-12-23 at 15 55 24" src="https://user-images.githubusercontent.com/5878421/71348304-d792bd00-259e-11ea-891a-14d114ad2ff3.png">

#### Able to get the Title if ScreenRecording is granted (Catalina)
1. Enable Timeline Recording in Preference
2. Don't grant Screen Recording Permission in Security
3. Play around and check whether it's able to get the Title name of other apps.
4. Make sure Filename is the same with Title Name
<img width="1125" alt="Screen Shot 2019-12-23 at 15 57 52" src="https://user-images.githubusercontent.com/5878421/71348352-f7c27c00-259e-11ea-8c5b-31484fff515f.png">

#### Work well in 10.14
1. Play around the app in 10.14 or older OS X
2. Make sure the app is able to get the Title + Filename as usual (No need grant permission)
