### PR TITLE
Shortcut Timeline and Time Entry list

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -64,11 +64,11 @@
                                     </view>
                                     <color key="fillColor" name="white-background-color"/>
                                 </box>
-                                <button horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ezz-Na-3Er" customClass="PanelSwitcherButton" customModule="TogglDesktop" customModuleProvider="target">
+                                <button toolTip="Time Entry Tab (⌘1)" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ezz-Na-3Er" customClass="PanelSwitcherButton" customModule="TogglDesktop" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="192" height="40"/>
                                     <buttonCell key="cell" type="bevel" title="List" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="lc5-kV-hsA">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="system" size="14"/>
+                                        <font key="font" metaFont="menu" size="14"/>
                                     </buttonCell>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="color" keyPath="selectedTextColor">
@@ -88,11 +88,11 @@
                                         <constraint firstAttribute="height" constant="20" id="u7t-Xu-ij7"/>
                                     </constraints>
                                 </box>
-                                <button horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ph1-05-Qce" customClass="PanelSwitcherButton" customModule="TogglDesktop" customModuleProvider="target">
+                                <button toolTip="Timeline Tab (⌘2)" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ph1-05-Qce" customClass="PanelSwitcherButton" customModule="TogglDesktop" customModuleProvider="target">
                                     <rect key="frame" x="193" y="0.0" width="192" height="40"/>
                                     <buttonCell key="cell" type="bevel" title="Timeline" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="O2U-sp-dei">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="system" size="14"/>
+                                        <font key="font" metaFont="menu" size="14"/>
                                     </buttonCell>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="color" keyPath="titleColor">

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -354,6 +354,16 @@ extern void *ctx;
     [self.mainDashboardViewController.timelineController zoomLevelDecreaseOnChange:sender];
 }
 
+- (IBAction)showTimeEntryTabBtnOnTap:(id)sender
+{
+    [self.mainDashboardViewController listBtnOnTap:sender];
+}
+
+- (IBAction)showTimelineTabBtnOnTap:(id)sender
+{
+    [self.mainDashboardViewController timelineBtnOnTap:sender];
+}
+
 #pragma mark - In app message
 
 - (void)startDisplayInAppMessage:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -240,6 +240,7 @@
                 <menuItem title="Window" id="19">
                     <menu key="submenu" title="Window" systemMenu="window" id="24">
                         <items>
+                            <menuItem isSeparatorItem="YES" id="8qb-je-u7S"/>
                             <menuItem title="Show Time Entry Tab" tag="3" keyEquivalent="1" id="KNi-Lb-k3k">
                                 <connections>
                                     <action selector="showTimeEntryTabBtnOnTap:" target="-1" id="dMt-Zv-OZR"/>
@@ -250,7 +251,7 @@
                                     <action selector="showTimelineTabBtnOnTap:" target="-1" id="dEZ-hf-7ib"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="8qb-je-u7S"/>
+                            <menuItem isSeparatorItem="YES" id="x5X-Qf-2pm"/>
                             <menuItem title="Minimize" keyEquivalent="m" id="23">
                                 <connections>
                                     <action selector="performMiniaturize:" target="-1" id="37"/>

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -224,9 +224,9 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Timeline" id="8ah-bF-5q6">
                         <items>
-                            <menuItem title="Zoom In" tag="3" keyEquivalent="+" id="XUZ-S2-QCm">
+                            <menuItem title="Zoom In" tag="3" keyEquivalent="+" id="7fU-3T-9nR">
                                 <connections>
-                                    <action selector="zoomInBtnOnTap:" target="-1" id="RZ3-A4-bxc"/>
+                                    <action selector="zoomInBtnOnTap:" target="-1" id="UTY-rg-Vkx"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Zoom Out" tag="3" keyEquivalent="-" id="zgY-fo-tDy">
@@ -240,6 +240,17 @@
                 <menuItem title="Window" id="19">
                     <menu key="submenu" title="Window" systemMenu="window" id="24">
                         <items>
+                            <menuItem title="Show Time Entry Tab" tag="3" keyEquivalent="1" id="KNi-Lb-k3k">
+                                <connections>
+                                    <action selector="showTimeEntryTabBtnOnTap:" target="-1" id="dMt-Zv-OZR"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show Timeline Tab" tag="3" keyEquivalent="2" id="X5i-M7-Ccl">
+                                <connections>
+                                    <action selector="showTimelineTabBtnOnTap:" target="-1" id="dEZ-hf-7ib"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="8qb-je-u7S"/>
                             <menuItem title="Minimize" keyEquivalent="m" id="23">
                                 <connections>
                                     <action selector="performMiniaturize:" target="-1" id="37"/>
@@ -250,7 +261,7 @@
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="8qb-je-u7S"/>
+                            <menuItem isSeparatorItem="YES" id="dfp-Zh-saR"/>
                             <menuItem title="Close Window" keyEquivalent="w" id="O2e-Kb-cHX">
                                 <connections>
                                     <action selector="onHideMenuItem:" target="494" id="dJX-ZW-bid"/>
@@ -290,6 +301,7 @@
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="139" y="154"/>
         </menu>
         <customObject id="494" customClass="AppDelegate">
             <connections>


### PR DESCRIPTION
### 📒 Description
This PR introduces the following shortcuts:
- CMD+1: Switch to Time Entry
- CMD+2: Switch to Timeline

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Add menu
- [x] Add shortcut logic
- [x] Add tooltip

### 👫 Relationships
Closes #3720

### 🔎 Review hints
### Able to switch Tab by keyboard
1. When the main windows is focus
2. Verify that CMD + 1 to switch to Time Entry Tab
3. Verify that CMD + 2 to switch to Timeline Tab

### Improvements
- Verify that we have tooltip in Timeline and List tab
- Verify that we have menus in Windows menu

<img width="248" alt="Screen Shot 2020-01-14 at 16 18 42" src="https://user-images.githubusercontent.com/5878421/72331087-2ccb7580-36ea-11ea-8cef-ae227a152329.png">
<img width="607" alt="Screen Shot 2020-01-14 at 16 16 54" src="https://user-images.githubusercontent.com/5878421/72331090-2ccb7580-36ea-11ea-9702-5a89a89a0c48.png">

