### PR TITLE
Timeline: Should close other Popovers when popover is presented 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.swift
@@ -59,6 +59,7 @@ final class DatePickerView: NSView {
             datePickerView.isEnabled = isEnabled
         }
     }
+    var isShown: Bool { return calendarPopover.isShown }
 
     // MARK: View
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.swift
@@ -14,6 +14,7 @@ protocol DatePickerViewDelegate: class {
     func datePickerShouldClose(_ sender: DatePickerView)
     func isTimeEntryRunning(_ sender: DatePickerView) -> Bool
     func shouldOpenCalendar(_ sender: DatePickerView) -> Bool
+    func datePickerWillOpen(_ sender: DatePickerView)
 
     func datePickerDidTapPreviousDate(_ sender: DatePickerView)
     func datePickerDidTapNextDate(_ sender: DatePickerView)
@@ -83,6 +84,7 @@ final class DatePickerView: NSView {
         guard let delegate = delegate,
             !delegate.isTimeEntryRunning(self) else { return }
         guard delegate.shouldOpenCalendar(self) else { return }
+        delegate.datePickerWillOpen(self)
         calendarPopover.present(from: dateSelectionBox.bounds, of: dateSelectionBox, preferredEdge: .maxY)
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -94,7 +94,8 @@ final class TimelineDashboardViewController: NSViewController {
         return !editorPopover.isShown &&
             !activityHoverPopover.isShown &&
             !timeEntryHoverPopover.isShown &&
-            !activityRecorderPopover.isShown
+            !activityRecorderPopover.isShown &&
+            !datePickerView.isShown
     }
 
     // MARK: View

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -296,6 +296,11 @@ extension TimelineDashboardViewController {
             }
         }
     }
+
+    private func closeAllPopovers() {
+        let popovers: [NSPopover] = [editorPopover, activityHoverPopover, activityRecorderPopover, timeEntryHoverPopover]
+        popovers.forEach { $0.performClose(self) }
+    }
 }
 
 // MARK: DatePickerViewDelegate
@@ -329,6 +334,10 @@ extension TimelineDashboardViewController: DatePickerViewDelegate {
         editorPopover.close()
         DesktopLibraryBridge.shared().timelineSetNextDate()
     }
+
+    func datePickerWillOpen(_ sender: DatePickerView) {
+        closeAllPopovers()
+    }
 }
 
 // MARK: TimelineDatasourceDelegate
@@ -348,8 +357,8 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
     }
 
     func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell) {
+        closeAllPopovers()
         cell.isHighlight = true
-        timeEntryHoverPopover.close()
         selectedGUID = timeEntry.guid
         editorPopover.show(relativeTo: view.bounds, of: view, preferredEdge: .maxX)
         editorPopover.setTimeEntry(timeEntry)


### PR DESCRIPTION
### 📒 Description
This PR would introduce the fix that make sure there is only 1 Popover on the screen at one time

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Close all popover when opening the calendar & Editor

### 👫 Relationships
Closes #3676

### 🔎 Review hints
- Make sure there is only one Popover is presented 

