### PR TITLE
Fix crash when displaying in-app notification

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/InAppNotification.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/InAppNotification.xaml.cs
@@ -48,14 +48,14 @@ namespace TogglDesktop
             set { SetValue(UrlProperty, value); }
         }
 
-        public void RunAppearAnimation(double maxHeight)
+        public void RunAppearAnimation()
         {
             var sb = new Storyboard();
             var slideAnimation = new DoubleAnimation
             {
                 Duration = TimeSpan.FromSeconds(1),
                 From = 0,
-                To = maxHeight,
+                To = 300,
                 DecelerationRatio = 0.3f
             };
             Storyboard.SetTargetProperty(slideAnimation, new PropertyPath("MaxHeight"));

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -475,7 +475,7 @@ namespace TogglDesktop
             inAppNotification.Button = button;
             inAppNotification.Url = url;
 
-            inAppNotification.RunAppearAnimation(this.Height);
+            inAppNotification.RunAppearAnimation();
         }
 
         #endregion


### PR DESCRIPTION
### 📒 Description
Fixes the crash when displaying the in-app notification

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3668

### 🔎 Review hints

1. Open database, change `settings`->`message_seen` to `0`.
2. Make sure there is nothing in the `updates` folder before running the app.
3. Run the app in `Release` mode.
4. In-app notification should be shown successfully, with no crash.