### PR TITLE
Add more Menu Context in Timeline

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -238,8 +238,8 @@ void *ctx;
 - (NSString *)starNewTimeEntryAtStarted:(NSTimeInterval)started ended:(NSTimeInterval)ended
 {
 	char *guid = toggl_start(ctx,
-							 @"".UTF8String,
-							 "0",
+							 "",
+							 "",
 							 0,
 							 0,
 							 0,

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -144,7 +144,15 @@ class TimelineData {
     }
 
     func startNewFromEnd(_ timeEntry: TimelineTimeEntry) {
-        NotificationCenter.default.post(name: Notification.Name(kStarTimeEntryWithStartTime), object: timeEntry.timeEntry.ended)
+        // Start a running TE if the TE is today
+        if timeEntry.isToday() {
+            let startTime = timeEntry.end + 1
+            guard let guid = DesktopLibraryBridge.shared().starNewTimeEntry(atStarted: 0, ended: 0) else { return }
+            DesktopLibraryBridge.shared().updateTimeEntryWithStart(atTimestamp: startTime, guid: guid)
+        } else {
+            // Create entry and open Editor
+            NotificationCenter.default.post(name: Notification.Name(kStarTimeEntryWithStartTime), object: timeEntry.timeEntry.ended)
+        }
     }
 
     func delete(_ timeEntry: TimelineTimeEntry) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -138,6 +138,18 @@ class TimelineData {
         DesktopLibraryBridge.shared().updateTimeEntryWithStart(atTimestamp: endAt.timeIntervalSince1970 + 1,
                                                                guid: entry.timeEntry.guid)
     }
+
+    func continueTimeEntry(_ timeEntry: TimelineTimeEntry) {
+        NotificationCenter.default.post(name: NSNotification.Name(kCommandContinue), object: timeEntry.timeEntry.guid)
+    }
+
+    func startNewFromEnd(_ timeEntry: TimelineTimeEntry) {
+        
+    }
+
+    func delete(_ timeEntry: TimelineTimeEntry) {
+        DesktopLibraryBridge.shared().deleteTimeEntryImte(timeEntry.timeEntry)
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -144,7 +144,7 @@ class TimelineData {
     }
 
     func startNewFromEnd(_ timeEntry: TimelineTimeEntry) {
-        
+        NotificationCenter.default.post(name: Notification.Name(kStarTimeEntryWithStartTime), object: timeEntry.timeEntry.ended)
     }
 
     func delete(_ timeEntry: TimelineTimeEntry) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -148,7 +148,12 @@ class TimelineData {
         if timeEntry.isToday() {
             let startTime = timeEntry.end + 1
             guard let guid = DesktopLibraryBridge.shared().starNewTimeEntry(atStarted: 0, ended: 0) else { return }
-            DesktopLibraryBridge.shared().updateTimeEntryWithStart(atTimestamp: startTime, guid: guid)
+
+            // Only set start time if it's not the future
+            // Otherwise, the library code gets buggy
+            if startTime < Date().timeIntervalSince1970 {
+                DesktopLibraryBridge.shared().updateTimeEntryWithStart(atTimestamp: startTime, guid: guid)
+            }
         } else {
             // Create entry and open Editor
             NotificationCenter.default.post(name: Notification.Name(kStarTimeEntryWithStartTime), object: timeEntry.timeEntry.ended)

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -93,4 +93,11 @@ final class TimelineTimeEntry: TimelineBaseTimeEntry {
         super.init(start: timeEntry.started.timeIntervalSince1970,
                    end: timeEntry.ended.timeIntervalSince1970)
     }
+
+    // MARK: Public
+
+    func isToday() -> Bool {
+        guard let date = timeEntry.ended else { return false }
+        return Calendar.current.isDateInToday(date)
+    }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -217,6 +217,10 @@ extension TimelineDashboardViewController {
                                                selector: #selector(self.editorOnChangeNotification(_:)),
                                                name: Notification.Name(kDisplayTimeEntryEditor),
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                       selector: #selector(startTimeEntryNoti(_:)),
+                                       name: Notification.Name(kStarTimeEntryWithStartTime),
+                                       object: nil)
     }
 
     private func initTrackingArea() {
@@ -314,6 +318,11 @@ extension TimelineDashboardViewController {
         guard let selectedGUID = selectedGUID else { return nil }
         guard let indexPath = datasource.timeline?.indexPathForItem(with: selectedGUID) else { return nil }
         return collectionView.item(at: indexPath) as? TimelineTimeEntryCell
+    }
+
+    @objc private func startTimeEntryNoti(_ noti: Notification) {
+        guard let startTime = noti.object as? Date else { return }
+        timelineShouldCreateEmptyEntry(with: startTime.timeIntervalSince1970)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -261,6 +261,18 @@ extension TimelineDatasource: TimelineFlowLayoutDelegate {
 
 extension TimelineDatasource: TimelineTimeEntryCellDelegate {
 
+    func timeEntryCellShouldContinue(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
+
+    }
+
+    func timeEntryCellShouldStartNew(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
+
+    }
+
+    func timeEntryCellShouldDelete(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
+
+    }
+
     func timeEntryCellShouldChangeFirstEntryStopTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
         timeline?.changeFirstEntryStopTime(at: entry)
     }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -262,15 +262,15 @@ extension TimelineDatasource: TimelineFlowLayoutDelegate {
 extension TimelineDatasource: TimelineTimeEntryCellDelegate {
 
     func timeEntryCellShouldContinue(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
-
+        timeline?.continueTimeEntry(entry)
     }
 
     func timeEntryCellShouldStartNew(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
-
+        timeline?.startNewFromEnd(entry)
     }
 
     func timeEntryCellShouldDelete(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
-
+        timeline?.delete(entry)
     }
 
     func timeEntryCellShouldChangeFirstEntryStopTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -114,7 +114,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
         }
 
         // Enable menu if it's overlap Time Entry
-        view.menu = timeEntry.isOverlap ? timeEntryMenu : nil
+        timeEntryMenu.isOverlapMenu = timeEntry.isOverlap
      }
 
     private func hideOutOfBoundControls() {
@@ -195,6 +195,7 @@ extension TimelineTimeEntryCell {
 
     fileprivate func initCommon() {
         timeEntryMenu.menuDelegate = self
+        view.menu = timeEntryMenu
         if let cursorView = foregroundBox as? CursorView {
             cursorView.cursor = NSCursor.pointingHand
         }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -112,9 +112,6 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
             updateLabels(item)
             hideOutOfBoundControls()
         }
-
-        // Enable menu if it's overlap Time Entry
-        timeEntryMenu.isOverlapMenu = timeEntry.isOverlap
      }
 
     private func hideOutOfBoundControls() {
@@ -196,6 +193,7 @@ extension TimelineTimeEntryCell {
     fileprivate func initCommon() {
         timeEntryMenu.menuDelegate = self
         view.menu = timeEntryMenu
+        view.menu?.delegate = self
         if let cursorView = foregroundBox as? CursorView {
             cursorView.cursor = NSCursor.pointingHand
         }
@@ -214,5 +212,15 @@ extension TimelineTimeEntryCell: TimelineTimeEntryMenuDelegate {
     func shouldChangeLastEntryStartTime() {
         guard let timeEntry = timeEntry else { return }
         delegate?.timeEntryCellShouldChangeLastEntryStartTime(for: timeEntry, sender: self)
+    }
+}
+
+// MARK: NSMenuDelegate
+
+extension TimelineTimeEntryCell: NSMenuDelegate {
+
+    func menuWillOpen(_ menu: NSMenu) {
+        // disable some menu if it's overlapped item
+        timeEntryMenu.isOverlapMenu = timeEntry.isOverlap
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -207,28 +207,23 @@ extension TimelineTimeEntryCell {
 
 extension TimelineTimeEntryCell: TimelineTimeEntryMenuDelegate {
     
-    func timelineMenuContinue() {
-        guard let timeEntry = timeEntry else { return }
+    func timelineMenuContinue(_ timeEntry: TimelineTimeEntry) {
         delegate?.timeEntryCellShouldContinue(for: timeEntry, sender: self)
     }
 
-    func timelineMenuStartEntry() {
-        guard let timeEntry = timeEntry else { return }
+    func timelineMenuStartEntry(_ timeEntry: TimelineTimeEntry) {
         delegate?.timeEntryCellShouldStartNew(for: timeEntry, sender: self)
     }
 
-    func timelineMenuDelete() {
-        guard let timeEntry = timeEntry else { return }
+    func timelineMenuDelete(_ timeEntry: TimelineTimeEntry) {
         delegate?.timeEntryCellShouldDelete(for: timeEntry, sender: self)
     }
 
-    func timelineMenuChangeFirstEntryStopTime() {
-        guard let timeEntry = timeEntry else { return }
+    func timelineMenuChangeFirstEntryStopTime(_ timeEntry: TimelineTimeEntry) {
         delegate?.timeEntryCellShouldChangeFirstEntryStopTime(for: timeEntry, sender: self)
     }
 
-    func timelineMenuChangeLastEntryStartTime() {
-        guard let timeEntry = timeEntry else { return }
+    func timelineMenuChangeLastEntryStartTime(_ timeEntry: TimelineTimeEntry) {
         delegate?.timeEntryCellShouldChangeLastEntryStartTime(for: timeEntry, sender: self)
     }
 }
@@ -240,6 +235,7 @@ extension TimelineTimeEntryCell: NSMenuDelegate {
     func menuWillOpen(_ menu: NSMenu) {
         guard let timeEntry = timeEntry else { return }
         // disable some menu if it's overlapped item
+        timeEntryMenu.timeEntry = timeEntry
         timeEntryMenu.isOverlapMenu = timeEntry.isOverlap
         isHighlight = true
     }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -241,5 +241,10 @@ extension TimelineTimeEntryCell: NSMenuDelegate {
         guard let timeEntry = timeEntry else { return }
         // disable some menu if it's overlapped item
         timeEntryMenu.isOverlapMenu = timeEntry.isOverlap
+        isHighlight = true
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        isHighlight = false
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -10,6 +10,9 @@ import Cocoa
 
 protocol TimelineTimeEntryCellDelegate: class {
 
+    func timeEntryCellShouldContinue(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell)
+    func timeEntryCellShouldStartNew(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell)
+    func timeEntryCellShouldDelete(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell)
     func timeEntryCellShouldChangeFirstEntryStopTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell)
     func timeEntryCellShouldChangeLastEntryStartTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell)
 }
@@ -203,13 +206,28 @@ extension TimelineTimeEntryCell {
 // MARK: TimelineTimeEntryMenuDelegate
 
 extension TimelineTimeEntryCell: TimelineTimeEntryMenuDelegate {
+    
+    func timelineMenuContinue() {
+        guard let timeEntry = timeEntry else { return }
+        delegate?.timeEntryCellShouldContinue(for: timeEntry, sender: self)
+    }
 
-    func shouldChangeFirstEntryStopTime() {
+    func timelineMenuStartEntry() {
+        guard let timeEntry = timeEntry else { return }
+        delegate?.timeEntryCellShouldStartNew(for: timeEntry, sender: self)
+    }
+
+    func timelineMenuDelete() {
+        guard let timeEntry = timeEntry else { return }
+        delegate?.timeEntryCellShouldDelete(for: timeEntry, sender: self)
+    }
+
+    func timelineMenuChangeFirstEntryStopTime() {
         guard let timeEntry = timeEntry else { return }
         delegate?.timeEntryCellShouldChangeFirstEntryStopTime(for: timeEntry, sender: self)
     }
 
-    func shouldChangeLastEntryStartTime() {
+    func timelineMenuChangeLastEntryStartTime() {
         guard let timeEntry = timeEntry else { return }
         delegate?.timeEntryCellShouldChangeLastEntryStartTime(for: timeEntry, sender: self)
     }
@@ -220,6 +238,7 @@ extension TimelineTimeEntryCell: TimelineTimeEntryMenuDelegate {
 extension TimelineTimeEntryCell: NSMenuDelegate {
 
     func menuWillOpen(_ menu: NSMenu) {
+        guard let timeEntry = timeEntry else { return }
         // disable some menu if it's overlapped item
         timeEntryMenu.isOverlapMenu = timeEntry.isOverlap
     }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -10,8 +10,11 @@ import Cocoa
 
 protocol TimelineTimeEntryMenuDelegate: class {
 
-    func shouldChangeFirstEntryStopTime()
-    func shouldChangeLastEntryStartTime()
+    func timelineMenuContinue()
+    func timelineMenuStartEntry()
+    func timelineMenuDelete()
+    func timelineMenuChangeFirstEntryStopTime()
+    func timelineMenuChangeLastEntryStartTime()
 }
 
 final class TimelineTimeEntryMenu: NSMenu {
@@ -70,19 +73,22 @@ extension TimelineTimeEntryMenu {
     }
 
     @objc private func continueMenuOnTap() {
+        menuDelegate?.timelineMenuContinue()
     }
 
     @objc private func startEntryOnTap() {
+        menuDelegate?.timelineMenuStartEntry()
     }
 
     @objc private func deleteEntryOnTap() {
+        menuDelegate?.timelineMenuDelete()
     }
 
     @objc private func changeFirstEntryStopTimeOnTap() {
-        menuDelegate?.shouldChangeFirstEntryStopTime()
+        menuDelegate?.timelineMenuChangeFirstEntryStopTime()
     }
 
     @objc private func changeLastEntryStartTimeOnTap() {
-        menuDelegate?.shouldChangeLastEntryStartTime()
+        menuDelegate?.timelineMenuChangeLastEntryStartTime()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -32,6 +32,7 @@ final class TimelineTimeEntryMenu: NSMenu {
 
     init() {
         super.init(title: "Menu")
+        initCommon()
         initSubmenu()
     }
 
@@ -44,8 +45,11 @@ final class TimelineTimeEntryMenu: NSMenu {
 
 extension TimelineTimeEntryMenu {
 
-    fileprivate func initSubmenu() {
+    private func initCommon() {
+        autoenablesItems = false
+    }
 
+    private func initSubmenu() {
         let continueMenu = NSMenuItem(title: "Continue this entry", action: #selector(self.continueMenuOnTap), keyEquivalent: "")
         let startNewMenu = NSMenuItem(title: "Start entry from the end of this entry", action: #selector(self.startEntryOnTap), keyEquivalent: "")
         let deleteMenu = NSMenuItem(title: "Delete", action: #selector(self.deleteEntryOnTap), keyEquivalent: "")

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -22,9 +22,10 @@ final class TimelineTimeEntryMenu: NSMenu {
     // MARK: Variables
 
     weak var menuDelegate: TimelineTimeEntryMenuDelegate?
-    var timeEntry: TimelineTimeEntry?
+    var timeEntry: TimelineTimeEntry? { didSet { updateMenuTitle() }}
     private var conflictChangeFirstMenu: NSMenuItem!
     private var conflictChangeLastMenu: NSMenuItem!
+    private var startNewMenu: NSMenuItem!
     var isOverlapMenu = false {
         didSet {
             conflictChangeFirstMenu.isEnabled = isOverlapMenu
@@ -55,8 +56,8 @@ extension TimelineTimeEntryMenu {
 
     private func initSubmenu() {
         let continueMenu = NSMenuItem(title: "Continue this entry", action: #selector(self.continueMenuOnTap), keyEquivalent: "")
-        let startNewMenu = NSMenuItem(title: "Start entry from the end of this entry", action: #selector(self.startEntryOnTap), keyEquivalent: "")
         let deleteMenu = NSMenuItem(title: "Delete", action: #selector(self.deleteEntryOnTap), keyEquivalent: "")
+        startNewMenu = NSMenuItem(title: "Start entry from the end of this entry", action: #selector(self.startEntryOnTap), keyEquivalent: "")
         conflictChangeFirstMenu = NSMenuItem(title: "Change first entry stop time", action: #selector(self.changeFirstEntryStopTimeOnTap), keyEquivalent: "")
         conflictChangeLastMenu = NSMenuItem(title: "Change last entry start time", action: #selector(self.changeLastEntryStartTimeOnTap), keyEquivalent: "")
 
@@ -71,6 +72,11 @@ extension TimelineTimeEntryMenu {
             item.target = self
             addItem(item)
         }
+    }
+
+    private func updateMenuTitle() {
+        guard let isToday = timeEntry?.isToday() else { return }
+        startNewMenu.title = isToday ? "Start entry from the end of this entry" : "Create entry from the end of this entry"
     }
 
     @objc private func continueMenuOnTap() {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -16,7 +16,19 @@ protocol TimelineTimeEntryMenuDelegate: class {
 
 final class TimelineTimeEntryMenu: NSMenu {
 
+    // MARK: Variables
+
     weak var menuDelegate: TimelineTimeEntryMenuDelegate?
+    private var conflictChangeFirstMenu: NSMenuItem!
+    private var conflictChangeLastMenu: NSMenuItem!
+    var isOverlapMenu = false {
+        didSet {
+            conflictChangeFirstMenu.isEnabled = isOverlapMenu
+            conflictChangeLastMenu.isEnabled = isOverlapMenu
+        }
+    }
+
+    // MARK: Init
 
     init() {
         super.init(title: "Menu")
@@ -33,13 +45,33 @@ final class TimelineTimeEntryMenu: NSMenu {
 extension TimelineTimeEntryMenu {
 
     fileprivate func initSubmenu() {
-        let firstMenuItem = NSMenuItem(title: "Change first entry stop time", action: #selector(self.changeFirstEntryStopTimeOnTap), keyEquivalent: "")
-        firstMenuItem.target = self
-        let secondMenuImte = NSMenuItem(title: "Change last entry start time", action: #selector(self.changeLastEntryStartTimeOnTap), keyEquivalent: "")
-        secondMenuImte.target = self
 
-        addItem(firstMenuItem)
-        addItem(secondMenuImte)
+        let continueMenu = NSMenuItem(title: "Continue this entry", action: #selector(self.continueMenuOnTap), keyEquivalent: "")
+        let startNewMenu = NSMenuItem(title: "Start entry from the end of this entry", action: #selector(self.startEntryOnTap), keyEquivalent: "")
+        let deleteMenu = NSMenuItem(title: "Delete", action: #selector(self.deleteEntryOnTap), keyEquivalent: "")
+        conflictChangeFirstMenu = NSMenuItem(title: "Change first entry stop time", action: #selector(self.changeFirstEntryStopTimeOnTap), keyEquivalent: "")
+        conflictChangeLastMenu = NSMenuItem(title: "Change last entry start time", action: #selector(self.changeLastEntryStartTimeOnTap), keyEquivalent: "")
+
+        // Default items
+        let menus: [NSMenuItem] = [continueMenu,
+                                   startNewMenu,
+                                   deleteMenu,
+                                   NSMenuItem.separator(),
+                                   conflictChangeFirstMenu,
+                                   conflictChangeLastMenu]
+        menus.forEach { item in
+            item.target = self
+            addItem(item)
+        }
+    }
+
+    @objc private func continueMenuOnTap() {
+    }
+
+    @objc private func startEntryOnTap() {
+    }
+
+    @objc private func deleteEntryOnTap() {
     }
 
     @objc private func changeFirstEntryStopTimeOnTap() {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -10,11 +10,11 @@ import Cocoa
 
 protocol TimelineTimeEntryMenuDelegate: class {
 
-    func timelineMenuContinue()
-    func timelineMenuStartEntry()
-    func timelineMenuDelete()
-    func timelineMenuChangeFirstEntryStopTime()
-    func timelineMenuChangeLastEntryStartTime()
+    func timelineMenuContinue(_ timeEntry: TimelineTimeEntry)
+    func timelineMenuStartEntry(_ timeEntry: TimelineTimeEntry)
+    func timelineMenuDelete(_ timeEntry: TimelineTimeEntry)
+    func timelineMenuChangeFirstEntryStopTime(_ timeEntry: TimelineTimeEntry)
+    func timelineMenuChangeLastEntryStartTime(_ timeEntry: TimelineTimeEntry)
 }
 
 final class TimelineTimeEntryMenu: NSMenu {
@@ -22,6 +22,7 @@ final class TimelineTimeEntryMenu: NSMenu {
     // MARK: Variables
 
     weak var menuDelegate: TimelineTimeEntryMenuDelegate?
+    var timeEntry: TimelineTimeEntry?
     private var conflictChangeFirstMenu: NSMenuItem!
     private var conflictChangeLastMenu: NSMenuItem!
     var isOverlapMenu = false {
@@ -73,22 +74,27 @@ extension TimelineTimeEntryMenu {
     }
 
     @objc private func continueMenuOnTap() {
-        menuDelegate?.timelineMenuContinue()
+        guard let timeEntry = timeEntry else { return }
+        menuDelegate?.timelineMenuContinue(timeEntry)
     }
 
     @objc private func startEntryOnTap() {
-        menuDelegate?.timelineMenuStartEntry()
+        guard let timeEntry = timeEntry else { return }
+        menuDelegate?.timelineMenuStartEntry(timeEntry)
     }
 
     @objc private func deleteEntryOnTap() {
-        menuDelegate?.timelineMenuDelete()
+        guard let timeEntry = timeEntry else { return }
+        menuDelegate?.timelineMenuDelete(timeEntry)
     }
 
     @objc private func changeFirstEntryStopTimeOnTap() {
-        menuDelegate?.timelineMenuChangeFirstEntryStopTime()
+        guard let timeEntry = timeEntry else { return }
+        menuDelegate?.timelineMenuChangeFirstEntryStopTime(timeEntry)
     }
 
     @objc private func changeLastEntryStartTimeOnTap() {
-        menuDelegate?.timelineMenuChangeLastEntryStartTime()
+        guard let timeEntry = timeEntry else { return }
+        menuDelegate?.timelineMenuChangeLastEntryStartTime(timeEntry)
     }
 }

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -59,6 +59,7 @@ extern NSString *const kDeselectAllTimeEntryList;
 extern NSString *const kDidAdddManualTimeNotification;
 extern NSString *const kTouchBarSettingChanged;
 extern NSString *const kStartDisplayInAppMessage;
+extern NSString *const kStarTimeEntryWithStartTime;
 
 const char *kFocusedFieldNameDuration;
 const char *kFocusedFieldNameDescription;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -57,6 +57,7 @@ NSString *const kStartDisplayInAppMessage = @"kStartDisplayInAppMessage";
 
 NSString *const kDeselectAllTimeEntryList = @"kDeselectAllTimeEntryList";
 NSString *const kDidAdddManualTimeNotification = @"kDidAdddManualTimeNotification";
+NSString *const kStarTimeEntryWithStartTime = @"kStarTimeEntryWithStartTime";
 
 const char *kFocusedFieldNameDuration = "duration";
 const char *kFocusedFieldNameDescription = "description";


### PR DESCRIPTION
### 📒 Description
This PR introduces some menu items for all Timeline TimeEntry.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality

### 🤯 List of changes
- [x] Add new menu items to Timeline menu
- [x] Normal Timeline TimeEntry and overlapped TimeEntry will have menu context
- [x] Logic for new menu

### 👫 Relationships
Closes #3724

### 🔎 Review hints
#### New menu logic is working normal TimeEntry and Overlapped TimeEntry
1. Right click on normal TimeEntry or Overlapped TimeEntry
2. "Continue" -> Verify that the running TimeEntry is the same 
3. "Start" -> Verify that there is new TE at the end of the selected TE -> Editor is presented
4. "Delete" -> Verify that we could delete the selected TE (or show confirm popup)

#### Overlap menu is disable in normal TimeEntry
1. Right click on normal TimeEntry (no overlap)
2. Verify that the both "Overlap menus" are disabled

<img width="570" alt="Screen Shot 2020-01-15 at 15 19 27" src="https://user-images.githubusercontent.com/5878421/72417433-73cd6f80-37ab-11ea-8677-77e77240c11d.png">

#### Overlap menu is enable in normal TimeEntry
1. Right click on overlapped TimeEntry
2. Verify that the both "Overlap menus" are enabled

<img width="507" alt="Screen Shot 2020-01-15 at 15 19 45" src="https://user-images.githubusercontent.com/5878421/72417475-8c3d8a00-37ab-11ea-8be7-b9a017781d31.png">

