### PR TITLE
Idle notification design update

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Typography.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Typography.xaml
@@ -16,6 +16,9 @@
         <Setter Property="FontSize" Value="24" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.TitleTextBrush}" />
     </Style>
+    <Style TargetType="TextBlock" x:Key="Toggl.SubtitleText" BasedOn="{StaticResource Toggl.Text}">
+        <Setter Property="FontSize" Value="20" />
+    </Style>
     <Style TargetType="TextBlock" x:Key="Toggl.BaseText" BasedOn="{StaticResource Toggl.Text}">
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="FontSize" Value="14" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DialogStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DialogStyles.xaml
@@ -10,23 +10,6 @@
         </Style.Resources>
     </Style>
 
-    <Style TargetType="Window" x:Key="IdleNotification">
-        <Style.Resources>
-            <Style TargetType="Button" BasedOn="{StaticResource RaisedButton}" />
-        </Style.Resources>
-    </Style>
-    
-    <Style TargetType="Window" x:Key="FeedbackWindow">
-        <Style.Resources>
-            <Style TargetType="Button" BasedOn="{StaticResource FlatButton}" />
-
-            <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type Control}}">
-                <Setter Property="BorderThickness" Value="1"/>
-                <Setter Property="Padding" Value="3"/>
-            </Style>
-        </Style.Resources>
-    </Style>
-
     <Style TargetType="{x:Type togglDesktop:TogglNotification}">
         <Setter Property="Template">
             <Setter.Value>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
@@ -3,17 +3,18 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:toggl="clr-namespace:TogglDesktop"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d" 
-        Height="350" Width="280"
-        MinHeight="350" MinWidth="280"
+        Width="340"
+        MinWidth="340"
+        SizeToContent="Height"
         KeyDown="windowKeyDown"
-        Title="Idle Notification"
+        Title="Toggl idle notification"
         WindowStartupLocation="CenterScreen"
-        Topmost="True">
+        Topmost="True"
+        Background="{DynamicResource Toggl.Background}">
     <mah:MetroWindow.Resources>
         <ResourceDictionary Source="../Resources/DesignUpdate/Controls.xaml" />
     </mah:MetroWindow.Resources>
@@ -23,35 +24,44 @@
     <i:Interaction.Behaviors>
         <behaviors:HideWindowOnClosingBehavior />
     </i:Interaction.Behaviors>
-    <Grid Background="{StaticResource ViewBackgroundLight}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-
-        <StackPanel Grid.Row="0" Margin="10">
-            <TextBlock Text="You have been idle since 12:34:56"
-                       Name="timeText" x:FieldModifier="private"
-                       HorizontalAlignment="Center"/>
-            <TextBlock Text="(5 minutes)"
-                       Name="durationText" x:FieldModifier="private"
-                       HorizontalAlignment="Center"/>
-            <TextBlock Text="Running time entry:"
-                       HorizontalAlignment="Center" Margin="0 15 0 5"/>
-            <TextBlock Text="Doing the thing"
-                       Name="descriptionText" x:FieldModifier="private"
-                       HorizontalAlignment="Center" FontWeight="Regular"/>
-        </StackPanel>
-        
-        <StackPanel Grid.Row="1" Margin="8" HorizontalAlignment="Center">
-            <Button Content="KEEP TIME"
-                    Click="onKeepTimeClick"/>
-            <Button Content="DISCARD TIME"
-                    Click="onDiscardTimeClick"/>
-            <Button Content="ADD TIME AS NEW ENTRY"
-                    Click="onAddAsNewClick"/>
-            <Button Content="DISCARD TIME AND CONTINUE"
-                    Click="onDiscardContinueClick"/>
-        </StackPanel>
-    </Grid>
+    <StackPanel Orientation="Vertical"
+                Margin="24 30 24 24">
+        <TextBlock Style="{StaticResource Toggl.SubtitleText}"
+                   Name="timeText" x:FieldModifier="private" />
+        <TextBlock Margin="0 4 0 0"
+                   Style="{StaticResource Toggl.CaptionText}"
+                   Name="durationText" x:FieldModifier="private" />
+        <TextBlock Margin="0 24 0 0"
+                   Style="{StaticResource Toggl.BodyText}"
+                   Text="Running time entry:" />
+        <TextBlock Margin="0 8 0 0"
+                   Style="{StaticResource Toggl.BaseText}"
+                   Name="descriptionText" x:FieldModifier="private" />
+        <TextBlock Margin="0 24 0 0"
+                   Style="{StaticResource Toggl.BodyText}"
+                   Text="What do you want to do with the idle time?" />
+        <Button Margin="0 8 0 0"
+                Style="{StaticResource Toggl.PrimaryButton}"
+                x:Name="keepTimeButton"
+                Content="Keep time"
+                Click="onKeepTimeClick" />
+        <Button Margin="0 8 0 0"
+                Style="{StaticResource Toggl.PrimaryButton}"
+                Content="Discard time"
+                Click="onDiscardTimeClick" />
+        <DockPanel Margin="0 8 0 0">
+            <Button DockPanel.Dock="Left"
+                    HorizontalAlignment="Left"
+                    Style="{StaticResource Toggl.OutlinedButton}"
+                    Width="143"
+                    Content="Discard &amp; continue"
+                    Click="onDiscardContinueClick" />
+            <Button DockPanel.Dock="Right"
+                    HorizontalAlignment="Right"
+                    Style="{StaticResource Toggl.OutlinedButton}"
+                    Width="143"
+                    Content="Add as new entry"
+                    Click="onAddAsNewClick" />
+        </DockPanel>
+    </StackPanel>
 </mah:MetroWindow>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
@@ -1,4 +1,4 @@
-﻿<toggl:TogglWindow x:Class="TogglDesktop.IdleNotificationWindow"
+﻿<mah:MetroWindow x:Class="TogglDesktop.IdleNotificationWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -6,15 +6,20 @@
         xmlns:toggl="clr-namespace:TogglDesktop"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
+        xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d" 
         Height="350" Width="280"
         MinHeight="350" MinWidth="280"
         KeyDown="windowKeyDown"
-        IsToolWindow="True"
         Title="Idle Notification"
         WindowStartupLocation="CenterScreen"
-        Topmost="True"
-        Style="{StaticResource IdleNotification}">
+        Topmost="True">
+    <mah:MetroWindow.Resources>
+        <ResourceDictionary Source="../Resources/DesignUpdate/Controls.xaml" />
+    </mah:MetroWindow.Resources>
+    <mah:MetroWindow.Style>
+        <StaticResource ResourceKey="Toggl.ToolWindow" />
+    </mah:MetroWindow.Style>
     <i:Interaction.Behaviors>
         <behaviors:HideWindowOnClosingBehavior />
     </i:Interaction.Behaviors>
@@ -23,9 +28,6 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-
-        <toggl:TogglChromeDesignTimeConverter
-            Title="Idle Notification" IsToolWindow="True" />
 
         <StackPanel Grid.Row="0" Margin="10">
             <TextBlock Text="You have been idle since 12:34:56"
@@ -52,4 +54,4 @@
                     Click="onDiscardContinueClick"/>
         </StackPanel>
     </Grid>
-</toggl:TogglWindow>
+</mah:MetroWindow>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Threading;
+using ControlzEx;
 
 namespace TogglDesktop
 {
@@ -35,6 +34,7 @@ namespace TogglDesktop
             this.Show();
             this.Topmost = true;
             this.Activate();
+            KeyboardNavigationEx.Focus(this.keepTimeButton);
         }
 
         protected override void OnDeactivated(EventArgs e)


### PR DESCRIPTION
### 📒 Description
Implementation of Idle notification window design update.

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Updated design of Idle notification window
- [x] Moved from custom `TogglWindow` to `MetroWindow`
- [x] Made sure initial button's focus visual style is shown

### 👫 Relationships
Closes #3708.

### 🔎 Review hints
- Make sure Idle notification window matches the design in Zeplin.
- Make sure the functionality of Idle notification window still works as expected without changes.

To see the idle notification window: set 1 min in Preferences->Idle detection, start time entry and wait >1min.

Note: Showing project information requires changes in the library, as does formatting the time passed, so they are moved to separate tickets: #3736, #3733. These changes are not directly related to the Windows design update and are relevant for other platforms as well.