### PR TITLE
Update Description, Project and Tag in one func

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -3171,10 +3171,10 @@ error Context::SetTimeEntryProject(
 }
 
 error Context::updateTimeEntryProject(
-                                      TimeEntry *te,
-                                      const Poco::UInt64 task_id,
-                                      const Poco::UInt64 project_id,
-                                      const std::string &project_guid) {
+    TimeEntry *te,
+    const Poco::UInt64 task_id,
+    const Poco::UInt64 project_id,
+    const std::string &project_guid) {
     Project *p = nullptr;
     if (project_id) {
         p = user_->related.ProjectByID(project_id);
@@ -3185,7 +3185,7 @@ error Context::updateTimeEntryProject(
 
     if (p && !canChangeProjectTo(te, p)) {
         return displayError(error(
-                                  "Cannot change project: would end up with locked time entry"));
+            "Cannot change project: would end up with locked time entry"));
     }
 
     if (p) {
@@ -3193,7 +3193,7 @@ error Context::updateTimeEntryProject(
         // flag any more. (User selected billable project, unchecked
         // billable, // then selected the same project again).
         if (p->ID() != te->PID()
-            || (!project_guid.empty() && p->GUID().compare(te->ProjectGUID()) != 0)) {
+                || (!project_guid.empty() && p->GUID().compare(te->ProjectGUID()) != 0)) {
             te->SetBillable(p->Billable());
         }
         te->SetWID(p->WID());
@@ -3490,8 +3490,8 @@ error Context::SetTimeEntryTags(
 }
 
 void Context::updateTimeEntryTags(
-                                   TimeEntry *te,
-                                   const std::string &value) {
+    TimeEntry *te,
+    const std::string &value) {
     te->SetTags(value);
 }
 
@@ -3533,8 +3533,8 @@ error Context::SetTimeEntryBillable(
 }
 
 void Context::updateTimeEntryBillable(
-                                      TimeEntry *te,
-                                      const bool value) {
+    TimeEntry *te,
+    const bool value) {
     te->SetBillable(value);
 }
 
@@ -3573,8 +3573,8 @@ error Context::SetTimeEntryDescription(
 }
 
 error Context::updateTimeEntryDescription(
-                                          TimeEntry *te,
-                                          const std::string &value) {
+    TimeEntry *te,
+    const std::string &value) {
     // Validate description length
     if (value.length() > kMaximumDescriptionLength) {
         return displayError(error(kMaximumDescriptionLengthError));
@@ -6189,13 +6189,13 @@ void Context::TrackExpandAllDays() {
 }
 
 error Context::updateTimeEntry(
-                      const std::string &GUID,
-                      const std::string &description,
-                      const Poco::UInt64 task_id,
-                      const Poco::UInt64 project_id,
-                      const std::string &project_guid,
-                      const std::string &tags,
-                    const bool billable) {
+    const std::string &GUID,
+    const std::string &description,
+    const Poco::UInt64 task_id,
+    const Poco::UInt64 project_id,
+    const std::string &project_guid,
+    const std::string &tags,
+    const bool billable) {
 
     if (GUID.empty()) {
         return displayError(std::string(__FUNCTION__) + ": Missing GUID");

--- a/src/context.cc
+++ b/src/context.cc
@@ -3134,7 +3134,8 @@ error Context::SetTimeEntryProject(
     const std::string &GUID,
     const Poco::UInt64 task_id,
     const Poco::UInt64 project_id,
-    const std::string &project_guid) {
+    const std::string &project_guid,
+    const bool_t update_ui) {
     try {
         if (GUID.empty()) {
             return displayError(std::string(__FUNCTION__) + ": Missing GUID");

--- a/src/context.cc
+++ b/src/context.cc
@@ -3160,6 +3160,10 @@ error Context::SetTimeEntryProject(
         if (err != noError) {
             return err;
         }
+        if (te->Dirty()) {
+            te->ClearValidationError();
+            te->SetUIModified();
+        }
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {
@@ -3201,11 +3205,6 @@ error Context::updateTimeEntryProject(
     te->SetTID(task_id);
     te->SetPID(project_id);
     te->SetProjectGUID(project_guid);
-
-    if (te->Dirty()) {
-        te->ClearValidationError();
-        te->SetUIModified();
-    }
     return noError;
 }
 
@@ -3478,7 +3477,7 @@ error Context::SetTimeEntryTags(
             return logAndDisplayUserTriedEditingLockedEntry();
         }
 
-        updateTimeEntryTags(te, value);
+        te->SetTags(value);
     }
 
     if (te->Dirty()) {
@@ -3487,12 +3486,6 @@ error Context::SetTimeEntryTags(
     }
 
     return displayError(save(true));
-}
-
-void Context::updateTimeEntryTags(
-    TimeEntry *te,
-    const std::string &value) {
-    te->SetTags(value);
 }
 
 error Context::SetTimeEntryBillable(
@@ -3521,7 +3514,7 @@ error Context::SetTimeEntryBillable(
             return logAndDisplayUserTriedEditingLockedEntry();
         }
 
-        updateTimeEntryBillable(te, value);
+        te->SetBillable(value);
     }
 
     if (te->Dirty()) {
@@ -3530,12 +3523,6 @@ error Context::SetTimeEntryBillable(
     }
 
     return displayError(save(true));
-}
-
-void Context::updateTimeEntryBillable(
-    TimeEntry *te,
-    const bool value) {
-    te->SetBillable(value);
 }
 
 error Context::SetTimeEntryDescription(
@@ -3568,6 +3555,11 @@ error Context::SetTimeEntryDescription(
         if (err != noError) {
             return err;
         }
+
+        if (te->Dirty()) {
+            te->ClearValidationError();
+            te->SetUIModified();
+        }
     }
     return displayError(save(true));
 }
@@ -3581,11 +3573,6 @@ error Context::updateTimeEntryDescription(
     }
 
     te->SetDescription(value);
-
-    if (te->Dirty()) {
-        te->ClearValidationError();
-        te->SetUIModified();
-    }
     return noError;
 }
 
@@ -6226,8 +6213,10 @@ error Context::updateTimeEntry(
     if (err != noError) {
         return err;
     }
-    updateTimeEntryTags(te, tags);
-    updateTimeEntryBillable(te, billable);
+
+    // Tag + billable
+    te->SetTags(tags);
+    te->SetBillable(billable);
 
     if (te->Dirty()) {
         te->ClearValidationError();

--- a/src/context.cc
+++ b/src/context.cc
@@ -6175,7 +6175,7 @@ void Context::TrackExpandAllDays() {
     }
 }
 
-error Context::updateTimeEntry(
+error Context::UpdateTimeEntry(
     const std::string &GUID,
     const std::string &description,
     const Poco::UInt64 task_id,

--- a/src/context.h
+++ b/src/context.h
@@ -389,13 +389,13 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const std::string &project_guid);
 
     error updateTimeEntry(
-                          const std::string &GUID,
-                          const std::string &description,
-                          const Poco::UInt64 task_id,
-                          const Poco::UInt64 project_id,
-                          const std::string &project_guid,
-                          const std::string &tags,
-                          const bool billable);
+        const std::string &GUID,
+        const std::string &description,
+        const Poco::UInt64 task_id,
+        const Poco::UInt64 project_id,
+        const std::string &project_guid,
+        const std::string &tags,
+        const bool billable);
 
     error SetTimeEntryDate(
         const std::string &GUID,
@@ -826,21 +826,21 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     const bool handleStopRunningEntry();
 
     error updateTimeEntryProject(
-                                 TimeEntry *te,
-                                 const Poco::UInt64 task_id,
-                                 const Poco::UInt64 project_id,
-                                 const std::string &project_guid);
+        TimeEntry *te,
+        const Poco::UInt64 task_id,
+        const Poco::UInt64 project_id,
+        const std::string &project_guid);
 
     void updateTimeEntryTags(
-                              TimeEntry *te,
-                              const std::string &value);
+        TimeEntry *te,
+        const std::string &value);
 
     error updateTimeEntryDescription(
-                                     TimeEntry *te,
-                                     const std::string &value);
+        TimeEntry *te,
+        const std::string &value);
 
     void updateTimeEntryBillable(TimeEntry *te,
-                                  const bool value) ;
+                                 const bool value) ;
 };
 
 void on_websocket_message(

--- a/src/context.h
+++ b/src/context.h
@@ -388,7 +388,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const Poco::UInt64 project_id,
         const std::string &project_guid);
 
-    error updateTimeEntry(
+    error UpdateTimeEntry(
         const std::string &GUID,
         const std::string &description,
         const Poco::UInt64 task_id,

--- a/src/context.h
+++ b/src/context.h
@@ -394,7 +394,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
                           const Poco::UInt64 task_id,
                           const Poco::UInt64 project_id,
                           const std::string &project_guid,
-                          const std::string &tags);
+                          const std::string &tags,
+                          const bool billable);
 
     error SetTimeEntryDate(
         const std::string &GUID,
@@ -830,15 +831,16 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
                                  const Poco::UInt64 project_id,
                                  const std::string &project_guid);
 
-    error updateTimeEntryTags(
+    void updateTimeEntryTags(
                               TimeEntry *te,
-                              const std::string &GUID,
                               const std::string &value);
 
     error updateTimeEntryDescription(
                                      TimeEntry *te,
-                                     const std::string &GUID,
                                      const std::string &value);
+
+    void updateTimeEntryBillable(TimeEntry *te,
+                                  const bool value) ;
 };
 
 void on_websocket_message(

--- a/src/context.h
+++ b/src/context.h
@@ -831,16 +831,9 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const Poco::UInt64 project_id,
         const std::string &project_guid);
 
-    void updateTimeEntryTags(
-        TimeEntry *te,
-        const std::string &value);
-
     error updateTimeEntryDescription(
         TimeEntry *te,
         const std::string &value);
-
-    void updateTimeEntryBillable(TimeEntry *te,
-                                 const bool value) ;
 };
 
 void on_websocket_message(

--- a/src/context.h
+++ b/src/context.h
@@ -386,8 +386,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const std::string &GUID,
         const Poco::UInt64 task_id,
         const Poco::UInt64 project_id,
-        const std::string &project_guid,
-        const bool_t update_ui = true);
+        const std::string &project_guid);
 
     error SetTimeEntryDate(
         const std::string &GUID,
@@ -816,6 +815,22 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     std::string last_message_id_;
 
     const bool handleStopRunningEntry();
+
+    error updateTimeEntryProject(
+                                 TimeEntry *te,
+                                 const Poco::UInt64 task_id,
+                                 const Poco::UInt64 project_id,
+                                 const std::string &project_guid);
+
+    error updateTimeEntryTags(
+                              TimeEntry *te,
+                              const std::string &GUID,
+                              const std::string &value);
+
+    error updateTimeEntryDescription(
+                                     TimeEntry *te,
+                                     const std::string &GUID,
+                                     const std::string &value);
 };
 
 void on_websocket_message(

--- a/src/context.h
+++ b/src/context.h
@@ -386,7 +386,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const std::string &GUID,
         const Poco::UInt64 task_id,
         const Poco::UInt64 project_id,
-        const std::string &project_guid);
+        const std::string &project_guid,
+        const bool_t update_ui = true);
 
     error SetTimeEntryDate(
         const std::string &GUID,

--- a/src/context.h
+++ b/src/context.h
@@ -388,6 +388,14 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const Poco::UInt64 project_id,
         const std::string &project_guid);
 
+    error updateTimeEntry(
+                          const std::string &GUID,
+                          const std::string &description,
+                          const Poco::UInt64 task_id,
+                          const Poco::UInt64 project_id,
+                          const std::string &project_guid,
+                          const std::string &tags);
+
     error SetTimeEntryDate(
         const std::string &GUID,
         const Poco::Int64 unix_timestamp);

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1545,7 +1545,7 @@ void track_expand_all_days(void *context) {
     app(context)->TrackExpandAllDays();
 }
 
-bool_t toggl_set_time_entry(
+bool_t toggl_update_time_entry(
     void *context,
     const char_t *guid,
     const char_t *description,

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1553,7 +1553,7 @@ bool_t toggl_set_time_entry(
     const uint64_t project_id,
     const char_t *project_guid,
     const char_t *tags) {
-    if (app(context)->SetTimeEntryProject(to_string(guid), task_id, project_id, to_string(project_guid), false) != toggl::noError) {
+    if (app(context)->SetTimeEntryProject(to_string(guid), task_id, project_id, to_string(project_guid)) != toggl::noError) {
         return false;
     }
     if (app(context)->SetTimeEntryTags(to_string(guid), to_string(tags)) != toggl::noError) {

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1544,3 +1544,20 @@ void track_expand_all_days(void *context) {
     }
     app(context)->TrackExpandAllDays();
 }
+
+bool_t toggl_set_time_entry(
+    void *context,
+    const char_t *guid,
+    const char_t *description,
+    const uint64_t task_id,
+    const uint64_t project_id,
+    const char_t *project_guid,
+    const char_t *tags) {
+    if (app(context)->SetTimeEntryProject(to_string(guid), task_id, project_id, to_string(project_guid), false) != toggl::noError) {
+        return false;
+    }
+    if (app(context)->SetTimeEntryTags(to_string(guid), to_string(tags)) != toggl::noError) {
+        return false;
+    }
+    return toggl::noError == app(context)->SetTimeEntryDescription(to_string(guid), to_string(description));
+}

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1552,7 +1552,8 @@ bool_t toggl_set_time_entry(
     const uint64_t task_id,
     const uint64_t project_id,
     const char_t *project_guid,
-    const char_t *tags) {
+    const char_t *tags,
+    const bool_t billable) {
 
     std::string _guid("");
     if (guid) {
@@ -1574,5 +1575,5 @@ bool_t toggl_set_time_entry(
         _tags = to_string(tags);
     }
 
-    return toggl::noError == app(context)->updateTimeEntry(_guid, _description, task_id, project_id, _project_guid, _tags);
+    return toggl::noError == app(context)->updateTimeEntry(_guid, _description, task_id, project_id, _project_guid, _tags, billable);
 }

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1575,5 +1575,5 @@ bool_t toggl_update_time_entry(
         _tags = to_string(tags);
     }
 
-    return toggl::noError == app(context)->updateTimeEntry(_guid, _description, task_id, project_id, _project_guid, _tags, billable);
+    return toggl::noError == app(context)->UpdateTimeEntry(_guid, _description, task_id, project_id, _project_guid, _tags, billable);
 }

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1553,11 +1553,26 @@ bool_t toggl_set_time_entry(
     const uint64_t project_id,
     const char_t *project_guid,
     const char_t *tags) {
-    if (app(context)->SetTimeEntryProject(to_string(guid), task_id, project_id, to_string(project_guid)) != toggl::noError) {
-        return false;
+
+    std::string _guid("");
+    if (guid) {
+        _guid = to_string(guid);
     }
-    if (app(context)->SetTimeEntryTags(to_string(guid), to_string(tags)) != toggl::noError) {
-        return false;
+
+    std::string _description("");
+    if (description) {
+        _description = to_string(description);
     }
-    return toggl::noError == app(context)->SetTimeEntryDescription(to_string(guid), to_string(description));
+
+    std::string _project_guid("");
+    if (project_guid) {
+        _project_guid = to_string(project_guid);
+    }
+
+    std::string _tags("");
+    if (tags) {
+        _tags = to_string(tags);
+    }
+
+    return toggl::noError == app(context)->updateTimeEntry(_guid, _description, task_id, project_id, _project_guid, _tags);
 }

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1185,7 +1185,8 @@ extern "C" {
         const uint64_t task_id,
         const uint64_t project_id,
         const char_t *project_guid,
-        const char_t *tags);
+        const char_t *tags,
+        const bool_t billable);
 
 #undef TOGGL_EXPORT
 

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1178,7 +1178,7 @@ extern "C" {
     TOGGL_EXPORT void track_expand_all_days(
         void *context);
 
-    TOGGL_EXPORT bool_t toggl_set_time_entry(
+    TOGGL_EXPORT bool_t toggl_update_time_entry(
         void *context,
         const char_t *guid,
         const char_t *description,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1178,6 +1178,15 @@ extern "C" {
     TOGGL_EXPORT void track_expand_all_days(
         void *context);
 
+    TOGGL_EXPORT bool_t toggl_set_time_entry(
+        void *context,
+        const char_t *guid,
+        const char_t *description,
+        const uint64_t task_id,
+        const uint64_t project_id,
+        const char_t *project_guid,
+        const char_t *tags);
+
 #undef TOGGL_EXPORT
 
 #ifdef __cplusplus

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -193,14 +193,14 @@ void *ctx;
 - (void)updateDescriptionForTimeEntry:(TimeEntryViewItem *)timeEntry autocomplete:(AutocompleteItem *)autocomplete
 {
     const char *tags = [[autocomplete.tags componentsJoinedByString:@"\t"] UTF8String];
-    toggl_set_time_entry(ctx,
+    toggl_update_time_entry(ctx,
                          [timeEntry.GUID UTF8String],
                          [autocomplete.Description UTF8String],
                          autocomplete.TaskID,
                          autocomplete.ProjectID,
                          0,
                          tags,
-                         timeEntry.billable);
+                         autocomplete.Billable);
 }
 
 - (NSString *)convertDuratonInSecond:(int64_t)durationInSecond

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -192,15 +192,14 @@ void *ctx;
 
 - (void)updateDescriptionForTimeEntry:(TimeEntryViewItem *)timeEntry autocomplete:(AutocompleteItem *)autocomplete
 {
-	toggl_set_time_entry_project(ctx,
-								 [timeEntry.GUID UTF8String],
-								 autocomplete.TaskID,
-								 autocomplete.ProjectID,
-								 0);
-	toggl_set_time_entry_description(ctx,
-									 [timeEntry.GUID UTF8String],
-									 [autocomplete.Description UTF8String]);
-	[self updateTimeEntryWithTags:autocomplete.tags guid:timeEntry.GUID];
+    const char *tags = [[autocomplete.tags componentsJoinedByString:@"\t"] UTF8String];
+    toggl_set_time_entry(ctx,
+                         [timeEntry.GUID UTF8String],
+                         [autocomplete.Description UTF8String],
+                         autocomplete.TaskID,
+                         autocomplete.ProjectID,
+                         0,
+                         tags);
 }
 
 - (NSString *)convertDuratonInSecond:(int64_t)durationInSecond

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -199,7 +199,8 @@ void *ctx;
                          autocomplete.TaskID,
                          autocomplete.ProjectID,
                          0,
-                         tags);
+                         tags,
+                         timeEntry.billable);
 }
 
 - (NSString *)convertDuratonInSecond:(int64_t)durationInSecond

--- a/src/websocket_client.h
+++ b/src/websocket_client.h
@@ -14,12 +14,12 @@
 #include "util/logger.h"
 
 namespace Poco {
-    namespace Net {
-        class HTTPClientSession;
-        class HTTPRequest;
-        class HTTPResponse;
-        class WebSocket;
-    } // namespace Poco::Net
+namespace Net {
+class HTTPClientSession;
+class HTTPRequest;
+class HTTPResponse;
+class WebSocket;
+} // namespace Poco::Net
 } // namespace Poco
 
 namespace toggl {


### PR DESCRIPTION
### 📒 Description
This PR improves how we update the TE from TimeEntryAutoComplete by reducing some unnecessary UI Update from the library from 4 -> 2 times:
- 1 call is for updating the UI from AutoComplete Item
- 1 call is from the Syncer

### 🕶️ Types of changes
 **New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
- [x] Introduce update_ui in save func to only update the UI if need
- [x] Add 1 func to update TE from autocomplete item (Description, project, task, tags)
- [x] Use this func to update on mac build

### 👫 Relationships
- macOS part of [Library] Update Description, Project and Tag in one func #3244

### 🔎 Review hints
#### All Features are remains
- Play around and make sure we're able to update the TE as usual

#### There are only 2 UI Updates from Library
1. Open Editor, and search some TE in Description Text Field
2. Select any TE AutoComplete Item in Description
3. Observer that there are only 2 UI Update from the library by looking at the Console
```
❌ TimeEntryListViewController displayTimeEntryList
```

