### PR TITLE
Timeline: Misaligned activity label 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -27,6 +27,8 @@ final class TimelineDashboardViewController: NSViewController {
     @IBOutlet weak var collectionViewContainerView: NSScrollView!
     @IBOutlet weak var mainContainerView: NSView!
     @IBOutlet weak var activityRecorderInfoImageView: HoverImageView!
+    @IBOutlet weak var activityPanelWidth: NSLayoutConstraint!
+    @IBOutlet weak var activityLabelRight: NSLayoutConstraint!
 
     // MARK: Variables
 
@@ -408,6 +410,11 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
 
         editorPopover.animates = false
         editorPopover.show(relativeTo: cell.popoverView.bounds, of: cell.popoverView, preferredEdge: .maxX)
+    }
+
+    func shouldUpdatePanelSize(with activityFrame: CGRect) {
+        // Adjust the Activity label to make it center alignment
+        activityLabelRight.constant = view.frame.width - activityFrame.origin.x - TimelineFlowLayout.Constants.Divider.SeconDividerRightPadding
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -9,6 +9,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="TimelineDashboardViewController" customModule="TogglDesktop" customModuleProvider="target">
             <connections>
+                <outlet property="activityLabelRight" destination="Amy-gg-D4X" id="uWG-1B-1dA"/>
                 <outlet property="activityRecorderInfoImageView" destination="mVu-t2-GXP" id="xO6-01-A5k"/>
                 <outlet property="collectionView" destination="hht-dC-mpO" id="9tS-ho-Ut6"/>
                 <outlet property="collectionViewContainerView" destination="DJx-ob-wM0" id="Mvz-Dl-Xx0"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -14,6 +14,7 @@ protocol TimelineDatasourceDelegate: class {
     func shouldPresentTimeEntryHover(in view: NSView, timeEntry: TimelineTimeEntry)
     func shouldPresentActivityHover(in view: NSView, activity: TimelineActivity)
     func startNewTimeEntry(at started: TimeInterval, ended: TimeInterval)
+    func shouldUpdatePanelSize(with activityFrame: CGRect)
 }
 
 final class TimelineDatasource: NSObject {
@@ -249,6 +250,10 @@ extension TimelineDatasource: TimelineFlowLayoutDelegate {
     func shouldDrawDetailBubble(at indexPath: IndexPath) -> Bool {
         guard let item = timeline?.item(at: indexPath) as? TimelineBaseTimeEntry else { return false }
         return item.hasDetailInfo
+    }
+
+    func flowLayoutDidUpdateLayout(with activityFrame: CGRect) {
+        delegate?.shouldUpdatePanelSize(with: activityFrame)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
@@ -14,11 +14,12 @@ protocol TimelineFlowLayoutDelegate: class {
     func timechunkForItem(at indexPath: IndexPath) -> TimeChunk?
     func columnForItem(at indexPath: IndexPath) -> Int
     func shouldDrawDetailBubble(at indexPath: IndexPath) -> Bool
+    func flowLayoutDidUpdateLayout(with activityFrame: CGRect)
 }
 
 final class TimelineFlowLayout: NSCollectionViewFlowLayout {
 
-    private struct Constants {
+    struct Constants {
         static let MinimumHeight: CGFloat = 2.0
 
         struct TimeLabel {
@@ -114,6 +115,11 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
         calculateTimeEntryAttributes()
         calculateActivityAttributes()
         calculateBackgroundAttributes()
+
+        // Update the position of labels
+        if let activitySection = dividerAttributes.last {
+            flowDelegate?.flowLayoutDidUpdateLayout(with: activitySection.frame)
+        }
     }
 
     override func layoutAttributesForElements(in rect: NSRect) -> [NSCollectionViewLayoutAttributes] {


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix to make sure the Activity Label should be centered when the Scroller bar is visible or not.

### Problem
The activity constraints doesn't take the ScrollerBar into account, so it doesn't update properly when we set it as "Always" in Preference

### 🕶️ Types of changes
- Fix bug

### 🤯 List of changes
- [x] Update the position of the activity labels if the flow layout is updated

### 👫 Relationships
Closes #3681

### 🔎 Review hints
1. Select scroller behavior as "When Scrolling" or "Always" in Preference -> General 
2. Make sure the Activity Label is updated and center-aligned

<img width="512" alt="Screen Shot 2020-01-07 at 17 44 08" src="https://user-images.githubusercontent.com/5878421/71890212-61817f00-3176-11ea-8530-4aa8007c996e.png">
<img width="468" alt="Screen Shot 2020-01-07 at 17 44 10" src="https://user-images.githubusercontent.com/5878421/71890213-621a1580-3176-11ea-9535-9725f4421677.png">
