### PR TITLE
Remove UPPERCASE of Workspace names 

### DIFF
--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -527,7 +527,7 @@ void RelatedData::workspaceAutocompleteItems(
             continue;
         }
 
-        std::string ws_name = Poco::UTF8::toUpper(ws->Name());
+        std::string ws_name = ws->Name();
         (*ws_names)[ws->ID()] = ws_name;
     }
 }

--- a/src/ui/linux/TogglDesktop/autocompleteview.h
+++ b/src/ui/linux/TogglDesktop/autocompleteview.h
@@ -49,7 +49,7 @@ class AutocompleteView : public QObject {
             view->TaskLabel = it->TaskLabel;
             view->ProjectID = it->ProjectID;
             view->WorkspaceID = it->WorkspaceID;
-            view->WorkspaceName = QString(it->WorkspaceName);
+            view->WorkspaceName = QString(it->WorkspaceName).toUpper();
             view->Type = it->Type;
             view->Billable = it->Billable;
             view->Tags = QString(it->Tags);

--- a/src/ui/osx/TogglDesktop/AutocompleteItem.m
+++ b/src/ui/osx/TogglDesktop/AutocompleteItem.m
@@ -77,7 +77,7 @@
 	}
 	if (data->WorkspaceName)
 	{
-		self.WorkspaceName = [NSString stringWithUTF8String:data->WorkspaceName];
+		self.WorkspaceName = [[NSString stringWithUTF8String:data->WorkspaceName] capitalizedString];
 	}
 	else
 	{

--- a/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
@@ -123,7 +123,7 @@
 	self.CanSeeBillable = te->CanSeeBillable;
 	if (te->WorkspaceName)
 	{
-		self.WorkspaceName = [NSString stringWithUTF8String:te->WorkspaceName];
+		self.WorkspaceName = [[NSString stringWithUTF8String:te->WorkspaceName] capitalizedString];
 	}
 	else
 	{

--- a/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/AutoCompleteController.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/AutoCompleteController.cs
@@ -118,7 +118,7 @@ namespace TogglDesktop.AutoCompletion
                         {
                             items.Add(new ListBoxItem()
                             {
-                                Text = it.Item.WorkspaceName,
+                                Text = it.Item.WorkspaceName.ToUpper(),
                                 Type = -3
                             });
                             lastWID = (int)it.Item.WorkspaceID;
@@ -187,7 +187,7 @@ namespace TogglDesktop.AutoCompletion
                             TaskLabel = taskLabel,
                             ClientLabel = clientLabel,
                             Type = (int)it.Item.Type,
-                            WorkspaceName = it.Item.WorkspaceName,
+                            WorkspaceName = it.Item.WorkspaceName.ToUpper(),
                             Index = count
                         });
                     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/ListBoxItem.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/ListBoxItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Globalization;
 
 namespace TogglDesktop.AutoCompletion
 {
@@ -16,7 +17,18 @@ namespace TogglDesktop.AutoCompletion
         public string TaskLabel { get; set; }
         public string ClientLabel { get; set; }
         public string Category { get; set; }
-        public string WorkspaceName { get; set; }
+        private string _workspaceName = "";
+        public string WorkspaceName
+        {
+            get
+            {
+                return this._workspaceName;
+            }
+            set
+            {
+                this._workspaceName = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
+            }
+        }
         public int Type { get; set; }
         public int Index { get; set; }
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/ListBoxItem.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/ListBoxItem.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Globalization;
-
-namespace TogglDesktop.AutoCompletion
+﻿namespace TogglDesktop.AutoCompletion
 {
     class ListBoxItem
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/ListBoxItem.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/ListBoxItem.cs
@@ -17,18 +17,7 @@ namespace TogglDesktop.AutoCompletion
         public string TaskLabel { get; set; }
         public string ClientLabel { get; set; }
         public string Category { get; set; }
-        private string _workspaceName = "";
-        public string WorkspaceName
-        {
-            get
-            {
-                return this._workspaceName;
-            }
-            set
-            {
-                this._workspaceName = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
-            }
-        }
+        public string WorkspaceName { get; set; }
         public int Type { get; set; }
         public int Index { get; set; }
     }


### PR DESCRIPTION
### 📒 Description
This PR will make sure the workspace name in library should be verbatim and let the UI to flexibly present it.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Remove Uppercase of workspace in auto-complete item
- [x] Capitalize the workspace in macOS (same design)
- [x] Windows
- [x] Linux

### 👫 Relationships
Closes #3555 

### 🔎 Review hints
- The workspace name in AutoComplete should not Uppercase. It should capitalize the first letter
- Same with Workspace label in the Editor

