### PR TITLE
Fix missing QRect include error

### DIFF
--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -6,6 +6,7 @@
 #include <QObject>
 #include <QUrl>
 #include <QVector>
+#include <QRect>
 
 #include <stdint.h>
 


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Getting error [similar to this](https://aur.archlinux.org/packages/toggldesktop/#comment-723453) when building `v7.5.3` version with Qt 5.14.0.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->
<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
Looks like including `QRect` to the linux ui headers helps. 
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->
`src/ui/linux/TogglDesktop/toggl.h`
### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

