### PR TITLE
Trigger permission in Switcher and MenuBar (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Permission/SystemPermissionManager.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Permission/SystemPermissionManager.swift
@@ -71,7 +71,7 @@ extension SystemPermissionManager {
     private func presentScreenRecordingAlert(_ complete: () -> Void) {
         let alert = NSAlert()
         alert.messageText = "Screen Recording permission not granted!"
-        alert.informativeText = "To get the Windows Name properly for the Timeline, TogglDesktop needs to be granted the Screen Recording permission in Security & Privacy in System Preferences .\n\nPlease open System Preferences -> Security & Privacy -> Privacy Tab -> Select Screen Recording and enable TogglDesktop app."
+        alert.informativeText = "To get the Focused application window name properly for the Timeline, TogglDesktop needs to be granted the Screen Recording permission in Security & Privacy in System Preferences .\n\nPlease open System Preferences -> Security & Privacy -> Privacy Tab -> Select Screen Recording and enable TogglDesktop app."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open")
         alert.addButton(withTitle: "Later")

--- a/src/ui/osx/TogglDesktop/Feature/Permission/SystemPermissionManager.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Permission/SystemPermissionManager.swift
@@ -71,7 +71,7 @@ extension SystemPermissionManager {
     private func presentScreenRecordingAlert(_ complete: () -> Void) {
         let alert = NSAlert()
         alert.messageText = "Screen Recording permission not granted!"
-        alert.informativeText = "To get the Focused application window name properly for the Timeline, TogglDesktop needs to be granted the Screen Recording permission in Security & Privacy in System Preferences .\n\nPlease open System Preferences -> Security & Privacy -> Privacy Tab -> Select Screen Recording and enable TogglDesktop app."
+        alert.informativeText = "To get the focused application window name properly for the Timeline, TogglDesktop needs to be granted the Screen Recording permission in Security & Privacy in System Preferences .\n\nPlease open System Preferences -> Security & Privacy -> Privacy Tab -> Select Screen Recording and enable TogglDesktop app."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open")
         alert.addButton(withTitle: "Later")

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -12,6 +12,7 @@
 #import "AutocompleteItem.h"
 #import "Utils.h"
 #import "UIEvents.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation DesktopLibraryBridge
 
@@ -201,6 +202,12 @@ void *ctx;
 - (void)enableTimelineRecord:(BOOL)isEnabled
 {
 	toggl_timeline_toggle_recording(ctx, isEnabled);
+
+    // Try to grant permission
+    if (isEnabled)
+    {
+        [ObjcSystemPermissionManager tryGrantScreenRecordingPermission];
+    }
 }
 
 - (void)timelineSetPreviousDate

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -15,6 +15,7 @@
 #import "NSCustomComboBox.h"
 #import <MASShortcut/Shortcut.h>
 #import "TogglDesktop-Swift.h"
+#import "DesktopLibraryBridge.h"
 
 NSString *const kPreferenceGlobalShortcutShowHide = @"TogglDesktopGlobalShortcutShowHide";
 NSString *const kPreferenceGlobalShortcutStartStop = @"TogglDesktopGlobalShortcutStartStop";
@@ -356,14 +357,7 @@ const int kUseProxyToConnectToToggl = 2;
 - (IBAction)recordTimelineCheckboxChanged:(id)sender
 {
 	BOOL record_timeline = [Utils stateToBool:[self.recordTimelineCheckbox state]];
-
-	toggl_timeline_toggle_recording(ctx, record_timeline);
-
-	// Try to grant permission
-	if (record_timeline)
-	{
-		[ObjcSystemPermissionManager tryGrantScreenRecordingPermission];
-	}
+    [[DesktopLibraryBridge shared] enableTimelineRecord:record_timeline];
 }
 
 - (IBAction)menubarTimerCheckboxChanged:(id)sender

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1108,8 +1108,8 @@ void *ctx;
 
 - (IBAction)onToggleRecordTimeline:(id)sender
 {
-	toggl_timeline_toggle_recording(ctx,
-									!toggl_timeline_is_recording_enabled(ctx));
+    BOOL isEnabled = !toggl_timeline_is_recording_enabled(ctx);
+    [[DesktopLibraryBridge shared] enableTimelineRecord:isEnabled];
 }
 
 - (IBAction)onModeChange:(id)sender


### PR DESCRIPTION
### 📒 Description
This PR improves how we trigger the Screen Recording Permission in Timeline Switcher and Timeline menu Bar

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Trigger the permission if enabled via Menu Item or Switcher

### 👫 Relationships
Closes #3654

### 🔎 Review hints
#### Trigger permission alert when enabling in Switcher and Menu Bar
1. Make sure we disable the permission for Toggl Desktop in Privacy Preference
2. Try to enable the Timeline from Timeline Switcher and Timeline Record menu item
3. Make sure the Permission Alert is triggered and guide the user to enable it
4. Play around and observer if TogglDesktop is able to get the Window Name properly.

#### Don't trigger permission alert if the permission is already granted 
1. Grant permission properly
2. Enable Timeline via the Switcher and Menu Bar
3. Make sure there is no Permission alert 
4. Play around and observer if TogglDesktop is able to get the Window Name properly.
