### PR TITLE
Timeline issues on 10.12

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,41 +11,41 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe" customClass="DatePickerView" customModule="TogglDesktop" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="281" height="30"/>
+            <rect key="frame" x="0.0" y="0.0" width="460" height="30"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <box boxType="custom" cornerRadius="8" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="e37-du-upS">
-                    <rect key="frame" x="0.0" y="0.0" width="281" height="30"/>
+                    <rect key="frame" x="0.0" y="0.0" width="460" height="30"/>
                     <view key="contentView" id="thk-uw-xHx">
-                        <rect key="frame" x="1" y="1" width="279" height="28"/>
+                        <rect key="frame" x="1" y="1" width="458" height="28"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <box boxType="custom" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="bMg-Pt-Nuo">
-                                <rect key="frame" x="30" y="-1" width="219" height="30"/>
+                                <rect key="frame" x="30" y="-1" width="398" height="30"/>
                                 <view key="contentView" id="zlB-IK-nNp">
-                                    <rect key="frame" x="1" y="1" width="217" height="28"/>
+                                    <rect key="frame" x="1" y="1" width="396" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <stackView distribution="equalSpacing" orientation="horizontal" alignment="baseline" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LJw-bl-vsP">
-                                            <rect key="frame" x="36" y="2" width="145" height="22"/>
+                                        <stackView distribution="equalSpacing" orientation="horizontal" alignment="top" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LJw-bl-vsP">
+                                            <rect key="frame" x="125" y="1" width="147" height="24"/>
                                             <subviews>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DEI-4B-6HO" customClass="CursorButton" customModule="TogglDesktop" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="3" width="61" height="18"/>
+                                                    <rect key="frame" x="0.0" y="5" width="61" height="17"/>
                                                     <buttonCell key="cell" type="bevel" title="Tuesday," bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="i0g-Ws-dGd">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="system" size="14"/>
+                                                        <font key="font" metaFont="menu" size="14"/>
                                                     </buttonCell>
                                                     <connections>
                                                         <action selector="dayButtonOnTap:" target="c22-O7-iKe" id="QAQ-ei-Qiy"/>
                                                     </connections>
                                                 </button>
                                                 <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6Jw-f6-4jC" customClass="KeyboardDatePicker" customModule="TogglDesktop" customModuleProvider="target">
-                                                    <rect key="frame" x="61" y="0.0" width="84" height="22"/>
+                                                    <rect key="frame" x="61" y="0.0" width="86" height="22"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="22" id="n6b-X9-Tlz"/>
                                                     </constraints>
                                                     <datePickerCell key="cell" alignment="left" drawsBackground="NO" datePickerStyle="textField" id="INP-WY-XWw">
-                                                        <font key="font" size="14" name=".SFNSText"/>
+                                                        <font key="font" metaFont="menu" size="14"/>
                                                         <date key="date" timeIntervalSinceReferenceDate="-569750400">
                                                             <!--1982-12-12 16:00:00 +0000-->
                                                         </date>
@@ -57,6 +57,10 @@
                                                     </connections>
                                                 </datePicker>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="6Jw-f6-4jC" firstAttribute="centerY" secondItem="LJw-bl-vsP" secondAttribute="centerY" constant="1" id="QIw-vX-dvX"/>
+                                                <constraint firstItem="DEI-4B-6HO" firstAttribute="centerY" secondItem="LJw-bl-vsP" secondAttribute="centerY" constant="-1" id="rOD-1P-WEj"/>
+                                            </constraints>
                                             <visibilityPriorities>
                                                 <integer value="1000"/>
                                                 <integer value="1000"/>
@@ -75,7 +79,7 @@
                                 <color key="borderColor" name="upload-border-color"/>
                             </box>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ge4-G4-Vqd">
-                                <rect key="frame" x="249" y="0.0" width="30" height="28"/>
+                                <rect key="frame" x="428" y="0.0" width="30" height="28"/>
                                 <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="next_date_arrow" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="2zx-Kp-QTZ">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -130,7 +134,7 @@
                 <outlet property="nextDateBtn" destination="ge4-G4-Vqd" id="rGp-Hl-Vv9"/>
                 <outlet property="previousDateBtn" destination="eFj-dP-iWE" id="YE6-y4-C9r"/>
             </connections>
-            <point key="canvasLocation" x="238.5" y="154"/>
+            <point key="canvasLocation" x="149" y="154"/>
         </customView>
     </objects>
     <resources>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/LayerBackedViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/LayerBackedViewController.swift
@@ -1,0 +1,24 @@
+//
+//  LayerBackedViewController.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 1/13/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Cocoa
+
+class LayerBackedViewController: NSViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        initCommon()
+    }
+}
+
+extension LayerBackedViewController {
+
+    private func initCommon() {
+        view.wantsLayer = true
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineActivityRecorderViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineActivityRecorderViewController.swift
@@ -13,7 +13,7 @@ protocol TimelineActivityRecorderViewControllerDelegate: class {
     func timelineActivityRecorderShouldDidClickOnCloseBtn(_ sender: Any)
 }
 
-final class TimelineActivityRecorderViewController: NSViewController {
+final class TimelineActivityRecorderViewController: LayerBackedViewController {
 
     private struct Constants {
         static let LearnMoreURL = "https://toggl.com"

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -43,7 +43,7 @@
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oEw-Jd-lIP">
                             <rect key="frame" x="34" y="56" width="101" height="17"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" title="Record activity" id="x0y-gM-oPn">
-                                <font key="font" metaFont="menu" size="14"/>
+                                <font key="font" metaFont="system" size="14"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineActivityHoverController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineActivityHoverController.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-final class TimelineActivityHoverController: NSViewController {
+final class TimelineActivityHoverController: LayerBackedViewController {
 
     private struct Constants {
         static let LeftRightPadding: CGFloat = 20.0

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryHoverViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryHoverViewController.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-final class TimelineTimeEntryHoverViewController: NSViewController {
+final class TimelineTimeEntryHoverViewController: LayerBackedViewController {
 
     // MARK: OUTLET
 

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -290,6 +290,8 @@
 		BAA11AC12251F49E007F31D2 /* WorkspaceStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA11AC02251F49E007F31D2 /* WorkspaceStorage.swift */; };
 		BAA11AC32251F4D6007F31D2 /* WorkspaceAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA11AC22251F4D6007F31D2 /* WorkspaceAutoCompleteTextField.swift */; };
 		BAA11AC52251F502007F31D2 /* WorkspaceDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA11AC42251F502007F31D2 /* WorkspaceDataSource.swift */; };
+		BAA3107223CC476D008F2893 /* LayerBackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA3107123CC476D008F2893 /* LayerBackedViewController.swift */; };
+		BAA3107323CC476D008F2893 /* LayerBackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA3107123CC476D008F2893 /* LayerBackedViewController.swift */; };
 		BAAF567E2223CAC5003D0D73 /* NSButton+TextColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAF567D2223CAC5003D0D73 /* NSButton+TextColor.swift */; };
 		BAAF569E2223D4C7003D0D73 /* DotImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAF569D2223D4C7003D0D73 /* DotImageView.swift */; };
 		BAAF56A02223DF9A003D0D73 /* VertificalTimeEntryFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAF569F2223DF9A003D0D73 /* VertificalTimeEntryFlowLayout.swift */; };
@@ -1011,6 +1013,7 @@
 		BAA11AC02251F49E007F31D2 /* WorkspaceStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStorage.swift; sourceTree = "<group>"; };
 		BAA11AC22251F4D6007F31D2 /* WorkspaceAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceAutoCompleteTextField.swift; sourceTree = "<group>"; };
 		BAA11AC42251F502007F31D2 /* WorkspaceDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDataSource.swift; sourceTree = "<group>"; };
+		BAA3107123CC476D008F2893 /* LayerBackedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerBackedViewController.swift; sourceTree = "<group>"; };
 		BAAC931A22EEF92100E2EE1C /* TogglDesktop.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = TogglDesktop.entitlements; path = TogglDesktop/TogglDesktop.entitlements; sourceTree = "<group>"; };
 		BAAF567D2223CAC5003D0D73 /* NSButton+TextColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSButton+TextColor.swift"; sourceTree = "<group>"; };
 		BAAF569D2223D4C7003D0D73 /* DotImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotImageView.swift; sourceTree = "<group>"; };
@@ -1661,6 +1664,7 @@
 				BA49912D22C0BA14008149D9 /* TimelineDateFormatter.swift */,
 				BA5E988B23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.swift */,
 				BA5E988C23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.xib */,
+				BAA3107123CC476D008F2893 /* LayerBackedViewController.swift */,
 			);
 			path = Timeline;
 			sourceTree = "<group>";
@@ -2425,6 +2429,7 @@
 				BA01E8A1232F77B3006B93EC /* ClickableImageView.m in Sources */,
 				C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */,
 				C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */,
+				BAA3107223CC476D008F2893 /* LayerBackedViewController.swift in Sources */,
 				BAE6379A22B225C70024DD08 /* AddTagButton.swift in Sources */,
 				BA2DA0C621A542E30027B7A5 /* NSTextField+Ext.m in Sources */,
 				747B74871A0AD28200BB3791 /* ConsoleViewController.m in Sources */,
@@ -2779,6 +2784,7 @@
 				BA22EA05239E24EE003551B1 /* TimelineLines.m in Sources */,
 				BA4A7D5423755A4200A42095 /* TouchBarService.swift in Sources */,
 				BAE64DDF2368334000244D2B /* HSBGen.swift in Sources */,
+				BAA3107323CC476D008F2893 /* LayerBackedViewController.swift in Sources */,
 				BAE64DE02368334000244D2B /* GoogleAuthenticationServer.swift in Sources */,
 				BAE64DE12368334000244D2B /* WorkspaceCellView.swift in Sources */,
 				BA22EA01239E24EE003551B1 /* TimelineEventsListItem.m in Sources */,


### PR DESCRIPTION
### 📒 Description
1. There is report on macOS 10.12 that Timeline build crash as soon as the user tries hovering on Timeline Activity.
2. And the Date label in DatePicker Calendar is misalignment

After preliminary investigation, the crash is "Crashing on exception: Vibrant controls require layer-backing when blurring inside the window" from our Custom Background on NSPopover.

### How to fix
1. Make sure we enable layer-backed in all Controller that are supposed to present on NSPopover by `self.view.wantLayer = true`
2. Don't use StackView's alignment `FirstBaseLine` -> Doesn't work in 10.12. We use Top and add center vertical Constraint.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Introduce LayerBackedViewController class and enable layer
- [x] Make sure all controllers in Timeline should be subclassed.
- [x] Fix the misalignment

### 👫 Relationships
Closes #3716

### 🔎 Review hints
- Run and verify the following steps in all macOS (10.11, 10.12, 10.13, 10.14 and 10.15)
1. Archive a build or extract the zip 
[TogglDesktop 2020-01-13 14-01-56.zip](https://github.com/toggl-open-source/toggldesktop/files/4052409/TogglDesktop.2020-01-13.14-01-56.zip)

2. Play around with Timeline (Create TE, enable Timeline Record)
3. Open Popover in Timeline Entry, Timeline Activity and Timeline Activity Recorder Info icon
4. Verify that there is no crash 
5. Verify the Date Picker in Timeline is correct in term of alignment 

### Screenshots
<img width="1056" alt="Screen_Shot_2020-01-13_at_13_52_01" src="https://user-images.githubusercontent.com/5878421/72238064-40ee7480-360f-11ea-98f3-a725353b838e.png">
<img width="1241" alt="Screen_Shot_2020-01-13_at_13_54_37" src="https://user-images.githubusercontent.com/5878421/72238065-40ee7480-360f-11ea-8016-8b7286892d1a.png">


