### PR TITLE
Fix menu on right click doesn't show on Overlap Time Entry

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -68,6 +68,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         initCommon()
         initTrackingArea()
     }
@@ -90,14 +91,6 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
         foregroundBox.resetCursorRects()
     }
 
-    override func rightMouseDown(with event: NSEvent) {
-        super.rightMouseDown(with: event)
-
-        if let timeEntry = timeEntry, timeEntry.isOverlap {
-            NSMenu.popUpContextMenu(timeEntryMenu, with: event, for: self.view)
-        }
-    }
-
     private func populateInfo() {
         guard let timeEntry = timeEntry else { return }
         backgroundBox?.isHidden = !timeEntry.hasDetailInfo
@@ -107,6 +100,9 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
             updateLabels(item)
             hideOutOfBoundControls()
         }
+
+        // Enable menu if it's overlap Time Entry
+        view.menu = timeEntry.isOverlap ? timeEntryMenu : nil
      }
 
     private func hideOutOfBoundControls() {


### PR DESCRIPTION
### 📒 Description
This PR would fix the menu on the overlap TimeEntry. The reason is that we should not manually present the Menu by overriding the Right Mouse action, we should set menu as it's an official way to do it.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Remove old code and set custom menu 
- [x] Enable/disable the menu if it's the overlap TimeEntry

### 👫 Relationships
Closes #3671

### 🔎 Review hints
- Try to right click in entire pillar and make sure it present the Menu
- Reproduce the bug in the ticket and make sure it works 👍 

