### PR TITLE
Timeline: Border selection

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -31,7 +31,13 @@ final class TimelineDashboardViewController: NSViewController {
 
     weak var delegate: TimelineDashboardViewControllerDelegate?
     private var isOpening = false
-    private var selectedGUID: String?
+    private var selectedGUID: String? {
+        didSet {
+            if selectedGUID == nil {
+                resetHighlightCells()
+            }
+        }
+    }
     private var isFirstTime = true
     lazy var datePickerView: DatePickerView = DatePickerView.xibView()
     private lazy var datasource = TimelineDatasource(collectionView)
@@ -70,14 +76,6 @@ final class TimelineDashboardViewController: NSViewController {
         popover.delegate = self
         return popover
     }()
-
-    private var hightlightItemGUID: String? {
-        didSet {
-            if hightlightItemGUID == nil {
-                resetHighlightCells()
-            }
-        }
-    }
 
     // MARK: View
     
@@ -270,7 +268,7 @@ extension TimelineDashboardViewController {
     }
 
     private func highlightCells() {
-        guard let guid = hightlightItemGUID else { return }
+        guard let guid = selectedGUID else { return }
         for item in collectionView.visibleItems() {
             if let itemCell = item as? TimelineTimeEntryCell {
                 itemCell.isHighlight = itemCell.timeEntry.timeEntry.guid == guid
@@ -329,7 +327,6 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
     }
 
     func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell) {
-        hightlightItemGUID = timeEntry.guid
         cell.isHighlight = true
         timeEntryHoverPopover.close()
         selectedGUID = timeEntry.guid
@@ -413,6 +410,6 @@ extension TimelineDashboardViewController: NSPopoverDelegate {
             popover === editorPopover else {
             return
         }
-        hightlightItemGUID = nil
+        selectedGUID = nil
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -33,11 +33,6 @@ final class TimelineDashboardViewController: NSViewController {
     private var isOpening = false
     private var selectedGUID: String?
     private var isFirstTime = true
-    private var hightlightCell: TimelineTimeEntryCell? {
-        didSet {
-            oldValue?.isHighlight = false
-        }
-    }
     lazy var datePickerView: DatePickerView = DatePickerView.xibView()
     private lazy var datasource = TimelineDatasource(collectionView)
     private var zoomLevel: TimelineDatasource.ZoomLevel = .x1 {
@@ -75,6 +70,12 @@ final class TimelineDashboardViewController: NSViewController {
         popover.delegate = self
         return popover
     }()
+
+    private var hightlightItemGUID: String? {
+        didSet {
+            resetAllHighlightCells(with: oldValue)
+        }
+    }
 
     // MARK: View
     
@@ -254,6 +255,12 @@ extension TimelineDashboardViewController {
         emptyActivityLbl.stringValue = recordSwitcher.isOn ? "No activity was recorded yet..." : "Turn on activity\nrecording to see results."
         emptyActivityLblPadding.constant = recordSwitcher.isOn ? -40 : -50
     }
+
+    private func resetAllHighlightCells(with guid: String?) {
+        guard let guid = guid,
+            let cell = datasource.timeEntryCell(for: guid) else { return }
+        cell.isHighlight = false
+    }
 }
 
 // MARK: DatePickerViewDelegate
@@ -306,7 +313,7 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
     }
 
     func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell) {
-        hightlightCell = cell
+        hightlightItemGUID = timeEntry.guid
         timeEntryHoverPopover.close()
         selectedGUID = timeEntry.guid
         editorPopover.show(relativeTo: view.bounds, of: view, preferredEdge: .maxX)
@@ -390,6 +397,6 @@ extension TimelineDashboardViewController: NSPopoverDelegate {
             popover === editorPopover else {
             return
         }
-        hightlightCell = nil
+        hightlightItemGUID = nil
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -73,7 +73,9 @@ final class TimelineDashboardViewController: NSViewController {
 
     private var hightlightItemGUID: String? {
         didSet {
-            resetHighlightCells(with: oldValue)
+            if hightlightItemGUID == nil {
+                resetHighlightCells()
+            }
         }
     }
 
@@ -259,16 +261,21 @@ extension TimelineDashboardViewController {
         emptyActivityLblPadding.constant = recordSwitcher.isOn ? -40 : -50
     }
 
-    private func resetHighlightCells(with guid: String?) {
-        guard let guid = guid,
-            let cell = datasource.timeEntryCell(for: guid) else { return }
-        cell.isHighlight = false
+    private func resetHighlightCells() {
+        for item in collectionView.visibleItems() {
+            if let itemCell = item as? TimelineTimeEntryCell {
+                itemCell.isHighlight = false
+            }
+        }
     }
 
     private func highlightCells() {
-        guard let guid = hightlightItemGUID,
-            let cell = datasource.timeEntryCell(for: guid) else { return }
-        cell.isHighlight = true
+        guard let guid = hightlightItemGUID else { return }
+        for item in collectionView.visibleItems() {
+            if let itemCell = item as? TimelineTimeEntryCell {
+                itemCell.isHighlight = itemCell.timeEntry.timeEntry.guid == guid
+            }
+        }
     }
 }
 
@@ -323,12 +330,12 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
 
     func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell) {
         hightlightItemGUID = timeEntry.guid
+        cell.isHighlight = true
         timeEntryHoverPopover.close()
         selectedGUID = timeEntry.guid
         editorPopover.show(relativeTo: view.bounds, of: view, preferredEdge: .maxX)
         editorPopover.setTimeEntry(timeEntry)
         DesktopLibraryBridge.shared().startEditor(atGUID: timeEntry.guid)
-        cell.isHighlight = true
     }
 
     func startNewTimeEntry(at started: TimeInterval, ended: TimeInterval) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -73,7 +73,7 @@ final class TimelineDashboardViewController: NSViewController {
 
     private var hightlightItemGUID: String? {
         didSet {
-            resetAllHighlightCells(with: oldValue)
+            resetHighlightCells(with: oldValue)
         }
     }
 
@@ -133,6 +133,9 @@ final class TimelineDashboardViewController: NSViewController {
         if shouldScroll {
             scrollToVisibleItem()
         }
+
+        // After the reload finishes, we hightlight a cell again
+        highlightCells()
     }
     
     @IBAction func recordSwitchOnChanged(_ sender: Any) {
@@ -256,10 +259,16 @@ extension TimelineDashboardViewController {
         emptyActivityLblPadding.constant = recordSwitcher.isOn ? -40 : -50
     }
 
-    private func resetAllHighlightCells(with guid: String?) {
+    private func resetHighlightCells(with guid: String?) {
         guard let guid = guid,
             let cell = datasource.timeEntryCell(for: guid) else { return }
         cell.isHighlight = false
+    }
+
+    private func highlightCells() {
+        guard let guid = hightlightItemGUID,
+            let cell = datasource.timeEntryCell(for: guid) else { return }
+        cell.isHighlight = true
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -129,6 +129,17 @@ final class TimelineDatasource: NSObject {
                                          scrollPosition: [.centeredHorizontally, .centeredVertically])
         }
     }
+
+    func timeEntryCell(for guid: String) -> TimelineTimeEntryCell? {
+        let cell = collectionView.visibleItems().first { item -> Bool in
+            if let cell = item as? TimelineTimeEntryCell,
+                cell.timeEntry.timeEntry.guid == guid {
+                return true
+            }
+            return false
+        }
+        return cell as? TimelineTimeEntryCell
+    }
 }
 
 extension TimelineDatasource: NSCollectionViewDataSource, NSCollectionViewDelegateFlowLayout, NSCollectionViewDelegate {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -10,7 +10,7 @@ import Cocoa
 
 protocol TimelineDatasourceDelegate: class {
 
-    func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem)
+    func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell)
     func shouldPresentTimeEntryHover(in view: NSView, timeEntry: TimelineTimeEntry)
     func shouldPresentActivityHover(in view: NSView, activity: TimelineActivity)
     func startNewTimeEntry(at started: TimeInterval, ended: TimeInterval)
@@ -203,7 +203,7 @@ extension TimelineDatasource: NSCollectionViewDataSource, NSCollectionViewDelega
         switch item {
         case let timeEntry as TimelineTimeEntry:
             if let cell = cell as? TimelineTimeEntryCell {
-                delegate?.shouldPresentTimeEntryEditor(in: cell.popoverView, timeEntry: timeEntry.timeEntry)
+                delegate?.shouldPresentTimeEntryEditor(in: cell.popoverView, timeEntry: timeEntry.timeEntry, cell: cell)
                 collectionView.deselectItems(at: indexPaths)
             }
         case let item as TimelineBaseTimeEntry:

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
@@ -24,6 +24,7 @@ class TimelineBaseCell: NSCollectionViewItem {
     // MARK: Variables
 
     weak var mouseDelegate: TimelineBaseCellDelegate?
+    private(set) var backgroundColor: NSColor?
 
     // MARK: Public
 
@@ -41,9 +42,11 @@ class TimelineBaseCell: NSCollectionViewItem {
     }
 
     func renderColor(with foregroundColor: NSColor, isSmallEntry: Bool) {
+        backgroundColor = foregroundColor.lighten(by: 0.1)
+
         foregroundBox.fillColor = foregroundColor
-        backgroundBox?.fillColor = foregroundColor.lighten(by: 0.1)
-        backgroundBox?.borderColor = foregroundColor
+        backgroundBox?.fillColor = backgroundColor ?? foregroundColor
+        backgroundBox?.borderColor = backgroundColor ?? foregroundColor
 
         let cornerRadius = suitableCornerRadius(isSmallEntry)
         foregroundBox.cornerRadius = cornerRadius

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
@@ -43,6 +43,7 @@ class TimelineBaseCell: NSCollectionViewItem {
     func renderColor(with foregroundColor: NSColor, isSmallEntry: Bool) {
         foregroundBox.fillColor = foregroundColor
         backgroundBox?.fillColor = foregroundColor.lighten(by: 0.1)
+        backgroundBox?.borderColor = foregroundColor
 
         let cornerRadius = suitableCornerRadius(isSmallEntry)
         foregroundBox.cornerRadius = cornerRadius

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -53,7 +53,6 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
 
     var isHighlight: Bool = false {
         didSet {
-            print("--- isHighlight \(isHighlight)")
             backgroundBox?.borderWidth = isHighlight ? 1 : 0
         }
     }
@@ -77,6 +76,11 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
         super.viewDidLoad()
         initCommon()
         initTrackingArea()
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        isHighlight = false
     }
 
     // MARK: Public

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -51,6 +51,13 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
         return backgroundBox.isHidden ? foregroundBox : view
     }
 
+    var isHighlight: Bool = false {
+        didSet {
+            print("--- isHighlight \(isHighlight)")
+            backgroundBox?.borderWidth = isHighlight ? 1 : 0
+        }
+    }
+
     // MARK: OUTLET
 
     @IBOutlet weak var titleLbl: NSTextField!

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -53,7 +53,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
 
     var isHighlight: Bool = false {
         didSet {
-            backgroundBox?.borderWidth = isHighlight ? 1 : 0
+            backgroundBox?.borderColor = (isHighlight ? foregroundBox.fillColor : backgroundColor) ?? foregroundBox.fillColor
         }
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -112,6 +112,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     private func populateInfo() {
         guard let timeEntry = timeEntry else { return }
         backgroundBox?.isHidden = !timeEntry.hasDetailInfo
+        isHighlight = false
 
         if timeEntry.hasDetailInfo {
             let item = timeEntry.timeEntry

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -13,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xE9-Ie-UP3">
+                <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="line" borderWidth="0.0" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xE9-Ie-UP3">
                     <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
                     <view key="contentView" id="r80-dl-MpV">
                         <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -13,14 +13,14 @@
             <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="line" borderWidth="0.0" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xE9-Ie-UP3">
+                <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="line" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xE9-Ie-UP3">
                     <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
                     <view key="contentView" id="r80-dl-MpV">
-                        <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
+                        <rect key="frame" x="1" y="1" width="195" height="105"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dpe-7G-baj">
-                                <rect key="frame" x="30" y="21" width="167" height="81"/>
+                                <rect key="frame" x="30" y="20" width="165" height="81"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXs-or-rIk">
                                         <rect key="frame" x="-2" y="66" width="77" height="15"/>
@@ -68,7 +68,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <stackView distribution="fill" orientation="horizontal" alignment="bottom" spacing="5" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-uW-hFa">
-                                        <rect key="frame" x="0.0" y="0.0" width="167" height="24"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="165" height="24"/>
                                         <subviews>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="qtZ-fn-lLE">
                                                 <rect key="frame" x="0.0" y="0.0" width="17" height="17"/>
@@ -87,10 +87,10 @@
                                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="time-entry-billable" id="WjC-yn-K4V"/>
                                             </imageView>
                                             <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8dq-AH-3f2">
-                                                <rect key="frame" x="44" y="0.0" width="123" height="16"/>
+                                                <rect key="frame" x="44" y="0.0" width="121" height="16"/>
                                                 <subviews>
                                                     <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fa0-T9-1iU">
-                                                        <rect key="frame" x="96" y="1" width="24" height="15"/>
+                                                        <rect key="frame" x="94" y="1" width="24" height="15"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" alignment="right" title="12h" id="k25-lb-1QZ">
                                                             <font key="font" metaFont="label" size="12"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -137,7 +137,7 @@
                         <constraints>
                             <constraint firstItem="Dpe-7G-baj" firstAttribute="leading" secondItem="r80-dl-MpV" secondAttribute="leading" constant="30" id="ci9-bO-9hN"/>
                             <constraint firstAttribute="trailing" secondItem="Dpe-7G-baj" secondAttribute="trailing" id="iiK-Hr-LDk"/>
-                            <constraint firstItem="Dpe-7G-baj" firstAttribute="top" secondItem="r80-dl-MpV" secondAttribute="top" constant="5" id="uJq-SO-k3o"/>
+                            <constraint firstItem="Dpe-7G-baj" firstAttribute="top" secondItem="r80-dl-MpV" secondAttribute="top" constant="4" id="uJq-SO-k3o"/>
                         </constraints>
                     </view>
                     <color key="fillColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -82,10 +82,6 @@ NSString *kInactiveTimerColor = @"#999999";
 													 name:kDisplayTimerState
 												   object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayTimeEntryEditor:)
-													 name:kDisplayTimeEntryEditor
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
 												 selector:@selector(focusTimer)
 													 name:kFocusTimer
 												   object:nil];
@@ -314,18 +310,6 @@ NSString *kInactiveTimerColor = @"#999999";
         }
     }
 
-}
-
-- (void)startDisplayTimeEntryEditor:(NSNotification *)notification
-{
-	[self displayTimeEntryEditor:notification.object];
-}
-
-- (void)displayTimeEntryEditor:(DisplayCommand *)cmd
-{
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-
-	NSLog(@"TimeEntryListViewController displayTimeEntryEditor, thread %@", [NSThread currentThread]);
 }
 
 - (void)showDefaultTimer


### PR DESCRIPTION
### 📒 Description
This PR introduce the selection border on the TimeEntry, which is being selected, as a new design

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add border if the cell is highlighted 
- [x] Add logic to reset or highlight the cell during the selection or the datasource is reloaded

### 👫 Relationships
Closes #3673

### 🔎 Review hints
- Play around the app, try to select to open the Editor in Timeline, and unselect it or close it => Make sure the border on the selected is correct

### Screenshot
<img width="693" alt="Screen Shot 2020-01-06 at 18 51 28" src="https://user-images.githubusercontent.com/5878421/71818091-8dd7c580-30ba-11ea-9554-307afa94e8b5.png">

![2020-01-06 18 51 52](https://user-images.githubusercontent.com/5878421/71818092-8dd7c580-30ba-11ea-97fd-738293be201f.gif)

