### PR TITLE
Support Undo Deleted Time Entry

### DIFF
--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1485,3 +1485,22 @@ void toggl_iam_click(void *context,
     }
     app(context)->TrackInAppMessage(type);
 }
+
+char_t *toggl_create_time_entry(void *context,
+                                const char_t *description,
+                                const char_t *duration,
+                                const uint64_t task_id,
+                                const uint64_t project_id,
+                                const char_t *project_guid,
+                                const char_t *tags,
+                                const char_t *start_time,
+                                const char_t *end_time,
+                                const int64_t start_date) {
+    char_t *guid = toggl_start(context, description, duration, task_id, project_id, project_guid, tags, false);
+    if (guid) {
+        toggl_set_time_entry_date(context, guid, start_date);
+        toggl_set_time_entry_start(context, guid, start_time);
+        toggl_set_time_entry_end(context, guid, end_time);
+    }
+    return nullptr;
+}

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1485,23 +1485,3 @@ void toggl_iam_click(void *context,
     }
     app(context)->TrackInAppMessage(type);
 }
-
-char_t *toggl_create_time_entry(void *context,
-                                const char_t *description,
-                                const char_t *duration,
-                                const uint64_t task_id,
-                                const uint64_t project_id,
-                                const char_t *project_guid,
-                                const char_t *tags,
-                                const char_t *start_time,
-                                const char_t *end_time,
-                                const int64_t start_date) {
-    char_t *guid = toggl_start(context, description, duration, task_id, project_id, project_guid, tags, false);
-    if (guid) {
-        toggl_set_time_entry_date(context, guid, start_date);
-        toggl_set_time_entry_start(context, guid, start_time);
-        toggl_set_time_entry_end(context, guid, end_time);
-        return guid;
-    }
-    return nullptr;
-}

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1501,6 +1501,7 @@ char_t *toggl_create_time_entry(void *context,
         toggl_set_time_entry_date(context, guid, start_date);
         toggl_set_time_entry_start(context, guid, start_time);
         toggl_set_time_entry_end(context, guid, end_time);
+        return guid;
     }
     return nullptr;
 }

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1124,6 +1124,19 @@ extern "C" {
     TOGGL_EXPORT void toggl_iam_click(
         void *context,
         const uint64_t type);
+
+TOGGL_EXPORT char_t *toggl_create_time_entry(
+        void *context,
+        const char_t *description,
+        const char_t *duration,
+        const uint64_t task_id,
+        const uint64_t project_id,
+        const char_t *project_guid,
+        const char_t *tags,
+        const char_t *start_time,
+        const char_t *end_time,
+        const int64_t start_date);
+
 #undef TOGGL_EXPORT
 
 #ifdef __cplusplus

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1125,18 +1125,6 @@ extern "C" {
         void *context,
         const uint64_t type);
 
-TOGGL_EXPORT char_t *toggl_create_time_entry(
-        void *context,
-        const char_t *description,
-        const char_t *duration,
-        const uint64_t task_id,
-        const uint64_t project_id,
-        const char_t *project_guid,
-        const char_t *tags,
-        const char_t *start_time,
-        const char_t *end_time,
-        const int64_t start_date);
-
 #undef TOGGL_EXPORT
 
 #ifdef __cplusplus

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -260,7 +260,7 @@ extern void *ctx;
 {
 	for (TimeEntryCell *cell in cells)
 	{
-		toggl_delete_time_entry(ctx, [cell.GUID UTF8String]);
+        [[DesktopLibraryBridge shared] deleteTimeEntryItem:cell.item undoManager:self.undoManager];
 	}
 	[self selectPreviousRowFromIndexPath:self.latestSelectedIndexPath];
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -272,24 +272,17 @@ extern void *ctx;
 		return;
 	}
 
-    [self.undoManager registerUndoWithTarget:self selector:@selector(undoDeletedItem:) object:cell.item];
-    [self.undoManager setActionName:@"Undo delete Time Entry"];
-
 	// If description is empty and duration is less than 15 seconds delete without confirmation
 	if (cell.confirmless_delete)
 	{
-		if (toggl_delete_time_entry(ctx, [cell.GUID UTF8String]))
-		{
-			[self selectPreviousRowFromIndexPath:self.latestSelectedIndexPath];
-		}
+        [[DesktopLibraryBridge shared] deleteTimeEntryItem:cell.item undoManager:self.undoManager];
+        [self selectPreviousRowFromIndexPath:self.latestSelectedIndexPath];
 		return;
 	}
 
 	// Delete and select preview cell
-	if ([Utils deleteTimeEntryWithConfirmationWithGUID:cell.GUID title:cell.descriptionString])
-	{
-		[self selectPreviousRowFromIndexPath:self.latestSelectedIndexPath];
-	}
+    [[DesktopLibraryBridge shared] deleteTimeEntryItem:cell.item undoManager:self.undoManager];
+    [self selectPreviousRowFromIndexPath:self.latestSelectedIndexPath];
 }
 
 - (void)selectPreviousRowFromIndexPath:(NSIndexPath *)indexPath
@@ -342,11 +335,5 @@ extern void *ctx;
 							 scrollPosition:NSCollectionViewScrollPositionTop];
 		}
 	}
-}
-
-- (void) undoDeletedItem:(TimeEntryViewItem *) item
-{
-    // Create new item
-    
 }
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -272,6 +272,9 @@ extern void *ctx;
 		return;
 	}
 
+    [self.undoManager registerUndoWithTarget:self selector:@selector(undoDeletedItem:) object:cell.item];
+    [self.undoManager setActionName:@"Undo delete Time Entry"];
+
 	// If description is empty and duration is less than 15 seconds delete without confirmation
 	if (cell.confirmless_delete)
 	{
@@ -341,4 +344,9 @@ extern void *ctx;
 	}
 }
 
+- (void) undoDeletedItem:(TimeEntryViewItem *) item
+{
+    // Create new item
+    
+}
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -97,6 +97,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setClickCloseBtnInAppMessage;
 - (void)setClickActionBtnInAppMessage;
 
+- (NSString *)createNewTimeEntryWithOldTimeEntry:(TimeEntryViewItem *) item;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateTimeEntryWithEndAtTimestamp:(NSTimeInterval)timestamp
 									 guid:(NSString *)guid;
 
-- (void)deleteTimeEntryImte:(TimeEntryViewItem *)item;
+- (void)deleteTimeEntryItem:(TimeEntryViewItem *)item undoManager:(NSUndoManager *_Nullable) undoManager;
 
 - (void)updateDescriptionForTimeEntry:(TimeEntryViewItem *)timeEntry
 						 autocomplete:(AutocompleteItem *)autocomplete;

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -318,16 +318,16 @@ void *ctx;
     if (tags == nil) {
         tags = @"";
     }
-    char *guid = toggl_create_time_entry(ctx,
-                                         [item.Description UTF8String],
-                                         [item.duration UTF8String],
-                                         item.TaskID,
-                                         item.ProjectID,
-                                         0,
-                                         [tags UTF8String],
-                                         [item.startTimeString UTF8String],
-                                         [item.endTimeString UTF8String],
-                                         [item.started timeIntervalSince1970]);
+    char *guid = toggl_start(ctx,
+                             [item.Description UTF8String],
+                             [item.duration UTF8String],
+                             item.TaskID,
+                             item.ProjectID,
+                             0,
+                             [tags UTF8String],
+                             false,
+                             [item.started timeIntervalSince1970],
+                             [item.ended timeIntervalSince1970]);
     if (guid != nil) {
         NSString *GUID = [NSString stringWithUTF8String:guid];
         free(guid);

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -293,4 +293,22 @@ void *ctx;
 {
     toggl_iam_click(ctx, 3);
 }
+
+- (NSString *)createNewTimeEntryWithOldTimeEntry:(TimeEntryViewItem *) item
+{
+    NSString *tags = [item.tags componentsJoinedByString:@"\t"];
+    char *guid = toggl_create_time_entry(ctx,
+                                         [item.Description UTF8String],
+                                         [item.duration UTF8String],
+                                         item.TaskID,
+                                         item.ProjectID, 0,
+                                         [tags UTF8String],
+                                         [item.startTimeString UTF8String],
+                                         [item.endTimeString UTF8String],
+                                         [item.started timeIntervalSince1970]);
+    NSString *GUID = [NSString stringWithUTF8String:guid];
+    free(guid);
+    return GUID;
+}
+
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -309,18 +309,25 @@ void *ctx;
 - (NSString *)createNewTimeEntryWithOldTimeEntry:(TimeEntryViewItem *) item
 {
     NSString *tags = [item.tags componentsJoinedByString:@"\t"];
+    if (tags == nil) {
+        tags = @"";
+    }
     char *guid = toggl_create_time_entry(ctx,
                                          [item.Description UTF8String],
                                          [item.duration UTF8String],
                                          item.TaskID,
-                                         item.ProjectID, 0,
+                                         item.ProjectID,
+                                         0,
                                          [tags UTF8String],
                                          [item.startTimeString UTF8String],
                                          [item.endTimeString UTF8String],
                                          [item.started timeIntervalSince1970]);
-    NSString *GUID = [NSString stringWithUTF8String:guid];
-    free(guid);
-    return GUID;
+    if (guid != nil) {
+        NSString *GUID = [NSString stringWithUTF8String:guid];
+        free(guid);
+        return GUID;
+    }
+    return nil;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -150,12 +150,12 @@ void *ctx;
 									   timestamp);
 }
 
-- (void)deleteTimeEntryImte:(TimeEntryViewItem *)item
+- (void)deleteTimeEntryItem:(TimeEntryViewItem *)item undoManager:(NSUndoManager *) undoManager
 {
 	// If description is empty and duration is less than 15 seconds delete without confirmation
 	if ([item confirmlessDelete])
 	{
-		toggl_delete_time_entry(ctx, [item.GUID UTF8String]);
+        [self deleteItem:item undoManager:undoManager];
 		return;
 	}
 	NSString *msg = [NSString stringWithFormat:@"Delete time entry \"%@\"?", item.Description];
@@ -172,7 +172,19 @@ void *ctx;
 	}
 
 	// Delete
-	toggl_delete_time_entry(ctx, [item.GUID UTF8String]);
+    [self deleteItem:item undoManager:undoManager];
+}
+
+- (void) deleteItem:(TimeEntryViewItem *) item undoManager:(NSUndoManager *) undoManager
+{
+    [self registerUndoDeleteItem:item undoManager:undoManager];
+    toggl_delete_time_entry(ctx, [item.GUID UTF8String]);
+}
+
+- (void) registerUndoDeleteItem:(TimeEntryViewItem *)item undoManager:(NSUndoManager *) undoManager
+{
+    [undoManager registerUndoWithTarget:self selector:@selector(createNewTimeEntryWithOldTimeEntry:) object:item];
+    [undoManager setActionName:@"Undo Delete Time Entry"];
 }
 
 - (void)updateDescriptionForTimeEntry:(TimeEntryViewItem *)timeEntry autocomplete:(AutocompleteItem *)autocomplete

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -179,8 +179,8 @@ final class EditorViewController: NSViewController {
     }
 
     @IBAction func deleteBtnOnTap(_ sender: Any) {
-        DesktopLibraryBridge.shared().deleteTimeEntryImte(timeEntry)
-        delegate?.editorShouldClose()
+        DesktopLibraryBridge.shared().deleteTimeEntryItem(timeEntry, undoManager: undoManager)
+        delegate?.editorShouldClose()   
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -160,8 +160,8 @@ class TimelineData {
         }
     }
 
-    func delete(_ timeEntry: TimelineTimeEntry) {
-        DesktopLibraryBridge.shared().deleteTimeEntryImte(timeEntry.timeEntry)
+    func delete(_ timeEntry: TimelineTimeEntry, undoManager: Foundation.UndoManager?) {
+        DesktopLibraryBridge.shared().deleteTimeEntryItem(timeEntry.timeEntry, undoManager: undoManager)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -270,7 +270,7 @@ extension TimelineDatasource: TimelineTimeEntryCellDelegate {
     }
 
     func timeEntryCellShouldDelete(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
-        timeline?.delete(entry)
+        timeline?.delete(entry, undoManager: collectionView.undoManager)
     }
 
     func timeEntryCellShouldChangeFirstEntryStopTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -757,8 +757,7 @@ NSString *kInactiveTimerColor = @"#999999";
 		}
 		else if (event.keyCode == kVK_Delete)
 		{
-			[Utils deleteTimeEntryWithConfirmationWithGUID:self.time_entry.GUID
-													 title:self.descriptionLabel.stringValue];
+            [[DesktopLibraryBridge shared] deleteTimeEntryItem:self.time_entry undoManager:self.undoManager];
 		}
 		else if (event.keyCode == kVK_Space)
 		{

--- a/src/ui/osx/TogglDesktop/Utils.h
+++ b/src/ui/osx/TogglDesktop/Utils.h
@@ -25,7 +25,6 @@
 + (void)setUpdaterChannel:(NSString *)channel;
 + (ScriptResult *)runScript:(NSString *)script;
 + (void)runClearCommand;
-+ (BOOL)deleteTimeEntryWithConfirmationWithGUID:(NSString *)guid title:(NSString *)title;
 @end
 
 BOOL wasLaunchedAsLoginOrResumeItem(void);

--- a/src/ui/osx/TogglDesktop/Utils.m
+++ b/src/ui/osx/TogglDesktop/Utils.m
@@ -148,25 +148,6 @@ extern void *ctx;
 	return path;
 }
 
-+ (BOOL)deleteTimeEntryWithConfirmationWithGUID:(NSString *)guid title:(NSString *)title
-{
-	NSString *msg = [NSString stringWithFormat:@"Delete time entry \"%@\"?", title];
-
-	NSAlert *alert = [[NSAlert alloc] init];
-
-	[alert addButtonWithTitle:@"OK"];
-	[alert addButtonWithTitle:@"Cancel"];
-	[alert setMessageText:msg];
-	[alert setInformativeText:@"Deleted time entries cannot be restored."];
-	[alert setAlertStyle:NSWarningAlertStyle];
-	if ([alert runModal] != NSAlertFirstButtonReturn)
-	{
-		return NO;
-	}
-
-	return toggl_delete_time_entry(ctx, [guid UTF8String]);
-}
-
 /*
  * Returns whether or not an NSString represents a numeric value.
  * For more info see:  http://appliedsoftwaredesign.com/blog/iphone-sdk-nsstring-numeric/

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.h
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.h
@@ -18,6 +18,7 @@ typedef NS_ENUM (NSUInteger, CellType)
 };
 
 @interface TimeEntryCell : NSCollectionViewItem
+@property (nonatomic, strong, readonly) TimeEntryViewItem *item;
 @property (nonatomic, copy, readonly) NSString *GUID;
 @property (nonatomic, copy, readonly) NSString *GroupName;
 @property (nonatomic, assign, readonly) BOOL GroupOpen;

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
@@ -30,6 +30,7 @@
 @property (weak) IBOutlet NSBox *horizontalLine;
 @property (weak) IBOutlet NSTextField *descriptionTextField;
 
+@property (nonatomic, strong) TimeEntryViewItem *item;
 @property (strong, nonatomic) NSColor *backgroundColor;
 @property (strong, nonatomic) NSColor *selectedSubItemBackgroundColor;
 @property (nonatomic, copy) NSString *GUID;
@@ -179,6 +180,7 @@ extern void *ctx;
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 
 	self.confirmless_delete = [view_item confirmlessDelete];
+    self.item = view_item;
 
 	self.GUID = view_item.GUID;
 	self.durationTextField.stringValue = view_item.duration;


### PR DESCRIPTION
### 📒 Description
This PR introduces the feature to undo deleting the TE.
For sake of simplicity, this PR only supports:
- Undo 1 last deleted TE (Delete by keyboard or from the Editor)
- Don't support Redo
- Don't support Undo for bulk deleting TE. 

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Introduce new lib func to clone a given TimeEntryItem
- [x] Logic for register Undo deleting

### 👫 Relationships
Closes #2928

### 🔎 Review hints
#### Able to Undo TE from the Editor
1. Open Editor in any TimeEntry (Observe the Description, Data, start, project, tags, ...)
2. Click Delete 
3. Focus on TimeEntry List and hit CMD+Z (If the Timer is focused -> It's impossible to undo the TE since it's undo what we type)
4. Make sure if the TE backs
5. Check the info and make sure they're the same.

#### Able to Undo TE from the keyboard
1. Do the same by following the above steps
2. Hit delete on Keyboard and check the result.