### PR TITLE
Global error UI implementation

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
@@ -143,6 +143,8 @@
 
     <Style TargetType="Button" x:Key="Toggl.CrossButton" BasedOn="{StaticResource Toggl.PrimaryButton}">
         <Setter Property="Foreground" Value="{DynamicResource Toggl.DarkGrayBrush}" />
+        <Setter Property="Height" Value="32" />
+        <Setter Property="Width" Value="32" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Typography.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Typography.xaml
@@ -20,6 +20,9 @@
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="FontSize" Value="14" />
     </Style>
+    <Style TargetType="TextBlock" x:Key="Toggl.BaseWhiteText" BasedOn="{StaticResource Toggl.BaseText}">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
     <Style TargetType="TextBlock" x:Key="Toggl.BodyText" BasedOn="{StaticResource Toggl.Text}">
         <Setter Property="FontSize" Value="14" />
     </Style>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Window.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Window.xaml
@@ -31,7 +31,7 @@
     </Style>
 
     <Style TargetType="mah:MetroWindow" x:Key="Toggl.MainWindow">
-        <Setter Property="ResizeMode" Value="CanResizeWithGrip" />
+        <Setter Property="ResizeMode" Value="CanResize" />
         <Setter Property="TitleCharacterCasing" Value="Normal" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="WindowTitleBrush" Value="Transparent" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ErrorBar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ErrorBar.xaml
@@ -2,68 +2,39 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             mc:Ignorable="d" d:DesignWidth="300">
-
-    <UserControl.Resources>
-        <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-            <Setter Property="Margin" Value="14 2 6 2"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
-        </Style>
-        <Style TargetType="Button">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ButtonBase">
-                        <Border Background="{TemplateBinding Background}" CornerRadius="2">
-                            <Image Source="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}}"
-                                   Margin="{Binding Path=Padding, RelativeSource={RelativeSource TemplatedParent}}"
-                                   Stretch="Fill" />
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="WindowChrome.IsHitTestVisibleInChrome" Value="True" />
-            <Setter Property="Height" Value="26"/>
-            <Setter Property="Width" Value="26"/>
-            <Setter Property="Padding" Value="4"/>
-            <Setter Property="Margin" Value="2"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Background" Value="Transparent"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#33ffffff"/>
-                </Trigger>
-                <Trigger Property="IsPressed" Value="True">
-                    <Setter Property="Background" Value="#66ffffff"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-    </UserControl.Resources>
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" d:DesignWidth="300"
+             MaxWidth="300"
+             VerticalAlignment="Bottom"
+             HorizontalAlignment="Stretch">
     
-    <StackPanel>
-        <Grid Background="#f0ff8080">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="8"/>
-            </Grid.ColumnDefinitions>
-        
-            <TextBlock Grid.Column="0"
-                       x:Name="errorText" x:FieldModifier="private"
-                       Text="Everything is fine."/>
-            <Button Grid.Column="1"
-                    Click="onCloseButtonClick"
-                    Content="/TogglDesktop;component/Resources/ic_close_grey600_36dp.png"
-                    />
-        </Grid>
-        <Rectangle Height="4">
-            <Rectangle.Fill>
-                <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                    <GradientStop Color="#33000000" Offset="0" />
-                    <GradientStop Color="#00000000" Offset="1" />
-                </LinearGradientBrush>
-            </Rectangle.Fill>
-        </Rectangle>
-    </StackPanel>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition />
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.ColumnSpan="2"
+                Background="{DynamicResource Toggl.ValidationErrorBackground}">
+            <Border.Effect>
+                <DropShadowEffect Opacity="0.3"
+                                  BlurRadius="8"
+                                  ShadowDepth="2"
+                                  Direction="270"/>
+            </Border.Effect>
+        </Border>
+
+        <TextBlock Grid.Column="0"
+                   x:Name="errorText" x:FieldModifier="private"
+                   Style="{DynamicResource Toggl.BaseWhiteText}"
+                   Padding="12 9 12 12"
+                   Text="Everything is fine."
+                   TextWrapping="Wrap"/>
+        <Button Grid.Column="1"
+                Click="onCloseButtonClick"
+                Style="{DynamicResource Toggl.CrossButton}"
+                Margin="4"
+                VerticalAlignment="Top"
+                Foreground="White" />
+    </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
@@ -160,8 +160,7 @@
 
         <toggl:LoginView x:Name="loginView" x:FieldModifier="private"/>
 
-        <toggl:ErrorBar x:Name="errorBar" x:FieldModifier="private"
-            VerticalAlignment="Top"/>
+        <toggl:ErrorBar x:Name="errorBar" x:FieldModifier="private" />
 
         <toggl:StatusBar x:Name="statusBar" x:FieldModifier="private"
                          VerticalAlignment="Bottom"/>


### PR DESCRIPTION
### 📒 Description
Implementation of UI for displaying global application or server errors according to the new design.

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #3621

### 🔎 Review hints

At the end of the `MainWindow` constructor call `Toggl.NewError("some error text");`. Or, if you know how to do it, cause the app to throw an error.

Also, you can remove the line `this.darkModeBorder.Visibility = Visibility.Visible;` or run the app in Release mode so that light/dark mode switch didn't overlap the error UI.

