### PR TITLE
Fix sub-entries display on Windows

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
@@ -208,7 +208,7 @@ namespace TogglDesktop
             group = item.Group;
             groupName = item.GroupName;
             groupOpen = item.GroupOpen;
-            SubItem = (item.GroupItemCount > 0 && item.GroupOpen && !item.Group);
+            SubItem = (item.GroupItemCount == 0 && !item.Group);
             // subitem that is open
             if (SubItem)
             {


### PR DESCRIPTION
### 📒 Description
Fixes sub-entries display on Windows by correctly detecting which time entry is a sub-entry.

![image](https://user-images.githubusercontent.com/16451391/73014507-fcd74d00-3e22-11ea-8c19-4b384af4de36.png)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3762

### 🔎 Review hints
Make sure the sub-entries are displayed correctly.
Make sure basic time entry list functionality still works as expected.