### PR TITLE
Add shortcut to switch to next or previous day

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.swift
@@ -75,6 +75,16 @@ final class MainDashboardViewController: NSViewController {
         guard let cmd = noti.object as? TimelineDisplayCommand else { return }
         timelineController.render(with: cmd)
     }
+
+    @objc func nextDay() {
+        currentTab = .timeline
+        timelineController.nextDay()
+    }
+
+    @objc func previousDay() {
+        currentTab = .timeline
+        timelineController.previousDay()
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -184,6 +184,14 @@ final class TimelineDashboardViewController: NSViewController {
         super.mouseExited(with: event)
         zoomContainerView.isHidden = true
     }
+
+    func nextDay() {
+        datePickerView.nextDateBtnOnTap(self)
+    }
+
+    func previousDay() {
+        datePickerView.previousDateBtnOnTap(self)
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -43,7 +43,7 @@
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oEw-Jd-lIP">
                             <rect key="frame" x="34" y="56" width="101" height="17"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" title="Record activity" id="x0y-gM-oPn">
-                                <font key="font" metaFont="system" size="14"/>
+                                <font key="font" metaFont="menu" size="14"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -115,7 +115,7 @@
                                             <rect key="frame" x="33" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSAddTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="as8-De-WrX">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
+                                                <font key="font" metaFont="label" size="13"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelIncreaseOnChange:" target="-2" id="QsV-0i-5La"/>
@@ -125,7 +125,7 @@
                                             <rect key="frame" x="10" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="kr9-Ry-BUy">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
+                                                <font key="font" metaFont="label" size="13"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelDecreaseOnChange:" target="-2" id="ksx-ak-4he"/>
@@ -207,7 +207,7 @@
                                 <constraint firstAttribute="width" constant="140" id="mdj-ct-y7d"/>
                             </constraints>
                             <textFieldCell key="cell" alignment="center" title="No entries here…  Go ahead and track some time!" id="rM7-R2-ABZ">
-                                <font key="font" metaFont="system"/>
+                                <font key="font" metaFont="label" size="13"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -215,7 +215,7 @@
                         <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3EE-on-mJF">
                             <rect key="frame" x="327" y="287" width="252" height="16"/>
                             <textFieldCell key="cell" alignment="center" title="Turn on activity recording to see results." id="PUb-OL-l5z">
-                                <font key="font" metaFont="system"/>
+                                <font key="font" metaFont="label" size="13"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -363,6 +363,16 @@ extern void *ctx;
     [self.mainDashboardViewController timelineBtnOnTap:sender];
 }
 
+- (IBAction)nextDayMenuOnClick:(id)sender
+{
+    [self.mainDashboardViewController nextDay];
+}
+
+- (IBAction)previouosDayMenuOnClick:(id)sender
+{
+    [self.mainDashboardViewController previousDay];
+}
+
 #pragma mark - In app message
 
 - (void)startDisplayInAppMessage:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -229,6 +229,17 @@
                                     <action selector="zoomOutBtnOnTap:" target="-1" id="Q5Y-dr-37M"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="KUm-TA-aKU"/>
+                            <menuItem title="Next Day" tag="3" keyEquivalent="" toolTip="Change a current Timeliine day to next day" id="HEB-2o-715">
+                                <connections>
+                                    <action selector="nextDayMenuOnClick:" target="-1" id="uVN-Lv-UoP"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Previous Day" tag="3" keyEquivalent="" toolTip="Change a current Timeliine day to previous day" id="kdC-8f-3ea">
+                                <connections>
+                                    <action selector="previouosDayMenuOnClick:" target="-1" id="kIq-Tb-6ik"/>
+                                </connections>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>
@@ -309,7 +320,7 @@
             <rect key="frame" x="0.0" y="0.0" width="164" height="23"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="selectOne" id="1459">
-                <font key="font" metaFont="menu" size="9"/>
+                <font key="font" metaFont="label" size="9"/>
                 <segments>
                     <segment label="Weekly log" width="81"/>
                     <segment label="Quick selection" width="81" selected="YES" tag="1"/>


### PR DESCRIPTION
### 📒 Description
This PR would introduce the Next Day and Previous Day menus, which are under Timeline menu and provide shortcut capability.

### 🕶️ Types of changes
 **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add menu, shortcut, and logic to switch to next or previous day

### 👫 Relationships
Close #3742

### 🔎 Review hints
1. Double check we can switch next day by CMD + Right , or CMD + Left for previous day

