### PR TITLE
Improve/timeline remove timeline preference

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -244,7 +244,12 @@ extension TimelineDashboardViewController {
         guard let cmd = noti.object as? DisplayCommand,
             let setting = cmd.settings else { return }
         recordSwitcher.setOn(isOn: setting.timeline_recording_enabled, animated: false)
-        permissionBtn.isHidden = SystemPermissionManager.shared.isGranted(.screenRecording)
+        if setting.timeline_recording_enabled {
+            permissionBtn.isHidden = SystemPermissionManager.shared.isGranted(.screenRecording)
+        } else {
+            permissionBtn.isHidden = true
+        }
+
         updateEmptyActivityText()
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -29,6 +29,7 @@ final class TimelineDashboardViewController: NSViewController {
     @IBOutlet weak var activityRecorderInfoImageView: HoverImageView!
     @IBOutlet weak var activityPanelWidth: NSLayoutConstraint!
     @IBOutlet weak var activityLabelRight: NSLayoutConstraint!
+    @IBOutlet weak var permissionBtn: NSButton!
 
     // MARK: Variables
 
@@ -175,6 +176,10 @@ final class TimelineDashboardViewController: NSViewController {
         zoomLevel = previous
     }
 
+    @IBAction func permissionBtnOnClicked(_ sender: Any) {
+        SystemPermissionManager.shared.grant(.screenRecording)
+    }
+
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
         zoomContainerView.isHidden = false
@@ -239,6 +244,7 @@ extension TimelineDashboardViewController {
         guard let cmd = noti.object as? DisplayCommand,
             let setting = cmd.settings else { return }
         recordSwitcher.setOn(isOn: setting.timeline_recording_enabled, animated: false)
+        permissionBtn.isHidden = SystemPermissionManager.shared.isGranted(.screenRecording)
         updateEmptyActivityText()
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -18,6 +18,7 @@
                 <outlet property="emptyActivityLblPadding" destination="ly2-AY-aiO" id="mfW-cZ-gGQ"/>
                 <outlet property="emptyLbl" destination="L7J-Lq-Z7U" id="x1D-xG-9dl"/>
                 <outlet property="mainContainerView" destination="Xu6-6s-ozI" id="ZFI-ck-oSW"/>
+                <outlet property="permissionBtn" destination="6pQ-LK-6Bo" id="7qC-gA-S5x"/>
                 <outlet property="recordSwitcher" destination="I6m-RA-gUy" id="Sef-EC-Cn6"/>
                 <outlet property="view" destination="c22-O7-iKe" id="D7F-6m-KJo"/>
                 <outlet property="zoomContainerView" destination="xXU-Yr-nTf" id="jDA-BO-CEK"/>
@@ -43,7 +44,7 @@
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oEw-Jd-lIP">
                             <rect key="frame" x="34" y="56" width="101" height="17"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" title="Record activity" id="x0y-gM-oPn">
-                                <font key="font" metaFont="system" size="14"/>
+                                <font key="font" metaFont="menu" size="14"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -62,6 +63,19 @@
                                 <action selector="recordSwitchOnChanged:" target="-2" id="yGC-CS-Z9N"/>
                             </connections>
                         </customView>
+                        <button hidden="YES" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6pQ-LK-6Bo">
+                            <rect key="frame" x="197" y="57" width="136" height="14"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="14" id="y9x-m5-wa7"/>
+                            </constraints>
+                            <buttonCell key="cell" type="bevel" title="Permission required!" bezelStyle="regularSquare" image="NSCaution" imagePosition="left" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="Uj3-3t-CiG">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system" size="10"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="permissionBtnOnClicked:" target="-2" id="z5L-tH-fof"/>
+                            </connections>
+                        </button>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="wlf-0e-ttW">
                             <rect key="frame" x="10" y="14" width="349" height="30"/>
                             <constraints>
@@ -73,12 +87,15 @@
                         <constraint firstItem="oEw-Jd-lIP" firstAttribute="leading" secondItem="mVu-t2-GXP" secondAttribute="trailing" constant="6" id="0gk-pQ-hvy"/>
                         <constraint firstItem="wlf-0e-ttW" firstAttribute="top" secondItem="oEw-Jd-lIP" secondAttribute="bottom" constant="12" id="0rH-e0-NUk"/>
                         <constraint firstAttribute="trailing" secondItem="sGN-8K-7IZ" secondAttribute="trailing" id="8d7-zq-V41"/>
+                        <constraint firstItem="6pQ-LK-6Bo" firstAttribute="top" secondItem="I6m-RA-gUy" secondAttribute="bottom" constant="-13" id="Fkx-PB-KIY"/>
                         <constraint firstItem="sGN-8K-7IZ" firstAttribute="leading" secondItem="CV9-Ue-zhq" secondAttribute="leading" id="GTe-dy-kVB"/>
                         <constraint firstItem="mVu-t2-GXP" firstAttribute="top" secondItem="CV9-Ue-zhq" secondAttribute="top" constant="12" id="OCz-Wk-a2y"/>
                         <constraint firstItem="mVu-t2-GXP" firstAttribute="leading" secondItem="CV9-Ue-zhq" secondAttribute="leading" constant="10" id="Qv6-J5-pRj"/>
+                        <constraint firstItem="I6m-RA-gUy" firstAttribute="leading" secondItem="6pQ-LK-6Bo" secondAttribute="trailing" id="TBB-Yb-XIk"/>
                         <constraint firstItem="I6m-RA-gUy" firstAttribute="centerY" secondItem="oEw-Jd-lIP" secondAttribute="centerY" id="aWn-ju-3Sc"/>
                         <constraint firstItem="sGN-8K-7IZ" firstAttribute="top" secondItem="CV9-Ue-zhq" secondAttribute="top" id="eaq-AF-dtf"/>
                         <constraint firstItem="oEw-Jd-lIP" firstAttribute="top" secondItem="CV9-Ue-zhq" secondAttribute="top" constant="13" id="igE-d4-QVd"/>
+                        <constraint firstItem="6pQ-LK-6Bo" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="oEw-Jd-lIP" secondAttribute="trailing" constant="4" id="lLk-a1-DzD"/>
                         <constraint firstAttribute="trailing" secondItem="wlf-0e-ttW" secondAttribute="trailing" constant="10" id="mPL-xl-8j9"/>
                         <constraint firstAttribute="trailing" secondItem="I6m-RA-gUy" secondAttribute="trailing" constant="10" id="maq-iT-Fcc"/>
                         <constraint firstAttribute="height" constant="86" id="wv3-y8-Rz9"/>
@@ -115,7 +132,7 @@
                                             <rect key="frame" x="33" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSAddTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="as8-De-WrX">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
+                                                <font key="font" metaFont="label" size="13"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelIncreaseOnChange:" target="-2" id="QsV-0i-5La"/>
@@ -125,7 +142,7 @@
                                             <rect key="frame" x="10" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="kr9-Ry-BUy">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
+                                                <font key="font" metaFont="label" size="13"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelDecreaseOnChange:" target="-2" id="ksx-ak-4he"/>
@@ -207,7 +224,7 @@
                                 <constraint firstAttribute="width" constant="140" id="mdj-ct-y7d"/>
                             </constraints>
                             <textFieldCell key="cell" alignment="center" title="No entries here…  Go ahead and track some time!" id="rM7-R2-ABZ">
-                                <font key="font" metaFont="system"/>
+                                <font key="font" metaFont="label" size="13"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -215,7 +232,7 @@
                         <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3EE-on-mJF">
                             <rect key="frame" x="327" y="287" width="252" height="16"/>
                             <textFieldCell key="cell" alignment="center" title="Turn on activity recording to see results." id="PUb-OL-l5z">
-                                <font key="font" metaFont="system"/>
+                                <font key="font" metaFont="label" size="13"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -250,6 +267,7 @@
     </objects>
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSCaution" width="32" height="32"/>
         <image name="NSRemoveTemplate" width="11" height="11"/>
         <image name="timeline-activity-recorder-info-icon" width="20" height="20"/>
         <namedColor name="timeline-background-color">

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -65,6 +65,9 @@
                         </customView>
                         <button hidden="YES" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6pQ-LK-6Bo">
                             <rect key="frame" x="197" y="57" width="136" height="14"/>
+                            <string key="toolTip">Screen Recording permission not granted!
+
+To get the focused application window name properly for the Timeline, TogglDesktop needs to be granted the Screen Recording permission in Security &amp; Privacy in System Preferences .</string>
                             <constraints>
                                 <constraint firstAttribute="height" constant="14" id="y9x-m5-wa7"/>
                             </constraints>

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -37,7 +37,6 @@ typedef enum : NSUInteger
 @property (weak) IBOutlet NSButton *useIdleDetectionButton;
 @property (weak) IBOutlet NSButton *usePomodoroButton;
 @property (weak) IBOutlet NSButton *usePomodoroBreakButton;
-@property (weak) IBOutlet NSButton *recordTimelineCheckbox;
 @property (weak) IBOutlet NSButton *menubarTimerCheckbox;
 @property (weak) IBOutlet NSButton *menubarProjectCheckbox;
 @property (weak) IBOutlet NSButton *dockIconCheckbox;
@@ -65,7 +64,6 @@ typedef enum : NSUInteger
 @property (weak) IBOutlet NSTextField *remindEnds;
 @property (weak) IBOutlet NSButton *autotrack;
 @property (weak) IBOutlet NSButton *openEditorOnShortcut;
-@property (weak) IBOutlet NSButton *renderTimeline;
 @property (weak) IBOutlet NSButton *proxyDoNot;
 @property (weak) IBOutlet NSButton *proxySystem;
 @property (weak) IBOutlet NSButton *proxyToggl;
@@ -75,7 +73,6 @@ typedef enum : NSUInteger
 @property (weak) IBOutlet NSTabView *tabView;
 @property (weak) IBOutlet NSButton *showTouchBarButton;
 @property (weak) IBOutlet NSLayoutConstraint *bottomContainerHeight;
-@property (weak) IBOutlet NSButton *screenRecordingPermissionBtn;
 
 @property (nonatomic, assign) NSInteger selectedProxyIndex;
 @property (nonatomic, strong) NSArray<AutotrackerRuleItem *> *rules;
@@ -95,7 +92,6 @@ typedef enum : NSUInteger
 - (IBAction)useIdleDetectionButtonChanged:(id)sender;
 - (IBAction)usePomodoroButtonChanged:(id)sender;
 - (IBAction)usePomodoroBreakButtonChanged:(id)sender;
-- (IBAction)recordTimelineCheckboxChanged:(id)sender;
 - (IBAction)menubarTimerCheckboxChanged:(id)sender;
 - (IBAction)menubarProjectCheckboxChanged:(id)sender;
 - (IBAction)dockIconCheckboxChanged:(id)sender;
@@ -192,13 +188,10 @@ extern void *ctx;
 	[self.pomodoroMinutesTextField setDelegate:self];
 	[self.pomodoroBreakMinutesTextField setDelegate:self];
 	[self.reminderMinutesTextField setDelegate:self];
-
-	self.renderTimeline.hidden = YES;
 }
 
 - (void)enableLoggedInUserControls
 {
-	[self.recordTimelineCheckbox setEnabled:self.user_id != 0];
 	[self.defaultProject setEnabled:self.user_id != 0];
 	[self.autotrack setEnabled:self.user_id != 0];
 	[self.autotrackerTerm setEnabled:self.user_id != 0];
@@ -354,12 +347,6 @@ const int kUseProxyToConnectToToggl = 2;
 									[self.remindEnds.stringValue UTF8String]);
 }
 
-- (IBAction)recordTimelineCheckboxChanged:(id)sender
-{
-	BOOL record_timeline = [Utils stateToBool:[self.recordTimelineCheckbox state]];
-    [[DesktopLibraryBridge shared] enableTimelineRecord:record_timeline];
-}
-
 - (IBAction)menubarTimerCheckboxChanged:(id)sender
 {
 	toggl_set_settings_menubar_timer(ctx,
@@ -436,10 +423,7 @@ const int kUseProxyToConnectToToggl = 2;
 	[self.ontopCheckbox setState:[Utils boolToState:settings.on_top]];
 	[self.reminderCheckbox setState:[Utils boolToState:settings.reminder]];
 	[self.focusOnShortcutCheckbox setState:[Utils boolToState:settings.focus_on_shortcut]];
-	[self.renderTimeline setState:[Utils boolToState:settings.render_timeline]];
 	[self.stopOnShutdownCheckbox setState:[Utils boolToState:settings.stopWhenShutdown]];
-	[self.recordTimelineCheckbox setEnabled:self.user_id != 0];
-	[self.recordTimelineCheckbox setState:[Utils boolToState:settings.timeline_recording_enabled]];
 
 	if (!settings.use_proxy && !settings.autodetect_proxy)
 	{
@@ -754,22 +738,4 @@ const int kUseProxyToConnectToToggl = 2;
 {
 	[self.tabView selectTabViewItemAtIndex:self.tabSegment.selectedSegment];
 }
-
-- (IBAction)screenRecordingPermissionOnTap:(id)sender
-{
-	[ObjcSystemPermissionManager tryGrantScreenRecordingPermission];
-}
-
-- (void)updatePermissionState
-{
-	BOOL isEnabled = [ObjcSystemPermissionManager isScreenRecordingPermissionGranted];
-
-	[self.screenRecordingPermissionBtn setHidden:isEnabled];
-}
-
-- (void)windowDidBecomeKey:(NSNotification *)notification
-{
-	[self updatePermissionState];
-}
-
 @end

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -32,7 +32,6 @@
                 <outlet property="proxyDoNot" destination="0Qt-eg-0Ut" id="bfh-uj-NOz"/>
                 <outlet property="proxySystem" destination="oWn-9e-NL5" id="OSv-Tk-q5n"/>
                 <outlet property="proxyToggl" destination="bge-rT-TdE" id="dd0-ne-6yt"/>
-                <outlet property="recordTimelineCheckbox" destination="V28-KN-5Vi" id="76u-Eg-Kf1"/>
                 <outlet property="remindEnds" destination="4pc-oy-DHZ" id="quq-ky-ubO"/>
                 <outlet property="remindFri" destination="5ab-YA-eHT" id="IcA-xD-aZo"/>
                 <outlet property="remindMon" destination="6g9-yq-5Jx" id="UqA-OK-H50"/>
@@ -44,7 +43,6 @@
                 <outlet property="remindWed" destination="E0j-Uw-3Nz" id="BSu-Cd-aT5"/>
                 <outlet property="reminderCheckbox" destination="Spu-c6-dBl" id="rce-jc-2Cq"/>
                 <outlet property="reminderMinutesTextField" destination="R9v-BZ-yhR" id="OVt-ic-hzF"/>
-                <outlet property="screenRecordingPermissionBtn" destination="iVg-hT-3JL" id="D9y-TN-96B"/>
                 <outlet property="showHideShortcutView" destination="DLB-Fw-7tX" id="T2o-mF-KXG"/>
                 <outlet property="showTouchBarButton" destination="uPL-ax-1Ux" id="eAl-AY-wbs"/>
                 <outlet property="startStopShortcutView" destination="Ft4-tk-xRA" id="5tb-G5-s2R"/>
@@ -63,21 +61,21 @@
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="Preferences" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="400" height="590"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
-            <value key="minSize" type="size" width="400" height="590"/>
-            <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="408" height="590"/>
+            <rect key="contentRect" x="196" y="240" width="400" height="565"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <value key="minSize" type="size" width="400" height="565"/>
+            <view key="contentView" misplaced="YES" id="2">
+                <rect key="frame" x="0.0" y="0.0" width="400" height="565"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="qdc-hR-YLw">
-                        <rect key="frame" x="0.0" y="0.0" width="408" height="590"/>
+                        <rect key="frame" x="0.0" y="0.0" width="408" height="565"/>
                         <view key="contentView" id="QZK-80-mX3">
-                            <rect key="frame" x="0.0" y="0.0" width="408" height="590"/>
+                            <rect key="frame" x="0.0" y="0.0" width="408" height="565"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RqW-Eb-jQc">
-                                    <rect key="frame" x="164" y="571" width="81" height="17"/>
+                                    <rect key="frame" x="164" y="547" width="81" height="16"/>
                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Preferences" id="DcZ-K3-JhQ">
                                         <font key="font" usesAppearanceFont="YES"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -93,22 +91,22 @@
                         <color key="fillColor" name="preference-background-color"/>
                     </box>
                     <tabView drawsBackground="NO" allowsTruncatedLabels="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="ZDX-gA-MBn">
-                        <rect key="frame" x="0.0" y="0.0" width="408" height="560"/>
+                        <rect key="frame" x="0.0" y="0.0" width="408" height="535"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="3dj-rq-0aF">
                                 <view key="view" id="7qY-5d-VHf">
-                                    <rect key="frame" x="0.0" y="0.0" width="408" height="560"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="408" height="535"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="KYJ-q7-LnW">
-                                            <rect key="frame" x="15" y="340" width="378" height="208"/>
+                                            <rect key="frame" x="15" y="347" width="378" height="176"/>
                                             <view key="contentView" id="a3O-tS-arC">
-                                                <rect key="frame" x="0.0" y="0.0" width="378" height="208"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="378" height="176"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K6B-0p-RS0">
-                                                        <rect key="frame" x="8" y="164" width="113" height="18"/>
+                                                        <rect key="frame" x="8" y="133" width="113" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Show/Hide Toggl" id="ZgR-r3-20o">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -116,7 +114,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="DLB-Fw-7tX" customClass="MASShortcutView">
-                                                        <rect key="frame" x="207" y="160" width="161" height="26"/>
+                                                        <rect key="frame" x="207" y="129" width="161" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="161" id="ars-NE-9zw"/>
                                                             <constraint firstAttribute="height" constant="26" id="kFH-FJ-b0C"/>
@@ -125,19 +123,8 @@
                                                             <outlet property="nextKeyView" destination="Ft4-tk-xRA" id="Fi4-jZ-hCB"/>
                                                         </connections>
                                                     </customView>
-                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="V28-KN-5Vi">
-                                                        <rect key="frame" x="8" y="8" width="123" height="18"/>
-                                                        <buttonCell key="cell" type="check" title="Record timeline" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yIY-fe-UHc">
-                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                            <font key="font" metaFont="menu" size="14"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="recordTimelineCheckboxChanged:" target="-2" id="shF-cM-Bvx"/>
-                                                            <outlet property="nextKeyView" destination="lUE-Lr-nId" id="ABE-oe-FHH"/>
-                                                        </connections>
-                                                    </button>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="BzK-d8-1HF" userLabel="pomodoro break timer">
-                                                        <rect key="frame" x="8" y="38" width="129" height="18"/>
+                                                        <rect key="frame" x="8" y="8" width="129" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Pomodoro break" bezelStyle="regularSquare" imagePosition="left" inset="2" id="fa3-Br-Doo">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="menu" size="14"/>
@@ -148,7 +135,7 @@
                                                         </connections>
                                                     </button>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Rmf-uW-sZP" userLabel="pomodoro timer">
-                                                        <rect key="frame" x="8" y="68" width="126" height="18"/>
+                                                        <rect key="frame" x="8" y="38" width="126" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Pomodoro timer" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2eM-Mq-Qkk">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="menu" size="14"/>
@@ -159,7 +146,7 @@
                                                         </connections>
                                                     </button>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Lgk-gZ-8Ha">
-                                                        <rect key="frame" x="8" y="98" width="111" height="18"/>
+                                                        <rect key="frame" x="8" y="68" width="111" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Idle detection" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Z6U-JU-oVS">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="menu" size="14"/>
@@ -170,7 +157,7 @@
                                                         </connections>
                                                     </button>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h4c-1q-AeO">
-                                                        <rect key="frame" x="8" y="130" width="134" height="18"/>
+                                                        <rect key="frame" x="8" y="100" width="134" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Continue/Stop timer" id="SH4-aB-XUn">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -178,14 +165,14 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="Ft4-tk-xRA" customClass="MASShortcutView">
-                                                        <rect key="frame" x="207" y="126" width="161" height="26"/>
+                                                        <rect key="frame" x="207" y="96" width="161" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="26" id="8gq-eJ-P9P"/>
                                                             <constraint firstAttribute="width" constant="161" id="hbh-Ud-GvF"/>
                                                         </constraints>
                                                     </customView>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Khj-es-fgU">
-                                                        <rect key="frame" x="253" y="98" width="56" height="18"/>
+                                                        <rect key="frame" x="253" y="69" width="56" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="Zfu-jF-pu2">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -193,7 +180,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ufH-RC-hfd">
-                                                        <rect key="frame" x="253" y="68" width="56" height="18"/>
+                                                        <rect key="frame" x="253" y="39" width="56" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="uD2-dD-ZQE">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -201,7 +188,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rmD-4u-Dda">
-                                                        <rect key="frame" x="207" y="34" width="38" height="26"/>
+                                                        <rect key="frame" x="207" y="4" width="38" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="38" id="L7D-Lz-n3c"/>
                                                             <constraint firstAttribute="height" constant="26" id="mhi-IV-f2K"/>
@@ -217,7 +204,7 @@
                                                         </connections>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bCE-Cp-Ipc">
-                                                        <rect key="frame" x="207" y="64" width="38" height="26"/>
+                                                        <rect key="frame" x="207" y="34" width="38" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="38" id="bc4-fl-TDP"/>
                                                             <constraint firstAttribute="height" constant="26" id="ozO-hP-Ur0"/>
@@ -233,7 +220,7 @@
                                                         </connections>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nRj-Zh-L5m">
-                                                        <rect key="frame" x="207" y="94" width="38" height="26"/>
+                                                        <rect key="frame" x="207" y="64" width="38" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="38" id="Kvx-Gb-5cr"/>
                                                             <constraint firstAttribute="height" constant="26" id="bc3-GI-FLm"/>
@@ -246,35 +233,20 @@
                                                         </textFieldCell>
                                                         <connections>
                                                             <action selector="idleMinutesChange:" target="-2" id="HN6-cL-vul"/>
-                                                            <outlet property="nextKeyView" destination="V28-KN-5Vi" id="mWW-dn-SyB"/>
                                                         </connections>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vM4-Nq-b4v">
-                                                        <rect key="frame" x="253" y="38" width="56" height="18"/>
+                                                        <rect key="frame" x="253" y="9" width="56" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="MLE-d1-bsN">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <button hidden="YES" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iVg-hT-3JL">
-                                                        <rect key="frame" x="137" y="9" width="224" height="14"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="14" id="0yo-we-mls"/>
-                                                        </constraints>
-                                                        <buttonCell key="cell" type="bevel" title="Screen Recording Permission required!" bezelStyle="regularSquare" image="NSCaution" imagePosition="left" alignment="left" controlSize="small" imageScaling="proportionallyDown" inset="2" id="8t0-dm-Sct">
-                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system" size="10"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="screenRecordingPermissionOnTap:" target="-2" id="UfO-37-V0F"/>
-                                                        </connections>
-                                                    </button>
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="ufH-RC-hfd" firstAttribute="leading" secondItem="bCE-Cp-Ipc" secondAttribute="trailing" constant="10" id="4V2-lj-a2r"/>
                                                     <constraint firstItem="bCE-Cp-Ipc" firstAttribute="leading" secondItem="nRj-Zh-L5m" secondAttribute="leading" id="4Zw-o3-lGa"/>
-                                                    <constraint firstItem="V28-KN-5Vi" firstAttribute="leading" secondItem="BzK-d8-1HF" secondAttribute="leading" id="7e7-eI-gc8"/>
                                                     <constraint firstAttribute="trailing" secondItem="Ft4-tk-xRA" secondAttribute="trailing" constant="10" id="9Vy-zz-uhn"/>
                                                     <constraint firstItem="nRj-Zh-L5m" firstAttribute="leading" secondItem="Ft4-tk-xRA" secondAttribute="leading" id="GMq-M1-Jr1"/>
                                                     <constraint firstItem="Lgk-gZ-8Ha" firstAttribute="leading" secondItem="h4c-1q-AeO" secondAttribute="leading" id="GOn-Z8-1Br"/>
@@ -291,13 +263,10 @@
                                                     <constraint firstItem="K6B-0p-RS0" firstAttribute="top" secondItem="a3O-tS-arC" secondAttribute="top" constant="26" id="bzA-L3-heJ"/>
                                                     <constraint firstItem="h4c-1q-AeO" firstAttribute="top" secondItem="K6B-0p-RS0" secondAttribute="bottom" constant="16" id="eHL-XA-SGD"/>
                                                     <constraint firstItem="K6B-0p-RS0" firstAttribute="leading" secondItem="a3O-tS-arC" secondAttribute="leading" constant="10" id="gLR-Xo-ggR"/>
-                                                    <constraint firstItem="V28-KN-5Vi" firstAttribute="top" secondItem="BzK-d8-1HF" secondAttribute="bottom" constant="16" id="iHf-PE-Q1T"/>
                                                     <constraint firstItem="BzK-d8-1HF" firstAttribute="leading" secondItem="Rmf-uW-sZP" secondAttribute="leading" id="k64-wG-pbl"/>
-                                                    <constraint firstItem="iVg-hT-3JL" firstAttribute="centerY" secondItem="V28-KN-5Vi" secondAttribute="centerY" constant="1" id="mDV-gZ-mDd"/>
                                                     <constraint firstItem="Lgk-gZ-8Ha" firstAttribute="top" secondItem="h4c-1q-AeO" secondAttribute="bottom" constant="16" id="n0f-uu-OBa"/>
                                                     <constraint firstItem="DLB-Fw-7tX" firstAttribute="centerY" secondItem="K6B-0p-RS0" secondAttribute="centerY" id="pW5-20-XJi"/>
                                                     <constraint firstItem="Rmf-uW-sZP" firstAttribute="leading" secondItem="Lgk-gZ-8Ha" secondAttribute="leading" id="re7-fo-rzE"/>
-                                                    <constraint firstItem="iVg-hT-3JL" firstAttribute="leading" secondItem="V28-KN-5Vi" secondAttribute="trailing" constant="8" id="tOU-XM-4hC"/>
                                                     <constraint firstItem="rmD-4u-Dda" firstAttribute="leading" secondItem="bCE-Cp-Ipc" secondAttribute="leading" id="uop-W0-g8U"/>
                                                     <constraint firstItem="rmD-4u-Dda" firstAttribute="centerY" secondItem="BzK-d8-1HF" secondAttribute="centerY" id="w9K-hb-kdd"/>
                                                     <constraint firstItem="vM4-Nq-b4v" firstAttribute="centerY" secondItem="rmD-4u-Dda" secondAttribute="centerY" id="ykM-VF-87a"/>
@@ -305,12 +274,12 @@
                                                 </constraints>
                                             </view>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="208" id="XRA-u5-VN2"/>
+                                                <constraint firstAttribute="height" constant="176" id="XRA-u5-VN2"/>
                                             </constraints>
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="brM-0V-2IH">
-                                            <rect key="frame" x="15" y="200" width="378" height="130"/>
+                                            <rect key="frame" x="15" y="207" width="378" height="130"/>
                                             <view key="contentView" id="vnT-py-ejH">
                                                 <rect key="frame" x="0.0" y="0.0" width="378" height="130"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -389,7 +358,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="zQS-pF-1EQ">
-                                            <rect key="frame" x="15" y="132" width="378" height="58"/>
+                                            <rect key="frame" x="15" y="139" width="378" height="58"/>
                                             <view key="contentView" id="Kte-rl-Tae">
                                                 <rect key="frame" x="0.0" y="0.0" width="378" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -430,13 +399,13 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="zez-BU-pHz">
-                                            <rect key="frame" x="15" y="76" width="378" height="46"/>
+                                            <rect key="frame" x="15" y="83" width="378" height="46"/>
                                             <view key="contentView" id="PaI-l4-AmI">
                                                 <rect key="frame" x="0.0" y="0.0" width="378" height="46"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hsE-xm-XAM">
-                                                        <rect key="frame" x="11" y="15" width="100" height="18"/>
+                                                        <rect key="frame" x="11" y="16" width="100" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default project" id="bIw-0T-jhz">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -473,7 +442,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="4OJ-cM-plX">
-                                            <rect key="frame" x="15" y="8" width="378" height="58"/>
+                                            <rect key="frame" x="15" y="15" width="378" height="58"/>
                                             <view key="contentView" id="l4g-U3-2Pc">
                                                 <rect key="frame" x="0.0" y="0.0" width="378" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -547,17 +516,17 @@
                             </tabViewItem>
                             <tabViewItem label="Proxy" identifier="2" id="adI-Zg-JOo">
                                 <view key="view" id="Leo-bI-fp3">
-                                    <rect key="frame" x="0.0" y="0.0" width="412" height="562"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="408" height="560"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="qEc-dB-aZv">
-                                            <rect key="frame" x="15" y="452" width="382" height="98"/>
+                                            <rect key="frame" x="15" y="450" width="378" height="98"/>
                                             <view key="contentView" id="Vcc-fQ-nPv">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="98"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="378" height="98"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5X7-ip-Vgo">
-                                                        <rect key="frame" x="10" y="10" width="362" height="68"/>
+                                                        <rect key="frame" x="10" y="10" width="358" height="68"/>
                                                         <subviews>
                                                             <button focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Qt-eg-0Ut">
                                                                 <rect key="frame" x="-1" y="51" width="132" height="18"/>
@@ -617,19 +586,19 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" title="Proxy Settings" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="hoK-7e-akc">
-                                            <rect key="frame" x="15" y="263" width="382" height="145"/>
+                                            <rect key="frame" x="15" y="261" width="378" height="145"/>
                                             <view key="contentView" id="XhL-bq-2bj">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="145"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="378" height="145"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PzD-mm-klI">
-                                                        <rect key="frame" x="10" y="11" width="362" height="124"/>
+                                                        <rect key="frame" x="10" y="11" width="358" height="124"/>
                                                         <subviews>
                                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DlD-dh-sFA">
-                                                                <rect key="frame" x="0.0" y="102" width="362" height="22"/>
+                                                                <rect key="frame" x="0.0" y="102" width="358" height="22"/>
                                                                 <subviews>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tTy-26-HVI">
-                                                                        <rect key="frame" x="-2" y="2" width="102" height="18"/>
+                                                                        <rect key="frame" x="-2" y="3" width="102" height="17"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="98" id="2mG-xS-ejo"/>
                                                                         </constraints>
@@ -640,7 +609,7 @@
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eSt-Rf-LI2">
-                                                                        <rect key="frame" x="99" y="0.0" width="263" height="22"/>
+                                                                        <rect key="frame" x="99" y="0.0" width="259" height="22"/>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" bezelStyle="round" id="QLq-5g-6i8">
                                                                             <font key="font" metaFont="menu" size="14"/>
                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -662,10 +631,10 @@
                                                                 </customSpacing>
                                                             </stackView>
                                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1be-dp-20I">
-                                                                <rect key="frame" x="0.0" y="68" width="362" height="22"/>
+                                                                <rect key="frame" x="0.0" y="68" width="358" height="22"/>
                                                                 <subviews>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mT9-N4-nJS">
-                                                                        <rect key="frame" x="-2" y="2" width="102" height="18"/>
+                                                                        <rect key="frame" x="-2" y="3" width="102" height="17"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="98" id="01c-hz-TJv"/>
                                                                         </constraints>
@@ -676,7 +645,7 @@
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0tH-DP-xDu">
-                                                                        <rect key="frame" x="99" y="0.0" width="263" height="22"/>
+                                                                        <rect key="frame" x="99" y="0.0" width="259" height="22"/>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" bezelStyle="round" id="jfs-4a-yrp">
                                                                             <font key="font" metaFont="menu" size="14"/>
                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -698,10 +667,10 @@
                                                                 </customSpacing>
                                                             </stackView>
                                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UxD-at-fjg">
-                                                                <rect key="frame" x="0.0" y="34" width="362" height="22"/>
+                                                                <rect key="frame" x="0.0" y="34" width="358" height="22"/>
                                                                 <subviews>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="580-sq-qzQ">
-                                                                        <rect key="frame" x="-2" y="2" width="102" height="18"/>
+                                                                        <rect key="frame" x="-2" y="3" width="102" height="17"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="98" id="4tK-Hv-CJj"/>
                                                                         </constraints>
@@ -712,7 +681,7 @@
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hml-tw-LUI">
-                                                                        <rect key="frame" x="99" y="0.0" width="263" height="22"/>
+                                                                        <rect key="frame" x="99" y="0.0" width="259" height="22"/>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" bezelStyle="round" id="vKb-gX-cME">
                                                                             <font key="font" metaFont="menu" size="14"/>
                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -734,10 +703,10 @@
                                                                 </customSpacing>
                                                             </stackView>
                                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JTp-GI-RpK">
-                                                                <rect key="frame" x="0.0" y="0.0" width="362" height="22"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="358" height="22"/>
                                                                 <subviews>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mDj-Eq-8xq">
-                                                                        <rect key="frame" x="-2" y="2" width="102" height="18"/>
+                                                                        <rect key="frame" x="-2" y="3" width="102" height="17"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="98" id="8Zs-ND-GAU"/>
                                                                         </constraints>
@@ -748,7 +717,7 @@
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bcT-3P-lAf" customClass="NSSecureTextField">
-                                                                        <rect key="frame" x="99" y="0.0" width="263" height="22"/>
+                                                                        <rect key="frame" x="99" y="0.0" width="259" height="22"/>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" bezelStyle="round" id="9oG-9p-TqV">
                                                                             <font key="font" metaFont="menu" size="14"/>
                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -797,7 +766,7 @@
                                             <font key="titleFont" metaFont="systemMedium" size="14"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="q6d-hl-jcC">
-                                            <rect key="frame" x="23" y="418" width="101" height="14"/>
+                                            <rect key="frame" x="23" y="416" width="101" height="14"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="PROXY SETTINGS" id="yxg-ba-w8p">
                                                 <font key="font" metaFont="systemMedium" size="11"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -829,7 +798,7 @@
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <scrollView focusRingType="none" borderType="line" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PL2-PA-tEh">
-                                                        <rect key="frame" x="10" y="12" width="362" height="257"/>
+                                                        <rect key="frame" x="10" y="13" width="362" height="257"/>
                                                         <clipView key="contentView" id="anG-U7-QUu">
                                                             <rect key="frame" x="1" y="1" width="360" height="255"/>
                                                             <autoresizingMask key="autoresizingMask"/>
@@ -906,7 +875,7 @@
                                                         </connections>
                                                     </button>
                                                     <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TN9-Mx-4gf" customClass="NSCustomComboBox">
-                                                        <rect key="frame" x="136" y="275" width="124" height="27"/>
+                                                        <rect key="frame" x="136" y="276" width="124" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="121" id="z3c-Ow-PkS"/>
                                                         </constraints>
@@ -921,7 +890,7 @@
                                                         </connections>
                                                     </comboBox>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hCm-WD-AX4">
-                                                        <rect key="frame" x="256" y="272" width="122" height="32"/>
+                                                        <rect key="frame" x="256" y="273" width="122" height="32"/>
                                                         <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="pQ9-Tf-Kue">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="menu" size="14"/>
@@ -932,7 +901,7 @@
                                                         </connections>
                                                     </button>
                                                     <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="afg-Ty-RcE">
-                                                        <rect key="frame" x="10" y="275" width="124" height="27"/>
+                                                        <rect key="frame" x="10" y="276" width="124" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="121" id="jHw-Bs-Z3j"/>
                                                         </constraints>
@@ -999,7 +968,7 @@
                                                         </connections>
                                                     </button>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9TN-or-dpG">
-                                                        <rect key="frame" x="25" y="224" width="132" height="18"/>
+                                                        <rect key="frame" x="25" y="225" width="132" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reminder start time" id="7rS-yr-ohN">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1007,7 +976,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XOd-HM-bZN">
-                                                        <rect key="frame" x="25" y="190" width="126" height="18"/>
+                                                        <rect key="frame" x="25" y="192" width="126" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reminder end time" id="sJf-LA-jhB">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1015,7 +984,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oCh-IL-u0y">
-                                                        <rect key="frame" x="25" y="156" width="100" height="18"/>
+                                                        <rect key="frame" x="25" y="159" width="100" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reminder days" id="tgu-cW-ZXH">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1040,7 +1009,7 @@
                                                         </connections>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JK4-nq-3q2">
-                                                        <rect key="frame" x="309" y="256" width="56" height="18"/>
+                                                        <rect key="frame" x="309" y="257" width="56" height="17"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="A65-xb-c7i">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1048,7 +1017,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="duI-RG-4BI">
-                                                        <rect key="frame" x="236" y="220" width="65" height="26"/>
+                                                        <rect key="frame" x="236" y="221" width="65" height="26"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="08:30" bezelStyle="round" id="b4B-zj-fDl">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1060,7 +1029,7 @@
                                                         </connections>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4pc-oy-DHZ">
-                                                        <rect key="frame" x="236" y="186" width="65" height="26"/>
+                                                        <rect key="frame" x="236" y="188" width="65" height="26"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="16:30" bezelStyle="round" id="tjn-vP-RNk">
                                                             <font key="font" metaFont="menu" size="14"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1072,7 +1041,7 @@
                                                         </connections>
                                                     </textField>
                                                     <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6QJ-hs-Dfs">
-                                                        <rect key="frame" x="236" y="13" width="48" height="158"/>
+                                                        <rect key="frame" x="236" y="15" width="48" height="158"/>
                                                         <subviews>
                                                             <button translatesAutoresizingMaskIntoConstraints="NO" id="6g9-yq-5Jx">
                                                                 <rect key="frame" x="-2" y="142" width="51" height="18"/>
@@ -1213,7 +1182,7 @@
                         </tabViewItems>
                     </tabView>
                     <box boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="x8k-FT-alL">
-                        <rect key="frame" x="32" y="538" width="344" height="20"/>
+                        <rect key="frame" x="32" y="513" width="344" height="20"/>
                         <view key="contentView" id="6PL-X1-TWK">
                             <rect key="frame" x="0.0" y="0.0" width="344" height="20"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1221,7 +1190,7 @@
                         <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </box>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2zJ-7y-OAc">
-                        <rect key="frame" x="30" y="535" width="348" height="24"/>
+                        <rect key="frame" x="30" y="510" width="348" height="24"/>
                         <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="V97-Jh-edB">
                             <font key="font" metaFont="system"/>
                             <segments>
@@ -1275,12 +1244,11 @@ CA
         </menu>
     </objects>
     <resources>
-        <image name="NSCaution" width="32" height="32"/>
         <namedColor name="preference-background-color">
-            <color red="0.98039215686274506" green="0.98431372549019602" blue="0.9882352941176471" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.98000001907348633" green="0.98400002717971802" blue="0.98799997568130493" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="preference-box-background-color">
-            <color red="0.69411764705882351" green="0.69411764705882351" blue="0.69411764705882351" alpha="0.070000000298023224" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.6940000057220459" green="0.6940000057220459" blue="0.6940000057220459" alpha="0.070000000298023224" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
### 📒 Description
This PR would do the following tasks:
1. Remove the Timeline checkbox and logic in Preference
2. Add the ⚠️ Warning icon, which positions next the Timeline Switcher in Timeline view to notify the user that the Screen Recording permission is not granted.

<img width="493" alt="Screen Shot 2020-01-20 at 13 12 58" src="https://user-images.githubusercontent.com/5878421/72702983-f88f0380-3b86-11ea-8e96-4052aa4751ce.png">

### Why do we need the ⚠️ 
There is a scenario that the user is not fully aware that they need to Screen Recording Permission in Catalina, even though the Timeline Switcher is ON. (Old user with timeline_record = true on the Backend)

By introducing the Warning, it would notify the user properly. 

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
- [x] Remove al Timeline in Preference 
- [x] Add the Warning and logic to present/hide if needed.

### 👫 Relationships
Closes #3744 

### 🔎 Review hints
#### Make sure the Timeline is removed from the Preference
1. Open the Preference and verify that

#### The warning icon is present / hide appropriately 
- If the app has not granted he Screen Recording permission yet -> ⚠️ should be presented
- If the app has granted he Screen Recording permission yet -> ⚠️ should be dismissed
- If the permission granted or not, but the Switcher is OFF -> ⚠️ should be dismissed
