### PR TITLE
Timeline upload issues

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -25,7 +25,7 @@
 #define kTimelineChunkSeconds 900
 #define kEnterpriseInstall false
 #define kDebianPackage (TOGGL_BUILD_TYPE == std::string("deb"))
-#define kTimelineUploadIntervalSeconds 300
+#define kTimelineUploadIntervalSeconds 60
 #define kTimelineUploadMaxBackoffSeconds (kTimelineUploadIntervalSeconds * 10)  // NOLINT
 #define kMaxFileSize 5242880  // 5MB
 #define kMaxDurationSeconds (999 * 3600)

--- a/src/const.h
+++ b/src/const.h
@@ -25,7 +25,7 @@
 #define kTimelineChunkSeconds 900
 #define kEnterpriseInstall false
 #define kDebianPackage (TOGGL_BUILD_TYPE == std::string("deb"))
-#define kTimelineUploadIntervalSeconds 60
+#define kTimelineUploadIntervalSeconds 300
 #define kTimelineUploadMaxBackoffSeconds (kTimelineUploadIntervalSeconds * 10)  // NOLINT
 #define kMaxFileSize 5242880  // 5MB
 #define kMaxDurationSeconds (999 * 3600)

--- a/src/context.cc
+++ b/src/context.cc
@@ -4615,7 +4615,7 @@ error Context::CreateCompressedTimelineBatchForUpload(TimelineBatch *batch) {
             return displayError(err);
         }
 
-        batch->SetEvents(user_->CompressedTimelineForUpload(nullptr));
+        batch->SetEvents(user_->CompressedTimelineForUpload());
         batch->SetUserID(user_->ID());
         batch->SetAPIToken(user_->APIToken());
         batch->SetDesktopID(db_->DesktopID());

--- a/src/context.cc
+++ b/src/context.cc
@@ -855,7 +855,7 @@ void Context::updateUI(const UIElements &what) {
         if (what.display_timeline && user_) {
             // Get Timeline data
             Poco::LocalDateTime date(UI()->TimelineDateAt());
-            timeline = user_->CompressedTimeline(&date);
+            timeline = user_->CompressedTimelineForUI(&date);
 
             // Get a sorted list of time entries
             std::vector<TimeEntry *> time_entries =
@@ -4615,7 +4615,7 @@ error Context::CreateCompressedTimelineBatchForUpload(TimelineBatch *batch) {
             return displayError(err);
         }
 
-        batch->SetEvents(user_->CompressedTimeline());
+        batch->SetEvents(user_->CompressedTimelineForUpload(nullptr));
         batch->SetUserID(user_->ID());
         batch->SetAPIToken(user_->APIToken());
         batch->SetDesktopID(db_->DesktopID());

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -174,7 +174,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     db.instance()->SaveUser(&user, true, &changes);
 
     user.CompressTimeline();
-    std::vector<TimelineEvent> timeline_events = user.CompressedTimeline();
+    std::vector<TimelineEvent> timeline_events = user.CompressedTimelineForUpload();
 
     if (timeline_events.size() != 1) {
         std::cerr << "user.related.TimelineEvents:" << std::endl;
@@ -185,7 +185,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
             std::cerr << ev->String() << std::endl;
         }
 
-        std::cerr << "user.CompressedTimeline:" << std::endl;
+        std::cerr << "user.CompressedTimelineForUpload:" << std::endl;
         for (std::vector<TimelineEvent>::const_iterator it =
             timeline_events.begin();
                 it != timeline_events.end(); it++) {
@@ -199,7 +199,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     // Compress some more, for fun and profit
     for (int i = 0; i < 100; i++) {
         user.CompressTimeline();
-        timeline_events = user.CompressedTimeline();
+        timeline_events = user.CompressedTimelineForUpload();
     }
 
     ASSERT_EQ(size_t(1), timeline_events.size());
@@ -226,7 +226,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     user.MarkTimelineBatchAsUploaded(timeline_events);
 
     // Now, no more events should exist for upload
-    std::vector<TimelineEvent> left_for_upload = user.CompressedTimeline();
+    std::vector<TimelineEvent> left_for_upload = user.CompressedTimelineForUpload();
     ASSERT_EQ(std::size_t(0), left_for_upload.size());
 }
 

--- a/src/user.cc
+++ b/src/user.cc
@@ -1441,7 +1441,7 @@ std::vector<TimelineEvent> User::CompressedTimeline(const Poco::LocalDateTime *d
             continue;
         }
 
-        if (is_for_upload && event->Uploaded()) {
+        if (is_for_upload && !event->VisibleToUser()) {
             continue;
         }
 

--- a/src/user.cc
+++ b/src/user.cc
@@ -1419,8 +1419,15 @@ void User::CompressTimeline() {
     }
 }
 
-std::vector<TimelineEvent> User::CompressedTimeline(
-    const Poco::LocalDateTime *date) const {
+std::vector<TimelineEvent> User::CompressedTimelineForUI(const Poco::LocalDateTime *date) const {
+    return CompressedTimeline(date, false);
+}
+
+std::vector<TimelineEvent> User::CompressedTimelineForUpload(const Poco::LocalDateTime *date) const {
+    return CompressedTimeline(date, true);
+}
+
+std::vector<TimelineEvent> User::CompressedTimeline(const Poco::LocalDateTime *date, bool is_for_upload) const {
     std::vector<TimelineEvent> list;
     for (std::vector<TimelineEvent *>::const_iterator i =
         related.TimelineEvents.begin();
@@ -1428,7 +1435,13 @@ std::vector<TimelineEvent> User::CompressedTimeline(
             ++i) {
         TimelineEvent *event = *i;
         poco_check_ptr(event);
+
+        // Skip if this event is deleted or uploaded
         if (event->DeletedAt() > 0) {
+            continue;
+        }
+
+        if (is_for_upload && event->Uploaded()) {
             continue;
         }
 

--- a/src/user.h
+++ b/src/user.h
@@ -198,7 +198,7 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     void CompressTimeline();
 
     std::vector<TimelineEvent> CompressedTimelineForUI(const Poco::LocalDateTime *date) const;
-    std::vector<TimelineEvent> CompressedTimelineForUpload(const Poco::LocalDateTime *date) const;
+    std::vector<TimelineEvent> CompressedTimelineForUpload(const Poco::LocalDateTime *date = nullptr) const;
 
     error UpdateJSON(
         std::vector<TimeEntry *> * const,

--- a/src/user.h
+++ b/src/user.h
@@ -196,8 +196,9 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     void MarkTimelineBatchAsUploaded(
         const std::vector<TimelineEvent> &events);
     void CompressTimeline();
-    std::vector<TimelineEvent> CompressedTimeline(
-        const Poco::LocalDateTime *date = nullptr) const;
+
+    std::vector<TimelineEvent> CompressedTimelineForUI(const Poco::LocalDateTime *date) const;
+    std::vector<TimelineEvent> CompressedTimelineForUpload(const Poco::LocalDateTime *date) const;
 
     error UpdateJSON(
         std::vector<TimeEntry *> * const,
@@ -312,6 +313,9 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     std::string generateKey(const std::string &password);
 
     void loadObmExperimentFromJson(Json::Value const &obm);
+
+    std::vector<TimelineEvent> CompressedTimeline(
+        const Poco::LocalDateTime *date = nullptr, bool is_for_upload = true) const;
 
     std::string api_token_;
     Poco::UInt64 default_wid_;


### PR DESCRIPTION
### 📒 Description
This PR would fix all possible upload timeline issues in order to improve performance / reduce the stress on the server.

Issues:
- [x] Don't upload the Events, which are already uploaded 
- [ ] ~Double check why the chunk 15 mins isn't working anymore~ -> There is no 15 interval for Timeline uploading.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Fix the way we get the event for uploading (ignore the uploaded=1)
- [x] Change the interval to 5 mins

### 👫 Relationships
No ticket yet

### 🔎 Review hints
### Make sure the app only upload events, which are not uploaded
1. Install Proxyman.io
2. Start TogglDesktop in Xcode (only work with debug build since the Production build has SSL-pinning to prevent Mitm)
3. Enable Timeline Recorder 
4. Open local database 
5. Observer after the interval, there is `v8/timeline` requests and the body only contains the new event.

<img width="2032" alt="Screen Shot 2020-01-16 at 16 17 52" src="https://user-images.githubusercontent.com/5878421/72515161-fcb6da80-3881-11ea-9df3-ce18522006f8.png">


