### PR TITLE
Add HTTP support (lib)

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -154,12 +154,12 @@ const std::string GoogleAnalyticsEvent::relativeURL() {
 }
 
 void GoogleAnalyticsEvent::runTask() {
-    HTTPSRequest req;
+    HTTPRequest req;
     req.host = "https://ssl.google-analytics.com";
     req.relative_url = relativeURL();
 
-    HTTPSClient client;
-    HTTPSResponse resp = client.Get(req);
+    HTTPClient client;
+    HTTPResponse resp = client.Get(req);
     if (resp.err != noError) {
         Logger("Analytics").error(resp.err);
         return;
@@ -316,12 +316,12 @@ void GoogleAnalyticsSettingsEvent::setActionString(const std::string &type,
 }
 
 void GoogleAnalyticsSettingsEvent::makeReq() {
-    HTTPSRequest req;
+    HTTPRequest req;
     req.host = "https://ssl.google-analytics.com";
     req.relative_url = relativeURL();
 
-    HTTPSClient client;
-    HTTPSResponse resp = client.Get(req);
+    HTTPClient client;
+    HTTPResponse resp = client.Get(req);
     if (resp.err != noError) {
         Logger("Analytics").error(resp.err);
         return;

--- a/src/context.cc
+++ b/src/context.cc
@@ -100,8 +100,8 @@ Context::Context(const std::string &app_name, const std::string &app_version)
     Poco::ErrorHandler::set(&error_handler_);
     Poco::Net::initializeSSL();
 
-    HTTPSClient::Config.AppName = app_name;
-    HTTPSClient::Config.AppVersion = app_version;
+    HTTPClient::Config.AppName = app_name;
+    HTTPClient::Config.AppVersion = app_version;
 
     Poco::Crypto::OpenSSLInitializer::initialize();
 
@@ -243,7 +243,7 @@ error Context::StartEvents() {
             }
         }
 
-        if (HTTPSClient::Config.CACertPath.empty()) {
+        if (HTTPClient::Config.CACertPath.empty()) {
             return displayError("Missing CA cert bundle path!");
         }
 
@@ -808,9 +808,9 @@ void Context::updateUI(const UIElements &what) {
             }
             idle_.SetSettings(settings_);
 
-            HTTPSClient::Config.UseProxy = use_proxy;
-            HTTPSClient::Config.ProxySettings = proxy;
-            HTTPSClient::Config.AutodetectProxy = settings_.autodetect_proxy;
+            HTTPClient::Config.UseProxy = use_proxy;
+            HTTPClient::Config.ProxySettings = proxy;
+            HTTPClient::Config.AutodetectProxy = settings_.autodetect_proxy;
         }
 
         if (what.display_unsynced_items && user_) {
@@ -1424,7 +1424,7 @@ error Context::downloadUpdate() {
             return err;
         }
 
-        if (HTTPSClient::Config.AppVersion.empty()) {
+        if (HTTPClient::Config.AppVersion.empty()) {
             return error("This version cannot check for updates. This has been probably already fixed. Please check https://toggl.com/toggl-desktop/ for a newer version.");
         }
 
@@ -1432,12 +1432,12 @@ error Context::downloadUpdate() {
         std::string url("");
         std::string version_number("");
         {
-            HTTPSRequest req;
+            HTTPRequest req;
             req.host = "https://toggl.github.io";
             req.relative_url = "/toggldesktop/assets/updates-link.txt";
 
             TogglClient client;
-            HTTPSResponse resp = client.Get(req);
+            HTTPResponse resp = client.Get(req);
             if (resp.err != noError) {
                 return resp.err;
             }
@@ -1463,7 +1463,7 @@ error Context::downloadUpdate() {
             }
             version_number = versionNumberJsonToken.asString();
 
-            if (lessThanVersion(HTTPSClient::Config.AppVersion, version_number)) {
+            if (lessThanVersion(HTTPClient::Config.AppVersion, version_number)) {
                 logger.debug("Found update ", version_number, " (", url, ")");
             } else {
                 logger.debug("The app is up to date");
@@ -1564,7 +1564,7 @@ error Context::fetchMessage(const bool periodic) {
             return err;
         }
 
-        if (HTTPSClient::Config.AppVersion.empty()) {
+        if (HTTPClient::Config.AppVersion.empty()) {
             return error("AppVersion missing!");
         }
 
@@ -1575,7 +1575,7 @@ error Context::fetchMessage(const bool periodic) {
         std::string url("");
         std::string appversion("");
         {
-            HTTPSRequest req;
+            HTTPRequest req;
             if ("production" != environment_) {
                 // testing location
                 req.host = "https://indrekv.github.io";
@@ -1586,7 +1586,7 @@ error Context::fetchMessage(const bool periodic) {
             }
 
             TogglClient client;
-            HTTPSResponse resp = client.Get(req);
+            HTTPResponse resp = client.Get(req);
             if (resp.err != noError) {
                 return resp.err;
             }
@@ -1624,19 +1624,19 @@ error Context::fetchMessage(const bool periodic) {
             if (!appversion.empty()) {
                 if (type == 0) {
                     // exactly same version as in message
-                    if (appversion.compare(HTTPSClient::Config.AppVersion) != 0) {
+                    if (appversion.compare(HTTPClient::Config.AppVersion) != 0) {
                         return noError;
                     }
 
                 } else if (type == 1) {
                     // we need older version to show message
-                    if (!lessThanVersion(HTTPSClient::Config.AppVersion, appversion)) {
+                    if (!lessThanVersion(HTTPClient::Config.AppVersion, appversion)) {
                         return noError;
                     }
 
                 } else if (type == 2) {
                     // we need newer version to show message
-                    if (lessThanVersion(HTTPSClient::Config.AppVersion, appversion)) {
+                    if (lessThanVersion(HTTPClient::Config.AppVersion, appversion)) {
                         return noError;
                     }
                 }
@@ -1804,7 +1804,7 @@ void Context::onTimelineUpdateServerSettings(Poco::Util::TimerTask&) {  // NOLIN
     }
 
     // Not implemented in v9 as of 12.05.2017
-    HTTPSRequest req;
+    HTTPRequest req;
     req.host = urls::TimelineUpload();
     req.relative_url = "/api/v8/timeline_settings";
     req.payload = json;
@@ -1812,7 +1812,7 @@ void Context::onTimelineUpdateServerSettings(Poco::Util::TimerTask&) {  // NOLIN
     req.basic_auth_password = "api_token";
 
     TogglClient client(UI());
-    HTTPSResponse resp = client.Post(req);
+    HTTPResponse resp = client.Post(req);
     if (resp.err != noError) {
         displayError(resp.err);
         logger.error(resp.body);
@@ -1868,7 +1868,7 @@ void Context::onSendFeedback(Poco::Util::TimerTask&) {  // NOLINT
     form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
 
     form.set("desktop", "true");
-    form.set("toggl_version", HTTPSClient::Config.AppVersion);
+    form.set("toggl_version", HTTPClient::Config.AppVersion);
     form.set("details", Formatter::EscapeJSONString(feedback_.Details()));
     form.set("subject", Formatter::EscapeJSONString(feedback_.Subject()));
     form.set("date", Formatter::Format8601(time(nullptr)));
@@ -1910,7 +1910,7 @@ void Context::onSendFeedback(Poco::Util::TimerTask&) {  // NOLINT
                      "settings.json"));
 
     // Not implemented in v9 as of 12.05.2017
-    HTTPSRequest req;
+    HTTPRequest req;
     req.host = urls::API();
     req.relative_url ="/api/v8/feedback/web";
     req.basic_auth_username = api_token_value;
@@ -1918,7 +1918,7 @@ void Context::onSendFeedback(Poco::Util::TimerTask&) {  // NOLINT
     req.form = &form;
 
     TogglClient client(UI());
-    HTTPSResponse resp = client.Post(req);
+    HTTPResponse resp = client.Post(req);
     logger.debug("Feedback result: " + resp.err);
     if (resp.err != noError) {
         displayError(resp.err);
@@ -2347,7 +2347,7 @@ void Context::SetEnvironment(const std::string &value) {
     logger.debug("SetEnvironment " + value);
     environment_ = value;
 
-    HTTPSClient::Config.IgnoreCert = ("development" == environment_);
+    HTTPClient::Config.IgnoreCert = ("development" == environment_);
     urls::SetRequestsAllowed("test" != environment_);
 }
 
@@ -4155,7 +4155,7 @@ error Context::OpenReportsInBrowser() {
     }
 
     // Not implemented in v9 as of 12.05.2017
-    HTTPSRequest req;
+    HTTPRequest req;
     req.host = urls::API();
     req.relative_url = "/api/v8/desktop_login_tokens";
     req.payload = "{}";
@@ -4163,7 +4163,7 @@ error Context::OpenReportsInBrowser() {
     req.basic_auth_password = "api_token";
 
     TogglClient client(UI());
-    HTTPSResponse resp = client.Post(req);
+    HTTPResponse resp = client.Post(req);
     if (resp.err != noError) {
         return displayError(resp.err);
     }
@@ -4849,13 +4849,13 @@ void Context::onLoadMore(Poco::Util::TimerTask&) {
         logger.debug("loading more: ", ss.str());
 
         TogglClient client(UI());
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = ss.str();
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = client.Get(req);
+        HTTPResponse resp = client.Get(req);
         if (resp.err != noError) {
             logger.warning(resp.err);
             return;
@@ -5146,14 +5146,14 @@ error Context::pushClients(
         Json::StyledWriter writer;
         client_json = writer.write(clientJson);
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = (*it)->ModelURL();
         req.payload = client_json;
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client.Post(req);
+        HTTPResponse resp = toggl_client.Post(req);
 
         if (resp.err != noError) {
             // if we're able to solve the error
@@ -5203,14 +5203,14 @@ error Context::pushProjects(
         Json::StyledWriter writer;
         project_json = writer.write(projectJson);
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = (*it)->ModelURL();
         req.payload = project_json;
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client.Post(req);
+        HTTPResponse resp = toggl_client.Post(req);
 
         if (resp.err != noError) {
             // if we're able to solve the error
@@ -5282,14 +5282,14 @@ error Context::pushEntries(
 
         // std::cout << entry_json;
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = (*it)->ModelURL();
         req.payload = entry_json;
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp;
+        HTTPResponse resp;
 
         if ((*it)->NeedsDELETE()) {
             req.payload = "";
@@ -5368,7 +5368,7 @@ error Context::pushEntries(
 
 error Context::pullObmExperiments() {
     try {
-        if (HTTPSClient::Config.OBMExperimentNrs.empty()) {
+        if (HTTPClient::Config.OBMExperimentNrs.empty()) {
             logger.debug("No OBM experiment enabled by UI");
             return noError;
         }
@@ -5385,14 +5385,14 @@ error Context::pullObmExperiments() {
             apitoken = user_->APIToken();
         }
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = "/api/v9/me/experiments";
         req.basic_auth_username = apitoken;
         req.basic_auth_password = "api_token";
 
         TogglClient client(UI());
-        HTTPSResponse resp = client.Get(req);
+        HTTPResponse resp = client.Get(req);
         if (resp.err != noError) {
             return resp.err;
         }
@@ -5425,7 +5425,7 @@ error Context::pullObmExperiments() {
 error Context::pushObmAction() {
     try {
         ObmAction *for_upload = nullptr;
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.basic_auth_password = "api_token";
 
@@ -5470,7 +5470,7 @@ error Context::pushObmAction() {
         logger.debug(req.payload);
 
         TogglClient toggl_client;
-        HTTPSResponse resp = toggl_client.Post(req);
+        HTTPResponse resp = toggl_client.Post(req);
         if (resp.err != noError) {
             // backend responds 204 on success
             if (resp.status_code != 204) {
@@ -5519,13 +5519,13 @@ error Context::me(
             ss << "&since=" << since;
         }
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = ss.str();
         req.basic_auth_username = email;
         req.basic_auth_password = password;
 
-        HTTPSResponse resp = toggl_client->Get(req);
+        HTTPResponse resp = toggl_client->Get(req);
         if (resp.err != noError) {
             return resp.err;
         }
@@ -5583,13 +5583,13 @@ error Context::pullWorkspaces(TogglClient* toggl_client) {
     std::string json("");
 
     try {
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = "/api/v9/me/workspaces";
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client->Get(req);
+        HTTPResponse resp = toggl_client->Get(req);
         if (resp.err != noError) {
             if (resp.err.find(kForbiddenError) != std::string::npos) {
                 // User has no workspaces
@@ -5671,13 +5671,13 @@ error Context::pullWorkspacePreferences(
            << workspace->ID()
            << "/preferences";
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = ss.str();
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client->Get(req);
+        HTTPResponse resp = toggl_client->Get(req);
         if (resp.err != noError) {
             return resp.err;
         }
@@ -5707,13 +5707,13 @@ error Context::pullUserPreferences(
     try {
         std::string json("");
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = "/api/v9/me/preferences/desktop";
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client->Get(req);
+        HTTPResponse resp = toggl_client->Get(req);
         if (resp.err != noError) {
             return resp.err;
         }
@@ -5767,7 +5767,7 @@ error Context::signupGoogle(
         Json::Value user;
         user["google_access_token"] = access_token;
         user["created_with"] = Formatter::EscapeJSONString(
-            HTTPSClient::Config.UserAgent());
+            HTTPClient::Config.UserAgent());
         user["tos_accepted"] = true;
         user["country_id"] = Json::UInt64(country_id);
 
@@ -5778,12 +5778,12 @@ error Context::signupGoogle(
         std::stringstream ss;
         ss << "/api/v9/signup?app_name=" << TogglClient::Config.AppName;
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = ss.str();
         req.payload = Json::StyledWriter().write(user);
 
-        HTTPSResponse resp = toggl_client->Post(req);
+        HTTPResponse resp = toggl_client->Post(req);
         if (resp.err != noError) {
             if (kBadRequestError == resp.err) {
                 return resp.body;
@@ -5832,7 +5832,7 @@ error Context::signup(
         user["email"] = email;
         user["password"] = password;
         user["created_with"] = Formatter::EscapeJSONString(
-            HTTPSClient::Config.UserAgent());
+            HTTPClient::Config.UserAgent());
         user["tos_accepted"] = true;
         user["country_id"] = Json::UInt64(country_id);
 
@@ -5840,12 +5840,12 @@ error Context::signup(
         ws["initial_pricing_plan"] = 0;
         user["workspace"] = ws;
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = "/api/v9/signup";
         req.payload = Json::StyledWriter().write(user);
 
-        HTTPSResponse resp = toggl_client->Post(req);
+        HTTPResponse resp = toggl_client->Post(req);
         if (resp.err != noError) {
             if (kBadRequestError == resp.err) {
                 return resp.body;
@@ -5922,13 +5922,13 @@ error Context::ToSAccept() {
 
     TogglClient toggl_client(UI());
     try {
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = "/api/v9/me/accept_tos";
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
-        HTTPSResponse resp = toggl_client.Post(req);
+        HTTPResponse resp = toggl_client.Post(req);
         if (resp.err != noError) {
             return displayError(resp.err);
         }
@@ -5965,10 +5965,10 @@ error Context::PullCountries() {
     try {
         TogglClient toggl_client(UI());
 
-        HTTPSRequest req;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = "/api/v9/countries";
-        HTTPSResponse resp = toggl_client.Get(req);
+        HTTPResponse resp = toggl_client.Get(req);
         if (resp.err != noError) {
             return resp.err;
         }

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <sstream>
+#include <memory>
 
 #include "formatter.h"
 #include "netconf.h"
@@ -88,12 +89,12 @@ void ServerStatus::runActivity() {
         }
 
         // Check server status
-        HTTPSClient client;
-        HTTPSRequest req;
+        HTTPClient client;
+        HTTPRequest req;
         req.host = urls::API();
         req.relative_url = "/api/v9/status";
 
-        HTTPSResponse resp = client.Get(req);
+        HTTPResponse resp = client.Get(req);
         if (noError != resp.err) {
             logger().error(resp.err);
 
@@ -140,18 +141,18 @@ void ServerStatus::UpdateStatus(const Poco::Int64 code) {
     stopStatusCheck("Status code " + std::to_string(code));
 }
 
-HTTPSClientConfig HTTPSClient::Config;
-std::map<std::string, Poco::Timestamp> HTTPSClient::banned_until_;
+HTTPClientConfig HTTPClient::Config;
+std::map<std::string, Poco::Timestamp> HTTPClient::banned_until_;
 
-Logger HTTPSClient::logger() const {
-    return { "HTTPSClient" };
+Logger HTTPClient::logger() const {
+    return { "HTTPClient" };
 }
 
-bool HTTPSClient::isRedirect(const Poco::Int64 status_code) const {
+bool HTTPClient::isRedirect(const Poco::Int64 status_code) const {
     return (status_code >= 300 && status_code < 400);
 }
 
-error HTTPSClient::statusCodeToError(const Poco::Int64 status_code) const {
+error HTTPClient::statusCodeToError(const Poco::Int64 status_code) const {
     switch (status_code) {
     case 200:
     case 201:
@@ -196,40 +197,40 @@ error HTTPSClient::statusCodeToError(const Poco::Int64 status_code) const {
     return kCannotConnectError;
 }
 
-HTTPSResponse HTTPSClient::Post(
-    HTTPSRequest req) const {
+HTTPResponse HTTPClient::Post(
+    HTTPRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_POST;
     return request(req);
 }
 
-HTTPSResponse HTTPSClient::Get(
-    HTTPSRequest req) const {
+HTTPResponse HTTPClient::Get(
+    HTTPRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_GET;
     return request(req);
 }
 
-HTTPSResponse HTTPSClient::GetFile(
-    HTTPSRequest req) const {
+HTTPResponse HTTPClient::GetFile(
+    HTTPRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_GET;
     req.timeout_seconds = kHTTPClientTimeoutSeconds * 10;
     return request(req);
 }
 
-HTTPSResponse HTTPSClient::Delete(
-    HTTPSRequest req) const {
+HTTPResponse HTTPClient::Delete(
+    HTTPRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_DELETE;
     return request(req);
 }
 
-HTTPSResponse HTTPSClient::Put(
-    HTTPSRequest req) const {
+HTTPResponse HTTPClient::Put(
+    HTTPRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_PUT;
     return request(req);
 }
 
-HTTPSResponse HTTPSClient::request(
-    HTTPSRequest req) const {
-    HTTPSResponse resp = makeHttpRequest(req);
+HTTPResponse HTTPClient::request(
+    HTTPRequest req) const {
+    HTTPResponse resp = makeHttpRequest(req);
 
     if (kCannotConnectError == resp.err && isRedirect(resp.status_code)) {
         // Reattempt request to the given location.
@@ -244,10 +245,10 @@ HTTPSResponse HTTPSClient::request(
     return resp;
 }
 
-HTTPSResponse HTTPSClient::makeHttpRequest(
-    HTTPSRequest req) const {
+HTTPResponse HTTPClient::makeHttpRequest(
+    HTTPRequest req) const {
 
-    HTTPSResponse resp;
+    HTTPResponse resp;
 
     if (!urls::RequestsAllowed()) {
         resp.err = error(kCannotSyncInTestEnv);
@@ -282,7 +283,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         resp.err = error("Cannot make a HTTP request without a relative URL");
         return resp;
     }
-    if (HTTPSClient::Config.CACertPath.empty()) {
+    if (HTTPClient::Config.CACertPath.empty()) {
         resp.err = error("Cannot make a HTTP request without certificates");
         return resp;
     }
@@ -296,22 +297,27 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
 
         Poco::Net::Context::VerificationMode verification_mode =
             Poco::Net::Context::VERIFY_RELAXED;
-        if (HTTPSClient::Config.IgnoreCert) {
+        if (HTTPClient::Config.IgnoreCert) {
             verification_mode = Poco::Net::Context::VERIFY_NONE;
         }
         Poco::Net::Context::Ptr context = new Poco::Net::Context(
             Poco::Net::Context::CLIENT_USE, "", "",
-            HTTPSClient::Config.CACertPath,
+            HTTPClient::Config.CACertPath,
             verification_mode, 9, true, "ALL");
 
         Poco::Net::SSLManager::instance().initializeClient(
             nullptr, acceptCertHandler, context);
 
-        Poco::Net::HTTPSClientSession session(uri.getHost(), uri.getPort(),
-                                              context);
+        std::shared_ptr<Poco::Net::HTTPClientSession> session;
+        if (uri.getScheme() == "http") {
+            session = std::make_shared<Poco::Net::HTTPClientSession>(uri.getHost(), uri.getPort());
+        }
+        else {
+            session = std::make_shared<Poco::Net::HTTPSClientSession>(uri.getHost(), uri.getPort(), context);
+        }
 
-        session.setKeepAlive(true);
-        session.setTimeout(
+        session->setKeepAlive(true);
+        session->setTimeout(
             Poco::Timespan(req.timeout_seconds * Poco::Timespan::SECONDS));
 
         logger().debug("Sending request to ", req.host, req.relative_url, " ..");
@@ -319,7 +325,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         std::string encoded_url("");
         Poco::URI::encode(req.relative_url, "", encoded_url);
 
-        error err = Netconf::ConfigureProxy(req.host + encoded_url, &session);
+        error err = Netconf::ConfigureProxy(req.host + encoded_url, session.get());
         if (err != noError) {
             resp.err = error("Error while configuring proxy: " + err);
             logger().error(resp.err);
@@ -335,7 +341,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         if (req.payload.size()) {
             poco_req.setContentType(kContentTypeApplicationJSON);
         }
-        poco_req.set("User-Agent", HTTPSClient::Config.UserAgent());
+        poco_req.set("User-Agent", HTTPClient::Config.UserAgent());
 
         Poco::Net::HTTPBasicCredentials cred(
             req.basic_auth_username, req.basic_auth_password);
@@ -365,10 +371,10 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
                 poco_req.setChunkedTransferEncoding(true);
             }
 
-            session.sendRequest(poco_req) << pBuff << std::flush;
+            session->sendRequest(poco_req) << pBuff << std::flush;
         } else {
             req.form->prepareSubmit(poco_req);
-            std::ostream& send = session.sendRequest(poco_req);
+            std::ostream& send = session->sendRequest(poco_req);
             req.form->write(send);
         }
 
@@ -384,7 +390,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
 
         // Receive response
         Poco::Net::HTTPResponse response;
-        std::istream& is = session.receiveResponse(response);
+        std::istream& is = session->receiveResponse(response);
 
         resp.status_code = response.getStatus();
 
@@ -476,13 +482,13 @@ Logger TogglClient::logger() const {
     return { "TogglClient" };
 }
 
-HTTPSResponse TogglClient::request(
-    HTTPSRequest req) const {
+HTTPResponse TogglClient::request(
+    HTTPRequest req) const {
 
     error err = TogglStatus.Status();
     if (err != noError) {
         logger().error("Will not connect, because of known bad Toggl status: ", err);
-        HTTPSResponse resp;
+        HTTPResponse resp;
         resp.err = err;
         return resp;
     }
@@ -491,7 +497,7 @@ HTTPSResponse TogglClient::request(
         monitor_->DisplaySyncState(kSyncStateWork);
     }
 
-    HTTPSResponse resp = HTTPSClient::request(req);
+    HTTPResponse resp = HTTPClient::request(req);
 
     if (monitor_) {
         monitor_->DisplaySyncState(kSyncStateIdle);

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -59,9 +59,9 @@ class TOGGL_INTERNAL_EXPORT ServerStatus {
     Logger logger() const;
 };
 
-class TOGGL_INTERNAL_EXPORT HTTPSClientConfig {
+class TOGGL_INTERNAL_EXPORT HTTPClientConfig {
  public:
-    HTTPSClientConfig()
+    HTTPClientConfig()
         : AppName("")
     , AppVersion("")
     , UseProxy(false)
@@ -69,7 +69,7 @@ class TOGGL_INTERNAL_EXPORT HTTPSClientConfig {
     , IgnoreCert(false)
     , CACertPath("")
     , AutodetectProxy(true) {}
-    ~HTTPSClientConfig() {}
+    ~HTTPClientConfig() {}
 
     std::string AppName;
     std::string AppVersion;
@@ -93,9 +93,9 @@ class TOGGL_INTERNAL_EXPORT HTTPSClientConfig {
     }
 };
 
-class TOGGL_INTERNAL_EXPORT HTTPSRequest {
+class TOGGL_INTERNAL_EXPORT HTTPRequest {
  public:
-    HTTPSRequest()
+    HTTPRequest()
         : method("")
     , host("")
     , relative_url("")
@@ -104,7 +104,7 @@ class TOGGL_INTERNAL_EXPORT HTTPSRequest {
     , basic_auth_password("")
     , form(nullptr)
     , timeout_seconds(kHTTPClientTimeoutSeconds) {}
-    virtual ~HTTPSRequest() {}
+    virtual ~HTTPRequest() {}
 
     std::string method;
     std::string host;
@@ -116,44 +116,44 @@ class TOGGL_INTERNAL_EXPORT HTTPSRequest {
     Poco::Int64 timeout_seconds;
 };
 
-class TOGGL_INTERNAL_EXPORT HTTPSResponse {
+class TOGGL_INTERNAL_EXPORT HTTPResponse {
  public:
-    HTTPSResponse()
+    HTTPResponse()
         : body("")
     , err(noError)
     , status_code(0) {}
-    virtual ~HTTPSResponse() {}
+    virtual ~HTTPResponse() {}
 
     std::string body;
     error err;
     Poco::Int64 status_code;
 };
 
-class TOGGL_INTERNAL_EXPORT HTTPSClient {
+class TOGGL_INTERNAL_EXPORT HTTPClient {
  public:
-    HTTPSClient() {}
-    virtual ~HTTPSClient() {}
+    HTTPClient() {}
+    virtual ~HTTPClient() {}
 
-    HTTPSResponse Post(
-        HTTPSRequest req) const;
+    HTTPResponse Post(
+        HTTPRequest req) const;
 
-    HTTPSResponse Get(
-        HTTPSRequest req) const;
+    HTTPResponse Get(
+        HTTPRequest req) const;
 
-    HTTPSResponse GetFile(
-        HTTPSRequest req) const;
+    HTTPResponse GetFile(
+        HTTPRequest req) const;
 
-    HTTPSResponse Delete(
-        HTTPSRequest req) const;
+    HTTPResponse Delete(
+        HTTPRequest req) const;
 
-    HTTPSResponse Put(
-        HTTPSRequest req) const;
+    HTTPResponse Put(
+        HTTPRequest req) const;
 
-    static HTTPSClientConfig Config;
+    static HTTPClientConfig Config;
 
  protected:
-    virtual HTTPSResponse request(
-        HTTPSRequest req) const;
+    virtual HTTPResponse request(
+        HTTPRequest req) const;
 
     virtual Logger logger() const;
 
@@ -165,8 +165,8 @@ class TOGGL_INTERNAL_EXPORT HTTPSClient {
 
     bool isRedirect(const Poco::Int64 status_code) const;
 
-    virtual HTTPSResponse makeHttpRequest(
-        HTTPSRequest req) const;
+    virtual HTTPResponse makeHttpRequest(
+        HTTPRequest req) const;
 };
 
 class TOGGL_INTERNAL_EXPORT SyncStateMonitor {
@@ -176,7 +176,7 @@ class TOGGL_INTERNAL_EXPORT SyncStateMonitor {
     virtual void DisplaySyncState(const Poco::Int64 state) = 0;
 };
 
-class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPSClient {
+class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPClient {
  public:
     explicit TogglClient(SyncStateMonitor *monitor = nullptr)
         : monitor_(monitor) {}
@@ -184,8 +184,8 @@ class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPSClient {
     static ServerStatus TogglStatus;
 
  protected:
-    virtual HTTPSResponse request(
-        HTTPSRequest req) const override;
+    virtual HTTPResponse request(
+        HTTPRequest req) const override;
 
     virtual Logger logger() const override;
 

--- a/src/netconf.cc
+++ b/src/netconf.cc
@@ -10,7 +10,7 @@
 #include <Poco/Environment.h>
 #include <Poco/Logger.h>
 #include <Poco/Net/HTTPCredentials.h>
-#include <Poco/Net/HTTPSClientSession.h>
+#include <Poco/Net/HTTPClientSession.h>
 #include <Poco/URI.h>
 #include <Poco/UnicodeConverter.h>
 
@@ -96,12 +96,12 @@ error Netconf::autodetectProxy(
 
 error Netconf::ConfigureProxy(
     const std::string &encoded_url,
-    Poco::Net::HTTPSClientSession *session) {
+    Poco::Net::HTTPClientSession *session) {
 
     Logger logger { "ConfigureProxy" };
 
     std::string proxy_url("");
-    if (HTTPSClient::Config.AutodetectProxy) {
+    if (HTTPClient::Config.AutodetectProxy) {
         if (Poco::Environment::has("HTTPS_PROXY")) {
             proxy_url = Poco::Environment::get("HTTPS_PROXY");
         }
@@ -153,24 +153,24 @@ error Netconf::ConfigureProxy(
     }
 
     // Try to use user-configured proxy
-    if (proxy_url.empty() && HTTPSClient::Config.UseProxy &&
-            HTTPSClient::Config.ProxySettings.IsConfigured()) {
+    if (proxy_url.empty() && HTTPClient::Config.UseProxy &&
+            HTTPClient::Config.ProxySettings.IsConfigured()) {
         session->setProxy(
-            HTTPSClient::Config.ProxySettings.Host(),
+            HTTPClient::Config.ProxySettings.Host(),
             static_cast<Poco::UInt16>(
-                HTTPSClient::Config.ProxySettings.Port()));
+                HTTPClient::Config.ProxySettings.Port()));
 
         logger.debug("Proxy configured ",
-                     " host=", HTTPSClient::Config.ProxySettings.Host(),
-                     " port=", HTTPSClient::Config.ProxySettings.Port());
+                     " host=", HTTPClient::Config.ProxySettings.Host(),
+                     " port=", HTTPClient::Config.ProxySettings.Port());
 
-        if (HTTPSClient::Config.ProxySettings.HasCredentials()) {
+        if (HTTPClient::Config.ProxySettings.HasCredentials()) {
             session->setProxyCredentials(
-                HTTPSClient::Config.ProxySettings.Username(),
-                HTTPSClient::Config.ProxySettings.Password());
+                HTTPClient::Config.ProxySettings.Username(),
+                HTTPClient::Config.ProxySettings.Password());
 
             logger.debug("Proxy credentials configured username=",
-                         HTTPSClient::Config.ProxySettings.Username());
+                         HTTPClient::Config.ProxySettings.Username());
         }
     }
 

--- a/src/netconf.h
+++ b/src/netconf.h
@@ -12,7 +12,7 @@ namespace Poco {
 
 namespace Net {
 
-class HTTPSClientSession;
+class HTTPClientSession;
 
 }  // namespace Net
 
@@ -27,7 +27,7 @@ class TOGGL_INTERNAL_EXPORT Netconf {
 
     static error ConfigureProxy(
         const std::string &encoded_url,
-        Poco::Net::HTTPSClientSession *session);
+        Poco::Net::HTTPClientSession *session);
 
  private:
     static error autodetectProxy(

--- a/src/test/toggl_api_test.cc
+++ b/src/test/toggl_api_test.cc
@@ -424,10 +424,10 @@ TEST(toggl_api, toggl_add_obm_experiment_nr) {
     testing::App app;
 
     toggl_add_obm_experiment_nr(123);
-    ASSERT_EQ("tests/0.1-obm-123", toggl::HTTPSClient::Config.UserAgent());
+    ASSERT_EQ("tests/0.1-obm-123", toggl::HTTPClient::Config.UserAgent());
 
     toggl_add_obm_experiment_nr(456);
-    ASSERT_EQ("tests/0.1-obm-123-obm-456", toggl::HTTPSClient::Config.UserAgent());
+    ASSERT_EQ("tests/0.1-obm-123-obm-456", toggl::HTTPClient::Config.UserAgent());
 }
 
 TEST(toggl_api, toggl_set_settings) {

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -68,7 +68,7 @@ bool TimeEntry::ResolveError(const error &err) {
         return true;
     }
     if (isMissingCreatedWith(err)) {
-        SetCreatedWith(HTTPSClient::Config.UserAgent());
+        SetCreatedWith(HTTPClient::Config.UserAgent());
         return true;
     }
     return false;

--- a/src/timeline_uploader.cc
+++ b/src/timeline_uploader.cc
@@ -87,7 +87,7 @@ error TimelineUploader::upload(TimelineBatch *batch) {
     logger().trace(json);
 
     // Not implemented in v9 as of 12.05.2017
-    HTTPSRequest req;
+    HTTPRequest req;
     req.host = urls::TimelineUpload();
     req.relative_url = "/api/v8/timeline";
     req.payload = json;

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -365,7 +365,7 @@ void toggl_set_cacert_path(
     void *,
     const char_t *path) {
 
-    toggl::HTTPSClient::Config.CACertPath = to_string(path);
+    toggl::HTTPClient::Config.CACertPath = to_string(path);
 }
 
 bool_t toggl_set_db_path(
@@ -517,7 +517,7 @@ bool_t toggl_add_obm_action(
 void toggl_add_obm_experiment_nr(
     const uint64_t nr) {
 
-    toggl::HTTPSClient::Config.OBMExperimentNrs.push_back(nr);
+    toggl::HTTPClient::Config.OBMExperimentNrs.push_back(nr);
 }
 
 char_t *toggl_create_client(

--- a/src/user.cc
+++ b/src/user.cc
@@ -176,7 +176,7 @@ TimeEntry *User::Start(
     ss << "User::Start now=" << now;
 
     TimeEntry *te = new TimeEntry();
-    te->SetCreatedWith(HTTPSClient::Config.UserAgent());
+    te->SetCreatedWith(HTTPClient::Config.UserAgent());
     te->SetDescription(description);
     te->SetUID(ID());
     te->SetPID(project_id);
@@ -251,7 +251,7 @@ TimeEntry *User::Continue(
     time_t now = time(nullptr);
 
     TimeEntry *result = new TimeEntry();
-    result->SetCreatedWith(HTTPSClient::Config.UserAgent());
+    result->SetCreatedWith(HTTPClient::Config.UserAgent());
     result->SetDescription(existing->Description());
     result->SetWID(existing->WID());
     result->SetPID(existing->PID());
@@ -266,7 +266,7 @@ TimeEntry *User::Continue(
         result->SetDurationInSeconds(-now);
     }
 
-    result->SetCreatedWith(HTTPSClient::Config.UserAgent());
+    result->SetCreatedWith(HTTPClient::Config.UserAgent());
 
     related.pushBackTimeEntry(result);
 
@@ -442,7 +442,7 @@ TimeEntry *User::DiscardTimeAt(
 
     if (te && split_into_new_entry) {
         TimeEntry *split = new TimeEntry();
-        split->SetCreatedWith(HTTPSClient::Config.UserAgent());
+        split->SetCreatedWith(HTTPClient::Config.UserAgent());
         split->SetUID(ID());
         split->SetStart(at);
         split->SetDurationInSeconds(-at);

--- a/src/websocket_client.cc
+++ b/src/websocket_client.cc
@@ -76,7 +76,7 @@ void WebSocketClient::Shutdown() {
 error WebSocketClient::createSession() {
     logger().debug("createSession");
 
-    if (HTTPSClient::Config.CACertPath.empty()) {
+    if (HTTPClient::Config.CACertPath.empty()) {
         return error("Missing CA certifcate, cannot start Websocket");
     }
 
@@ -101,21 +101,23 @@ error WebSocketClient::createSession() {
 
         Poco::Net::Context::VerificationMode verification_mode =
             Poco::Net::Context::VERIFY_RELAXED;
-        if (HTTPSClient::Config.IgnoreCert) {
+        if (HTTPClient::Config.IgnoreCert) {
             verification_mode = Poco::Net::Context::VERIFY_NONE;
         }
         Poco::Net::Context::Ptr context = new Poco::Net::Context(
             Poco::Net::Context::CLIENT_USE, "", "",
-            HTTPSClient::Config.CACertPath,
+            HTTPClient::Config.CACertPath,
             verification_mode, 9, true, "ALL");
 
         Poco::Net::SSLManager::instance().initializeClient(
             nullptr, acceptCertHandler, context);
 
-        session_ = new Poco::Net::HTTPSClientSession(
-            uri.getHost(),
-            uri.getPort(),
-            context);
+        if (uri.getScheme() == "http") {
+            session_ = new Poco::Net::HTTPClientSession(uri.getHost(), uri.getPort());
+        }
+        else {
+            session_ = new Poco::Net::HTTPSClientSession(uri.getHost(), uri.getPort(), context);
+        }
 
         Netconf::ConfigureProxy(urls::WebSocket(), session_);
 
@@ -123,7 +125,7 @@ error WebSocketClient::createSession() {
             Poco::Net::HTTPRequest::HTTP_GET, "/ws",
             Poco::Net::HTTPMessage::HTTP_1_1);
         req_->set("Origin", "https://localhost");
-        req_->set("User-Agent", HTTPSClient::Config.UserAgent());
+        req_->set("User-Agent", HTTPClient::Config.UserAgent());
         res_ = new Poco::Net::HTTPResponse();
         ws_ = new Poco::Net::WebSocket(*session_, *req_, *res_);
         ws_->setBlocking(false);

--- a/src/websocket_client.h
+++ b/src/websocket_client.h
@@ -8,13 +8,14 @@
 #include <ctime>
 
 #include <Poco/Activity.h>
+#include <Poco/Net/HTTPClientSession.h>
 
 #include "types.h"
 #include "util/logger.h"
 
 namespace Poco {
     namespace Net {
-        class HTTPSClientSession;
+        class HTTPClientSession;
         class HTTPRequest;
         class HTTPResponse;
         class WebSocket;
@@ -68,7 +69,7 @@ class TOGGL_INTERNAL_EXPORT WebSocketClient {
     Logger logger() const;
 
     Poco::Activity<WebSocketClient> activity_;
-    Poco::Net::HTTPSClientSession *session_;
+    Poco::Net::HTTPClientSession *session_;
     Poco::Net::HTTPRequest *req_;
     Poco::Net::HTTPResponse *res_;
     Poco::Net::WebSocket *ws_;


### PR DESCRIPTION
### 📒 Description
This PR adds HTTP support in addition to HTTPS. I'm running the backend code locally and this will make life a lot easier while testing.
The gist is we now look at the URI scheme from the URIs/URLs returned from `urls.cc` and if it is `http`, we create a `Poco::Net::HTTPClientSession` instead of `Poco::Net::HTTPSClientSession` (which is pretty easy due to polymorphism).
I also renamed all `toggl::HTTPS<x>` classes to `toggl::HTTP<x>` because having the `S` in there would be a lie.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
Test if you can still connect to staging and production as expected. You can also test connecting to a HTTP Toggl server but I think our main API is not accessible over it. Basically just focus on what wold change for the user (and that should be nothing: nothing should change).
