### PR TITLE
Tracking user activity

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -340,11 +340,19 @@ void Analytics::TrackDeleteTimeEntry(const std::string &client_id) {
 }
 
 void Analytics::TrackLoginWithUsernamePassword(const std::string &client_id) {
-    TrackUserAuthentication(client_id, "username_password");
+    TrackUserAuthentication(client_id, "login", "username_password");
 }
 
 void Analytics::TrackLoginWithGoogle(const std::string &client_id) {
-    TrackUserAuthentication(client_id, "google");
+    TrackUserAuthentication(client_id, "login", "google");
+}
+
+void Analytics::TrackSignupWithUsernamePassword(const std::string &client_id) {
+    TrackUserAuthentication(client_id, "signup", "username_password");
+}
+
+void Analytics::TrackSignupWithGoogle(const std::string &client_id) {
+    TrackUserAuthentication(client_id, "signup", "google");
 }
 
 void Analytics::TrackTimeEntryActiity(const std::string &client_id, const std::string &action) {
@@ -353,9 +361,9 @@ void Analytics::TrackTimeEntryActiity(const std::string &client_id, const std::s
     Track(client_id, "time_entry", ss.str());
 }
 
-void Analytics::TrackUserAuthentication(const std::string &client_id, const std::string &action) {
+void Analytics::TrackUserAuthentication(const std::string &client_id, const std::string &action, const std::string &from) {
     std::stringstream ss;
-    ss << "login" << "/" << action;
+    ss << action << "/" << from;
     Track(client_id, "user", ss.str());
 }
 

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -327,36 +327,16 @@ void GoogleAnalyticsSettingsEvent::makeReq() {
     }
 }
 
-void Analytics::TrackActiveView(const std::string &client_id, const uint8_t tabIndex) {
-    if (tabIndex == 0) {
-        TrackActiveTimeEntryListView(client_id);
-    } else {
-        TrackActiveTimelineView(client_id);
-    }
+void Analytics::TrackStartTimeEntry(const std::string &client_id, const uint8_t tab_index) {
+    TrackTimeEntryActivity(client_id, "start", tab_index);
 }
 
-void Analytics::TrackActiveTimeEntryListView(const std::string &client_id) {
-    std::stringstream ss;
-    ss << "list-view/start";
-    Track(client_id, "list-view", ss.str());
+void Analytics::TrackEditTimeEntry(const std::string &client_id, const uint8_t tab_index) {
+    TrackTimeEntryActivity(client_id, "edit", tab_index);
 }
 
-void Analytics::TrackActiveTimelineView(const std::string &client_id) {
-    std::stringstream ss;
-    ss << "timeline-view/start";
-    Track(client_id, "timeline-view", ss.str());
-}
-
-void Analytics::TrackStartTimeEntry(const std::string &client_id) {
-    TrackTimeEntryActivity(client_id, "start");
-}
-
-void Analytics::TrackEditTimeEntry(const std::string &client_id) {
-    TrackTimeEntryActivity(client_id, "edit");
-}
-
-void Analytics::TrackDeleteTimeEntry(const std::string &client_id) {
-    TrackTimeEntryActivity(client_id, "delete");
+void Analytics::TrackDeleteTimeEntry(const std::string &client_id, const uint8_t tab_index) {
+    TrackTimeEntryActivity(client_id, "delete", tab_index);
 }
 
 void Analytics::TrackLoginWithUsernamePassword(const std::string &client_id) {
@@ -375,10 +355,11 @@ void Analytics::TrackSignupWithGoogle(const std::string &client_id) {
     TrackUserAuthentication(client_id, "signup", "google");
 }
 
-void Analytics::TrackTimeEntryActivity(const std::string &client_id, const std::string &action) {
+void Analytics::TrackTimeEntryActivity(const std::string &client_id, const std::string &action, const uint8_t tab_index) {
+    std::string active_view = tab_index == 0 ? "list-view" : "timeline-view";
     std::stringstream ss;
-    ss << "time_entry" << "/" << action;
-    Track(client_id, "time_entry", ss.str());
+    ss << active_view << "/" << action;
+    Track(client_id, active_view, ss.str());
 }
 
 void Analytics::TrackUserAuthentication(const std::string &client_id, const std::string &action, const std::string &from) {

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -327,4 +327,36 @@ void GoogleAnalyticsSettingsEvent::makeReq() {
     }
 }
 
+void Analytics::TrackStartTimeEntry(const std::string &client_id) {
+    TrackTimeEntryActiity(client_id, "start");
+}
+
+void Analytics::TrackEditTimeEntry(const std::string &client_id) {
+    TrackTimeEntryActiity(client_id, "edit");
+}
+
+void Analytics::TrackDeleteTimeEntry(const std::string &client_id) {
+    TrackTimeEntryActiity(client_id, "delete");
+}
+
+void Analytics::TrackLoginWithUsernamePassword(const std::string &client_id) {
+    TrackUserAuthentication(client_id, "username_password");
+}
+
+void Analytics::TrackLoginWithGoogle(const std::string &client_id) {
+    TrackUserAuthentication(client_id, "google");
+}
+
+void Analytics::TrackTimeEntryActiity(const std::string &client_id, const std::string &action) {
+    std::stringstream ss;
+    ss << "time_entry" << "/" << action;
+    Track(client_id, "time_entry", ss.str());
+}
+
+void Analytics::TrackUserAuthentication(const std::string &client_id, const std::string &action) {
+    std::stringstream ss;
+    ss << "login" << "/" << action;
+    Track(client_id, "user", ss.str());
+}
+
 }  // namespace toggl

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -327,6 +327,26 @@ void GoogleAnalyticsSettingsEvent::makeReq() {
     }
 }
 
+void Analytics::TrackActiveView(const std::string &client_id, const uint8_t tabIndex) {
+    if (tabIndex == 0) {
+        TrackActiveTimeEntryListView(client_id);
+    } else {
+        TrackActiveTimelineView(client_id);
+    }
+}
+
+void Analytics::TrackActiveTimeEntryListView(const std::string &client_id) {
+    std::stringstream ss;
+    ss << "list-view/start";
+    Track(client_id, "list-view", ss.str());
+}
+
+void Analytics::TrackActiveTimelineView(const std::string &client_id) {
+    std::stringstream ss;
+    ss << "timeline-view/start";
+    Track(client_id, "timeline-view", ss.str());
+}
+
 void Analytics::TrackStartTimeEntry(const std::string &client_id) {
     TrackTimeEntryActivity(client_id, "start");
 }

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -328,15 +328,15 @@ void GoogleAnalyticsSettingsEvent::makeReq() {
 }
 
 void Analytics::TrackStartTimeEntry(const std::string &client_id) {
-    TrackTimeEntryActiity(client_id, "start");
+    TrackTimeEntryActivity(client_id, "start");
 }
 
 void Analytics::TrackEditTimeEntry(const std::string &client_id) {
-    TrackTimeEntryActiity(client_id, "edit");
+    TrackTimeEntryActivity(client_id, "edit");
 }
 
 void Analytics::TrackDeleteTimeEntry(const std::string &client_id) {
-    TrackTimeEntryActiity(client_id, "delete");
+    TrackTimeEntryActivity(client_id, "delete");
 }
 
 void Analytics::TrackLoginWithUsernamePassword(const std::string &client_id) {
@@ -355,7 +355,7 @@ void Analytics::TrackSignupWithGoogle(const std::string &client_id) {
     TrackUserAuthentication(client_id, "signup", "google");
 }
 
-void Analytics::TrackTimeEntryActiity(const std::string &client_id, const std::string &action) {
+void Analytics::TrackTimeEntryActivity(const std::string &client_id, const std::string &action) {
     std::stringstream ss;
     ss << "time_entry" << "/" << action;
     Track(client_id, "time_entry", ss.str());

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -82,7 +82,7 @@ class Analytics : public Poco::TaskManager {
                    const std::string &name,
                    const toggl::Rectangle rect);
 
-    void TrackTimeEntryActiity(const std::string &client_id,
+    void TrackTimeEntryActivity(const std::string &client_id,
                                const std::string &action);
 
 

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -66,14 +66,17 @@ class Analytics : public Poco::TaskManager {
                        const std::string &os,
                        const toggl::Rectangle rect);
 
-    void TrackStartTimeEntry(const std::string &client_id);
-    void TrackEditTimeEntry(const std::string &client_id);
-    void TrackDeleteTimeEntry(const std::string &client_id);
+    void TrackStartTimeEntry(const std::string &client_id,
+                             const uint8_t tab_index);
+    void TrackEditTimeEntry(const std::string &client_id,
+                            const uint8_t tab_index);
+    void TrackDeleteTimeEntry(const std::string &client_id,
+                              const uint8_t tab_index);
+
     void TrackLoginWithUsernamePassword(const std::string &client_id);
     void TrackLoginWithGoogle(const std::string &client_id);
     void TrackSignupWithUsernamePassword(const std::string &client_id);
     void TrackSignupWithGoogle(const std::string &client_id);
-    void TrackActiveView(const std::string &client_id, const uint8_t tabIndex);
 
  private:
     Poco::LocalDateTime settings_sync_date;
@@ -84,15 +87,12 @@ class Analytics : public Poco::TaskManager {
                    const toggl::Rectangle rect);
 
     void TrackTimeEntryActivity(const std::string &client_id,
-                               const std::string &action);
-
+                                const std::string &action,
+                                const uint8_t tab_index);
 
     void TrackUserAuthentication(const std::string &client_id,
                                  const std::string &action,
                                  const std::string &from);
-
-    void TrackActiveTimeEntryListView(const std::string &client_id);
-    void TrackActiveTimelineView(const std::string &client_id);
 };
 
 class GoogleAnalyticsEvent : public Poco::Task {

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -66,6 +66,12 @@ class Analytics : public Poco::TaskManager {
                        const std::string &os,
                        const toggl::Rectangle rect);
 
+    void TrackStartTimeEntry(const std::string &client_id);
+    void TrackEditTimeEntry(const std::string &client_id);
+    void TrackDeleteTimeEntry(const std::string &client_id);
+    void TrackLoginWithUsernamePassword(const std::string &client_id);
+    void TrackLoginWithGoogle(const std::string &client_id);
+
  private:
     Poco::LocalDateTime settings_sync_date;
 
@@ -73,6 +79,13 @@ class Analytics : public Poco::TaskManager {
                    const std::string &os,
                    const std::string &name,
                    const toggl::Rectangle rect);
+
+    void TrackTimeEntryActiity(const std::string &client_id,
+                               const std::string &action);
+
+
+    void TrackUserAuthentication(const std::string &client_id,
+                                 const std::string &action);
 };
 
 class GoogleAnalyticsEvent : public Poco::Task {

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -71,6 +71,8 @@ class Analytics : public Poco::TaskManager {
     void TrackDeleteTimeEntry(const std::string &client_id);
     void TrackLoginWithUsernamePassword(const std::string &client_id);
     void TrackLoginWithGoogle(const std::string &client_id);
+    void TrackSignupWithUsernamePassword(const std::string &client_id);
+    void TrackSignupWithGoogle(const std::string &client_id);
 
  private:
     Poco::LocalDateTime settings_sync_date;
@@ -85,7 +87,8 @@ class Analytics : public Poco::TaskManager {
 
 
     void TrackUserAuthentication(const std::string &client_id,
-                                 const std::string &action);
+                                 const std::string &action,
+                                 const std::string &from);
 };
 
 class GoogleAnalyticsEvent : public Poco::Task {

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -73,6 +73,7 @@ class Analytics : public Poco::TaskManager {
     void TrackLoginWithGoogle(const std::string &client_id);
     void TrackSignupWithUsernamePassword(const std::string &client_id);
     void TrackSignupWithGoogle(const std::string &client_id);
+    void TrackActiveView(const std::string &client_id, const uint8_t tabIndex);
 
  private:
     Poco::LocalDateTime settings_sync_date;
@@ -89,6 +90,9 @@ class Analytics : public Poco::TaskManager {
     void TrackUserAuthentication(const std::string &client_id,
                                  const std::string &action,
                                  const std::string &from);
+
+    void TrackActiveTimeEntryListView(const std::string &client_id);
+    void TrackActiveTimelineView(const std::string &client_id);
 };
 
 class GoogleAnalyticsEvent : public Poco::Task {

--- a/src/context.cc
+++ b/src/context.cc
@@ -5846,6 +5846,10 @@ error Context::signupGoogle(
         }
 
         *user_data_json = resp.body;
+
+        if ("production" == environment_) {
+            analytics_.TrackSignupWithGoogle(db_->AnalyticsClientID());
+        }
     }
     catch (const Poco::Exception& exc) {
         return exc.displayText();
@@ -5904,6 +5908,10 @@ error Context::signup(
         }
 
         *user_data_json = resp.body;
+
+        if ("production" == environment_) {
+            analytics_.TrackSignupWithUsernamePassword(db_->AnalyticsClientID());
+        }
     } catch(const Poco::Exception& exc) {
         return exc.displayText();
     } catch(const std::exception& ex) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -2511,6 +2511,15 @@ error Context::Login(
                 return displayError(err);
             }
         }
+
+        if ("production" == environment_) {
+            if (password.compare("google_access_token") == 0) {
+                analytics_.TrackLoginWithGoogle(db_->AnalyticsClientID());
+            } else {
+                analytics_.TrackLoginWithUsernamePassword(db_->AnalyticsClientID());
+            }
+        }
+
         overlay_visible_ = false;
         return displayError(save(false));
     } catch(const Poco::Exception& exc) {
@@ -2842,6 +2851,7 @@ TimeEntry *Context::Start(
     if ("production" == environment_) {
         analytics_.TrackAutocompleteUsage(db_->AnalyticsClientID(),
                                           task_id || project_id);
+        analytics_.TrackStartTimeEntry(db_->AnalyticsClientID());
     }
 
     OpenTimeEntryList();
@@ -2909,6 +2919,10 @@ void Context::OpenTimeEntryEditor(
 
         render.open_time_entry_list = true;
         render.display_time_entries = true;
+    }
+
+    if ("production" == environment_) {
+        analytics_.TrackEditTimeEntry(db_->AnalyticsClientID());
     }
 
     updateUI(render);
@@ -3079,6 +3093,11 @@ error Context::DeleteTimeEntryByGUID(const std::string &GUID) {
     }
     te->ClearValidationError();
     te->Delete();
+
+    if ("production" == environment_) {
+        analytics_.TrackDeleteTimeEntry(db_->AnalyticsClientID());
+    }
+
     return displayError(save(true));
 }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -2851,8 +2851,7 @@ TimeEntry *Context::Start(
     if ("production" == environment_) {
         analytics_.TrackAutocompleteUsage(db_->AnalyticsClientID(),
                                           task_id || project_id);
-        analytics_.TrackStartTimeEntry(db_->AnalyticsClientID());
-        analytics_.TrackActiveView(db_->AnalyticsClientID(), GetActiveTab());
+        analytics_.TrackStartTimeEntry(db_->AnalyticsClientID(), GetActiveTab());
     }
 
     OpenTimeEntryList();
@@ -2923,8 +2922,7 @@ void Context::OpenTimeEntryEditor(
     }
 
     if ("production" == environment_) {
-        analytics_.TrackEditTimeEntry(db_->AnalyticsClientID());
-        analytics_.TrackActiveView(db_->AnalyticsClientID(), GetActiveTab());
+        analytics_.TrackEditTimeEntry(db_->AnalyticsClientID(), GetActiveTab());
     }
 
     updateUI(render);
@@ -3097,8 +3095,7 @@ error Context::DeleteTimeEntryByGUID(const std::string &GUID) {
     te->Delete();
 
     if ("production" == environment_) {
-        analytics_.TrackDeleteTimeEntry(db_->AnalyticsClientID());
-        analytics_.TrackActiveView(db_->AnalyticsClientID(), GetActiveTab());
+        analytics_.TrackDeleteTimeEntry(db_->AnalyticsClientID(), GetActiveTab());
     }
 
     return displayError(save(true));

--- a/src/context.cc
+++ b/src/context.cc
@@ -2852,6 +2852,7 @@ TimeEntry *Context::Start(
         analytics_.TrackAutocompleteUsage(db_->AnalyticsClientID(),
                                           task_id || project_id);
         analytics_.TrackStartTimeEntry(db_->AnalyticsClientID());
+        analytics_.TrackActiveView(db_->AnalyticsClientID(), GetActiveTab());
     }
 
     OpenTimeEntryList();
@@ -2923,6 +2924,7 @@ void Context::OpenTimeEntryEditor(
 
     if ("production" == environment_) {
         analytics_.TrackEditTimeEntry(db_->AnalyticsClientID());
+        analytics_.TrackActiveView(db_->AnalyticsClientID(), GetActiveTab());
     }
 
     updateUI(render);
@@ -3096,6 +3098,7 @@ error Context::DeleteTimeEntryByGUID(const std::string &GUID) {
 
     if ("production" == environment_) {
         analytics_.TrackDeleteTimeEntry(db_->AnalyticsClientID());
+        analytics_.TrackActiveView(db_->AnalyticsClientID(), GetActiveTab());
     }
 
     return displayError(save(true));

--- a/src/context.h
+++ b/src/context.h
@@ -645,13 +645,13 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error updateEntryProjects(
         const std::vector<Project *> &projects,
         const std::vector<TimeEntry *> &time_entries);
-    static error signup(
+    error signup(
         TogglClient *https_client,
         const std::string &email,
         const std::string &password,
         std::string *user_data_json,
         const uint64_t country_id);
-    static error signupGoogle(
+    error signupGoogle(
         TogglClient *toggl_client,
         const std::string &access_token,
         std::string *user_data_json,


### PR DESCRIPTION
### 📒 Description
This PR would add some tracking for user activities:
- Login / Sign up with username / password
- Start / Edit / Delete TimeEntry

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add tracking for TimeEntry activity: Start, Delete, open Edit
- [x] Add tracking for login and signup from username / google

### 👫 Relationships
Closes #3719 
Closes #3740 

### 🔎 Review hints
- Do login, signup with Username/password or Google
- Do Start / Open Editor / Delete TimeEntry
in Production mode and make sure the analytic data is sent 

