### PR TITLE
Fix how we trigger Pomodoro if we update Start / Duration in current running Time Entry

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4554,6 +4554,13 @@ void Context::displayPomodoro() {
                 return;
             }
         }
+
+        // At this state, the total duration > pomodoro time
+        // but we should skip if the user manually update start / duration time
+        if (current_te->ManualUpdateFromUser()) {
+            return;
+        }
+
         const Poco::Int64 pomodoroDuration = settings_.pomodoro_minutes * 60;
         wid = current_te->WID();
         Stop(true);

--- a/src/context.h
+++ b/src/context.h
@@ -823,8 +823,9 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error updateTimeEntryDescription(
         TimeEntry *te,
         const std::string &value);
-};
 
+    bool checkIfSkipPomodoro(TimeEntry *te);
+};
 void on_websocket_message(
     void *context,
     std::string json);

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -297,6 +297,9 @@ void TimeEntry::SetDurationInSeconds(const Poco::Int64 value) {
 
 void TimeEntry::SetStartUserInput(const std::string &value,
                                   const bool keepEndTimeFixed) {
+    // For skip Pomodoro
+    manualUpdateFromUser = true;
+
     Poco::Int64 start = Formatter::Parse8601(value);
     if (IsTracking()) {
         SetDurationInSeconds(-start);
@@ -321,6 +324,9 @@ void TimeEntry::SetStartString(const std::string &value) {
 }
 
 void TimeEntry::SetDurationUserInput(const std::string &value) {
+    // For skip Pomodoro
+    manualUpdateFromUser = true;
+
     int seconds = Formatter::ParseDurationString(value);
     if (IsTracking()) {
         time_t now = time(nullptr);

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -297,9 +297,6 @@ void TimeEntry::SetDurationInSeconds(const Poco::Int64 value) {
 
 void TimeEntry::SetStartUserInput(const std::string &value,
                                   const bool keepEndTimeFixed) {
-    // For skip Pomodoro
-    manualUpdateFromUser = true;
-
     Poco::Int64 start = Formatter::Parse8601(value);
     if (IsTracking()) {
         SetDurationInSeconds(-start);
@@ -324,9 +321,6 @@ void TimeEntry::SetStartString(const std::string &value) {
 }
 
 void TimeEntry::SetDurationUserInput(const std::string &value) {
-    // For skip Pomodoro
-    manualUpdateFromUser = true;
-
     int seconds = Formatter::ParseDurationString(value);
     if (IsTracking()) {
         time_t now = time(nullptr);
@@ -553,6 +547,10 @@ std::string TimeEntry::ModelURL() const {
     }
 
     return relative_url.str();
+}
+
+void TimeEntry::SetSkipPomodoro(const bool value) {
+    skipPomodoro = value;
 }
 
 }   // namespace toggl

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -30,7 +30,8 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     , created_with_("")
     , project_guid_("")
     , unsynced_(false)
-    , last_start_at_(0) {}
+    , last_start_at_(0)
+    , manualUpdateFromUser(false) {}
 
     virtual ~TimeEntry() {}
 
@@ -106,6 +107,10 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
 
     bool IsToday() const;
 
+    const bool &ManualUpdateFromUser() const {
+        return manualUpdateFromUser;
+    }
+
     const std::string &ProjectGUID() const {
         return project_guid_;
     }
@@ -157,6 +162,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string project_guid_;
     bool unsynced_;
     Poco::Int64 last_start_at_;
+    bool manualUpdateFromUser;
 
     bool setDurationStringHHMMSS(const std::string &value);
     bool setDurationStringHHMM(const std::string &value);

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -31,7 +31,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     , project_guid_("")
     , unsynced_(false)
     , last_start_at_(0)
-    , manualUpdateFromUser(false) {}
+    , skipPomodoro(false) {}
 
     virtual ~TimeEntry() {}
 
@@ -107,8 +107,9 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
 
     bool IsToday() const;
 
-    const bool &ManualUpdateFromUser() const {
-        return manualUpdateFromUser;
+    void SetSkipPomodoro(const bool value);
+    const bool &SkipPomodoro() const {
+        return skipPomodoro;
     }
 
     const std::string &ProjectGUID() const {
@@ -162,7 +163,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string project_guid_;
     bool unsynced_;
     Poco::Int64 last_start_at_;
-    bool manualUpdateFromUser;
+    bool skipPomodoro;
 
     bool setDurationStringHHMMSS(const std::string &value);
     bool setDurationStringHHMM(const std::string &value);


### PR DESCRIPTION
### 📒 Description
This PR would improve how we trigger the Pomodoro if the user updates a Start or Duration on a current Running Time Entry.

### Current problem
Describe in https://github.com/toggl-open-source/toggldesktop/issues/2778

### Solution
- Skip Pomodoro if the total time (after updating from the user) is greater than Pomodoro Time
- Pomodoro is still working if the total time (after updating from the user) is lesser than Pomodoro Time.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Add logic to check if we should skip Pomodoro or not when the user updating the "Start / Duration" on the current running Time Entry

### 👫 Relationships
Closes #2778

### 🔎 Review hints
#### 1. Don't show Pomodoro notification if we change Start Time of the current Running TimeEntry later than Pomodoro Time
1. Set Pomodoro Time in Preference is 10 minutes
2. Start Time Entry A and open Editor on the current running 
3. Update the Start time back to 1 hour ago. Ex: from 16:30 to 15:30
4. Make sure the Pomodoro notification doesn't trigger
5. Make sure the running TimeEntry is still running 
6. Click Stop button after 10 mins
7. Make sure the start and duration time of this TE is correct.

#### 2. Don't show Pomodoro notification if we change Duration of the current Running TimeEntry later than Pomodoro Time
1. Repeat the 1st review instruction and update the Duration instead of the Start Time.
2. Verify that all expectations are met.

#### 3. Show Pomodoro notification if we change Start Time of the current Running TimeEntry less than Pomodoro Time
1. Set Pomodoro Time in Preference is 10 minutes
2. Start Time Entry A and open Editor on the current running 
3. Update the Start time back to 5 min ago. Ex: from 16:30 to 16:25
4. Make sure the Pomodoro notification triggers after 5 min (duration of this TE is 10 mins)
5. Make sure the running TimeEntry is stopped 
7. Make sure the start and duration time of this TE is correct.

#### 4. Show Pomodoro notification if we change Duration of the current Running TimeEntry less than Pomodoro Time
1. Repeat the 3rd review instruction and update the Duration instead of the Start Time.
2. Verify that all expectations are met.