### PR TITLE
Menu cleanup for timeline

### DIFF
--- a/src/ui/osx/TogglDesktop/MenuItemTags.h
+++ b/src/ui/osx/TogglDesktop/MenuItemTags.h
@@ -17,4 +17,3 @@ static NSInteger const kMenuItemTagOpenBrowser = 9;
 static NSInteger const kMenuItemTagEdit = 10;
 static NSInteger const kMenuItemTagMode = 12;
 static NSInteger const kMenuItemTagSendFeedBack = 13;
-static NSInteger const kMenuItemTagHideTimelineData = 15;

--- a/src/ui/osx/TogglDesktop/MenuItemTags.h
+++ b/src/ui/osx/TogglDesktop/MenuItemTags.h
@@ -15,7 +15,6 @@ static NSInteger const kMenuItemTagStop = 5;
 static NSInteger const kMenuItemTagClearCache = 6;
 static NSInteger const kMenuItemTagOpenBrowser = 9;
 static NSInteger const kMenuItemTagEdit = 10;
-static NSInteger const kMenuItemTagRecordTimeline = 11;
 static NSInteger const kMenuItemTagMode = 12;
 static NSInteger const kMenuItemTagSendFeedBack = 13;
 static NSInteger const kMenuItemTagHideTimelineData = 15;

--- a/src/ui/osx/TogglDesktop/MenuItemTags.h
+++ b/src/ui/osx/TogglDesktop/MenuItemTags.h
@@ -18,5 +18,4 @@ static NSInteger const kMenuItemTagEdit = 10;
 static NSInteger const kMenuItemTagRecordTimeline = 11;
 static NSInteger const kMenuItemTagMode = 12;
 static NSInteger const kMenuItemTagSendFeedBack = 13;
-static NSInteger const kMenuItemTagShowTimelineData = 14;
 static NSInteger const kMenuItemTagHideTimelineData = 15;

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -75,9 +75,6 @@
 // We'll add user email once userdata has been loaded
 @property (nonatomic, strong) NSMenuItem *currentUserEmailMenuItem;
 
-// We'll change "show timeline" caption when needed
-@property (strong) IBOutlet NSMenuItem *showTimelineMenuitem;
-
 // Where logs are written and db is kept
 @property (nonatomic, copy) NSString *app_path;
 @property (nonatomic, copy) NSString *db_path;
@@ -224,14 +221,7 @@ void *ctx;
 											 selector:@selector(startUpdateIconTooltip:)
 												 name:kUpdateIconTooltip
 											   object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self
-											 selector:@selector(startDisplayTimeline:)
-												 name:kDisplayTimeline
-											   object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self
-											 selector:@selector(startDisplayTimeEntryList:)
-												 name:kDisplayTimeEntryList
-											   object:nil];
+
 	if (@available(macOS 10.14, *))
 	{
 		self.effectiveAppearanceObs = [self.mainWindowController.window observerEffectiveAppearanceNotification];
@@ -731,36 +721,6 @@ void *ctx;
 	toggl_set_promotion_response(ctx, promotion_type.intValue, NSAlertFirstButtonReturn == result);
 }
 
-- (void)startDisplayTimeline:(NSNotification *)notification
-{
-	[self displayTimeline:notification.object];
-}
-
-- (void)displayTimeline:(DisplayCommand *)cmd
-{
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	if (cmd.open)
-	{
-		[self.showTimelineMenuitem setTitle:@"Hide timeline data"];
-		[self.showTimelineMenuitem setTag:kMenuItemTagHideTimelineData];
-	}
-}
-
-- (void)startDisplayTimeEntryList:(NSNotification *)notification
-{
-	[self displayTimeEntryList:notification.object];
-}
-
-- (void)displayTimeEntryList:(DisplayCommand *)cmd
-{
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	if (cmd.open)
-	{
-		[self.showTimelineMenuitem setTitle:@"Show timeline data"];
-		[self.showTimelineMenuitem setTag:kMenuItemTagShowTimelineData];
-	}
-}
-
 - (void)startDisplayLogin:(NSNotification *)notification
 {
 	[self displayLogin:notification.object];
@@ -1007,10 +967,6 @@ void *ctx;
 	[menu addItemWithTitle:@"Edit"
 					action:@selector(onEditMenuItem:)
 			 keyEquivalent:@"e"].tag = kMenuItemTagEdit;
-	self.showTimelineMenuitem = [menu addItemWithTitle:@"Show timeline data"
-												action:@selector(onShowTimelineDataMenuItem:)
-										 keyEquivalent:@"l"];
-	self.showTimelineMenuitem.tag = kMenuItemTagShowTimelineData;
 	[menu addItem:[NSMenuItem separatorItem]];
 	[menu addItemWithTitle:@"Sync"
 					action:@selector(onSyncMenuItem:)
@@ -1174,20 +1130,6 @@ void *ctx;
 {
 	[self.mainWindowController showWindowAndFocus];
 	toggl_edit(ctx, "", true, "description");
-}
-
-- (IBAction)onShowTimelineDataMenuItem:(id)sender
-{
-	[self.mainWindowController showWindow:self];
-	switch (self.showTimelineMenuitem.tag)
-	{
-		case kMenuItemTagShowTimelineData :
-			toggl_view_timeline_data(ctx);
-			break;
-		case kMenuItemTagHideTimelineData :
-			toggl_view_time_entry_list(ctx);
-			break;
-	}
 }
 
 - (IBAction)onPreferencesMenuItem:(id)sender
@@ -1492,7 +1434,6 @@ const NSString *appName = @"osx_native_app";
 		case kMenuItemTagOpenBrowser :
 		case kMenuItemTagNew :
 		case kMenuItemTagSendFeedBack :
-		case kMenuItemTagShowTimelineData :
 		case kMenuItemTagHideTimelineData :
 			if (!self.lastKnownUserID)
 			{

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -977,9 +977,6 @@ void *ctx;
 	[menu addItemWithTitle:@"Preferences"
 					action:@selector(onPreferencesMenuItem:)
 			 keyEquivalent:@""];
-	[menu addItemWithTitle:@"Record Timeline"
-					action:@selector(onToggleRecordTimeline:)
-			 keyEquivalent:@""].tag = kMenuItemTagRecordTimeline;
 	self.manualModeMenuItem = [menu addItemWithTitle:@"Use manual mode"
 											  action:@selector(onModeChange:)
 									   keyEquivalent:@"d"];
@@ -1057,12 +1054,6 @@ void *ctx;
 - (IBAction)onSyncMenuItem:(id)sender
 {
 	toggl_sync(ctx);
-}
-
-- (IBAction)onToggleRecordTimeline:(id)sender
-{
-    BOOL isEnabled = !toggl_timeline_is_recording_enabled(ctx);
-    [[DesktopLibraryBridge shared] enableTimelineRecord:isEnabled];
 }
 
 - (IBAction)onModeChange:(id)sender
@@ -1438,24 +1429,6 @@ const NSString *appName = @"osx_native_app";
 			if (!self.lastKnownUserID)
 			{
 				return NO;
-			}
-			break;
-		case kMenuItemTagRecordTimeline :
-			if (!self.lastKnownUserID)
-			{
-				NSMenuItem *menuItem = (NSMenuItem *)anItem;
-				[menuItem setState:NSOffState];
-				return NO;
-			}
-			if (toggl_timeline_is_recording_enabled(ctx))
-			{
-				NSMenuItem *menuItem = (NSMenuItem *)anItem;
-				[menuItem setState:NSOnState];
-			}
-			else
-			{
-				NSMenuItem *menuItem = (NSMenuItem *)anItem;
-				[menuItem setState:NSOffState];
 			}
 			break;
 		default :

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1425,7 +1425,6 @@ const NSString *appName = @"osx_native_app";
 		case kMenuItemTagOpenBrowser :
 		case kMenuItemTagNew :
 		case kMenuItemTagSendFeedBack :
-		case kMenuItemTagHideTimelineData :
 			if (!self.lastKnownUserID)
 			{
 				return NO;

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -68,11 +68,6 @@
                                     <action selector="onModeChange:" target="494" id="SoP-VP-yqv"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Show Timeline" keyEquivalent="l" id="cRQ-QS-A1h">
-                                <connections>
-                                    <action selector="onShowTimelineDataMenuItem:" target="494" id="SwG-Wr-lyw"/>
-                                </connections>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="149">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>


### PR DESCRIPTION
### 📒 Description
Remove duplicate functionality items from the menu

### 🤯 List of changes
- remove 'Show timeline data' item from menu (was not working at all)
- remove 'Record timeline' item from menu (duplicated functionality)

### 👫 Relationships
Closes #3743 

### 🔎 Review hints
Check if other 'record timeline' switch functionalities work and you are able to switch to timeline view.

