### PR TITLE
Timeline issues on 10.11

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -180,6 +180,7 @@ final class EditorViewController: NSViewController {
 
     @IBAction func deleteBtnOnTap(_ sender: Any) {
         DesktopLibraryBridge.shared().deleteTimeEntryImte(timeEntry)
+        delegate?.editorShouldClose()
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -85,6 +85,15 @@ class TimelineData {
         }
     }
 
+    func indexPathForItem(with guid: String) -> IndexPath? {
+        for (index, item) in timeEntries.enumerated() {
+            if let timeEntry = item as? TimelineTimeEntry, timeEntry.timeEntry.guid == guid {
+                return IndexPath(item: index, section: Section.timeEntry.rawValue)
+            }
+        }
+        return nil
+    }
+
     func render(with zoomLevel: TimelineDatasource.ZoomLevel) {
         self.zoomLevel = zoomLevel
         timeChunks = generateTimelineLabel(for: start, endDate: end, zoomLevel: zoomLevel)

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -74,7 +74,6 @@ final class TimelineDashboardViewController: NSViewController {
     private lazy var editorPopover: EditorPopover = {
         let popover = EditorPopover()
         popover.animates = false
-        popover.behavior = .semitransient
         popover.prepareViewController()
         popover.delegate = self
         return popover
@@ -430,7 +429,10 @@ extension TimelineDashboardViewController: TimelineCollectionViewDelegate {
 
     func timelineShouldCreateEmptyEntry(with startTime: TimeInterval) {
         // Don't create new TE if one of Popover is active
-        guard isAllPopoverClosed else { return }
+        guard isAllPopoverClosed else {
+            closeAllPopovers()
+            return
+        }
 
         // Create
         startNewTimeEntry(at: startTime, ended: startTime + 1)

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -74,6 +74,7 @@ final class TimelineDashboardViewController: NSViewController {
     private lazy var editorPopover: EditorPopover = {
         let popover = EditorPopover()
         popover.animates = false
+        popover.behavior = .transient
         popover.prepareViewController()
         popover.delegate = self
         return popover

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -372,7 +372,8 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
     func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell) {
         // Make sure all are closed
         closeAllPopoverExceptEditor()
-
+        resetHighlightCells()
+        
         // Close the Editor if we select the same
         let isSameEntry = timeEntry.guid == selectedGUID
         if isSameEntry {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -373,7 +373,7 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
         // Make sure all are closed
         closeAllPopoverExceptEditor()
         resetHighlightCells()
-        
+
         // Close the Editor if we select the same
         let isSameEntry = timeEntry.guid == selectedGUID
         if isSameEntry {
@@ -403,24 +403,13 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
     }
 
     fileprivate func showEditorForTimeEntry(with guid: String) {
-        guard let timeEntries = datasource.timeline?.timeEntries else { return }
-
-        // Get the index for item with guid
-        let foundIndex = timeEntries.firstIndex(where: { entry -> Bool in
-            if let timeEntry = entry as? TimelineTimeEntry,
-                let timeEntryGUID = timeEntry.timeEntry.guid,
-                timeEntryGUID == guid {
-                return true
-            }
-            return false
-        })
-
-        // Get all essential data to present Editor
-        guard let index = foundIndex else { return }
-        let indexPath = IndexPath(item:index, section: TimelineData.Section.timeEntry.rawValue)
-        guard let item = datasource.timeline?.item(at: indexPath) as? TimelineTimeEntry,
-            let cell = collectionView.item(at: indexPath) as? TimelineTimeEntryCell else { return }
-        shouldPresentTimeEntryEditor(in: cell.popoverView, timeEntry: item.timeEntry, cell: cell)
+        selectedGUID = guid
+        if let cell = getSelectedCell() {
+            cell.isHighlight = true
+            let frame = collectionView.convert(cell.popoverView.bounds, from: cell.popoverView)
+            editorPopover.setTimeEntry(cell.timeEntry.timeEntry)
+            editorPopover.show(relativeTo: frame, of: collectionView, preferredEdge: .maxX)
+        }
     }
 
     fileprivate func updatePositionOfEditorIfNeed() {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineCollectionView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineCollectionView.swift
@@ -23,9 +23,10 @@ final class TimelineCollectionView: NSCollectionView {
 
     override func mouseDown(with event: NSEvent) {
         super.mouseDown(with: event)
-        handleMouseClick(with: event)
+        if #available(OSX 10.13, *) {
+            handleMouseClick(with: event)
+        }
     }
-
 }
 
 // MARK: Private


### PR DESCRIPTION
### 📒 Description
This PR fixes some Timeline issues on 10.11

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Improve the way we present the Popover on 10.11
- [x] Disable Click on Empty to create Timeline TE on 10.11 and 10.12
- [x] Refactor

### 🔎 Review hints
- Download: 
[TogglDesktop 2020-01-14 16-08-53.zip](https://github.com/toggl-open-source/toggldesktop/files/4058263/TogglDesktop.2020-01-14.16-08-53.zip)

- Play around the Timeline and make sure it works **perfectly**  in 10.13, 10.14 and 10.15
- Play around on 10.11 and 10.12 and make sure:
-> There is no jump Editor
-> No crash
-> Reasonable to use
