### PR TITLE
Introduce a new Logger class, use it instead of Poco::Logger

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,8 @@ include_directories(
 
 # TogglDesktopLibrary sources
 set(LIBRARY_SOURCE_FILES
+    util/logger.cc
+
     base_model.cc
     batch_update_result.cc
     client.cc

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -17,8 +17,7 @@
 #include "settings.h"
 #include "urls.h"
 #include "user.h"
-
-#include <Poco/Logger.h>
+#include "util/logger.h"
 
 namespace toggl {
 
@@ -162,7 +161,7 @@ void GoogleAnalyticsEvent::runTask() {
     HTTPSClient client;
     HTTPSResponse resp = client.Get(req);
     if (resp.err != noError) {
-        Poco::Logger::get("Analytics").error(resp.err);
+        Logger("Analytics").error(resp.err);
         return;
     }
 }
@@ -322,7 +321,7 @@ void GoogleAnalyticsSettingsEvent::makeReq() {
     HTTPSClient client;
     HTTPSResponse resp = client.Get(req);
     if (resp.err != noError) {
-        Poco::Logger::get("Analytics").error(resp.err);
+        Logger("Analytics").error(resp.err);
         return;
     }
 }

--- a/src/base_model.cc
+++ b/src/base_model.cc
@@ -12,7 +12,6 @@
 #include <Poco/Timestamp.h>
 #include <Poco/DateTime.h>
 #include <Poco/LocalDateTime.h>
-#include <Poco/Logger.h>
 
 namespace toggl {
 
@@ -197,8 +196,8 @@ error BaseModel::BatchUpdateJSON(Json::Value *result) const {
     return noError;
 }
 
-Poco::Logger &BaseModel::logger() const {
-    return Poco::Logger::get(ModelName());
+Logger BaseModel::logger() const {
+    return { ModelName() };
 }
 
 void BaseModel::SetDirty() {

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -12,12 +12,9 @@
 
 #include "const.h"
 #include "types.h"
+#include "util/logger.h"
 
 #include <Poco/Types.h>
-
-namespace Poco {
-class Logger;
-}
 
 namespace toggl {
 
@@ -156,7 +153,7 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     error BatchUpdateJSON(Json::Value *result) const;
 
  protected:
-    Poco::Logger &logger() const;
+    Logger logger() const;
 
     bool userCannotAccessWorkspace(const toggl::error &err) const;
 

--- a/src/batch_update_result.cc
+++ b/src/batch_update_result.cc
@@ -7,8 +7,6 @@
 
 #include "base_model.h"
 
-#include <Poco/Logger.h>
-
 namespace toggl {
 
 error BatchUpdateResult::Error() const {
@@ -56,25 +54,21 @@ void BatchUpdateResult::ProcessResponseArray(
     poco_check_ptr(models);
     poco_check_ptr(errors);
 
-    Poco::Logger &logger = Poco::Logger::get("BatchUpdateResult");
     for (std::vector<BatchUpdateResult>::const_iterator it = results->begin();
             it != results->end();
             ++it) {
         BatchUpdateResult result = *it;
 
-        logger.debug(result.String());
+        logger().debug(result.String());
 
         if (result.GUID.empty()) {
-            logger.error("Batch update result has no GUID");
+            logger().error("Batch update result has no GUID");
             continue;
         }
 
         BaseModel *model = (*models)[result.GUID];
         if (!model) {
-            std::stringstream ss;
-            ss << "Server response includes a model we don't have! GUID="
-               << result.GUID;
-            logger.warning(ss.str());
+            logger().warning("Server response includes a model we don't have! GUID=", result.GUID);
             continue;
         }
         error err = model->ApplyBatchUpdateResult(&result);
@@ -85,22 +79,24 @@ void BatchUpdateResult::ProcessResponseArray(
     }
 }
 
+Logger BatchUpdateResult::logger() {
+    return { "BatchUpdateResult" };
+}
+
 error BatchUpdateResult::ParseResponseArray(
     const std::string &response_body,
     std::vector<BatchUpdateResult> *responses) {
 
     poco_check_ptr(responses);
 
-    Poco::Logger &logger = Poco::Logger::get("BatchUpdateResult");
-
     // There seem to be cases where response body is 0.
     // Must investigate further.
     if (response_body.empty()) {
-        logger.warning("Response is empty!");
+        logger().warning("Response is empty!");
         return noError;
     }
 
-    logger.debug(response_body);
+    logger().debug(response_body);
 
     Json::Value root;
     Json::Reader reader;

--- a/src/batch_update_result.h
+++ b/src/batch_update_result.h
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "types.h"
+#include "util/logger.h"
 
 #include <json/json.h>  // NOLINT
 
@@ -43,6 +44,10 @@ class TOGGL_INTERNAL_EXPORT BatchUpdateResult {
         std::vector<BatchUpdateResult> * const results,
         std::map<std::string, BaseModel *> *models,
         std::vector<error> *errors);
+
+ private:
+    static Logger logger();
+
 };
 
 }  // namespace toggl

--- a/src/context.cc
+++ b/src/context.cc
@@ -38,7 +38,6 @@
 #include <Poco/File.h>
 #include <Poco/FileStream.h>
 #include <Poco/FormattingChannel.h>
-#include <Poco/Logger.h>
 #include <Poco/Net/FilePartSource.h>
 #include <Poco/Net/HTMLForm.h>
 #include <Poco/Net/HTTPStreamFactory.h>
@@ -191,11 +190,11 @@ void Context::stopActivities() {
             }
         }
     } catch(const Poco::Exception& exc) {
-        logger().debug(exc.displayText());
+        logger.debug(exc.displayText());
     } catch(const std::exception& ex) {
-        logger().debug(ex.what());
+        logger.debug(ex.what());
     } catch(const std::string & ex) {
-        logger().debug(ex);
+        logger.debug(ex);
     }
 
     {
@@ -236,7 +235,7 @@ void Context::Shutdown() {
 
 error Context::StartEvents() {
     try {
-        logger().debug("StartEvents");
+        logger.debug("StartEvents");
 
         {
             Poco::Mutex::ScopedLock lock(user_m_);
@@ -252,7 +251,7 @@ error Context::StartEvents() {
         // Check that UI is wired up
         error err = UI()->VerifyCallbacks();
         if (err != noError) {
-            logger().error(err);
+            logger.error(err);
             std::cerr << err << std::endl;
             std::cout << err << std::endl;
             return displayError("UI is not properly wired up!");
@@ -279,7 +278,7 @@ error Context::StartEvents() {
 
         // Set since param to 0 to force full sync on app start
         user->SetSince(0);
-        logger().debug("fullSyncOnAppStart");
+        logger.debug("fullSyncOnAppStart");
 
         updateUI(UIElements::Reset());
 
@@ -310,7 +309,7 @@ error Context::StartEvents() {
 }
 
 error Context::save(const bool push_changes) {
-    logger().debug("save");
+    logger.debug("save");
     try {
         std::vector<ModelChange> changes;
 
@@ -329,7 +328,7 @@ error Context::save(const bool push_changes) {
         updateUI(render);
 
         if (push_changes) {
-            logger().debug("onPushChanges executing");
+            logger.debug("onPushChanges executing");
 
             // Always sync asyncronously with syncerActivity
             trigger_push_ = true;
@@ -496,7 +495,7 @@ void UIElements::ApplyChanges(
 }
 
 void Context::OpenTimeEntryList() {
-    logger().debug("OpenTimeEntryList");
+    logger.debug("OpenTimeEntryList");
 
     UIElements render;
     render.open_time_entry_list = true;
@@ -505,7 +504,7 @@ void Context::OpenTimeEntryList() {
 }
 
 void Context::updateUI(const UIElements &what) {
-    logger().debug("updateUI " + what.String());
+    logger.debug("updateUI " + what.String());
 
     view::TimeEntry editor_time_entry_view;
 
@@ -1017,7 +1016,7 @@ bool Context::isPostponed(
     }
     Poco::Timestamp::TimeDiff diff = value - now;
     if (diff > 2*throttleMicros) {
-        logger().warning(
+        logger.warning(
             "Cannot postpone task, its foo far in the future");
         return false;
     }
@@ -1056,26 +1055,16 @@ error Context::displayError(const error &err) {
 
 int Context::nextSyncIntervalSeconds() const {
     int n = static_cast<int>(Random::next(kSyncIntervalRangeSeconds)) + kSyncIntervalRangeSeconds;
-    std::stringstream ss;
-    ss << "Next autosync in " << n << " seconds";
-    logger().trace(ss.str());
+    logger.trace("Next autosync in ", n, " seconds");
     return n;
 }
 
 void Context::scheduleSync() {
     Poco::Int64 elapsed_seconds = Poco::Int64(time(nullptr)) - last_sync_started_;
-
-    {
-        std::stringstream ss;
-        ss << "scheduleSync elapsed_seconds=" << elapsed_seconds;
-        logger().debug(ss.str());
-    }
+    logger.debug("scheduleSync elapsed_seconds=", elapsed_seconds);
 
     if (elapsed_seconds < sync_interval_seconds_) {
-        std::stringstream ss;
-        ss << "Last sync attempt less than " << sync_interval_seconds_
-           << " seconds ago, chill";
-        logger().trace(ss.str());
+        logger.trace("Last sync attempt less than ", sync_interval_seconds_, " seconds ago, chill");
         return;
     }
 
@@ -1088,7 +1077,7 @@ void Context::FullSync() {
 }
 
 void Context::Sync() {
-    logger().debug("Sync");
+    logger.debug("Sync");
 
     if (!user_) {
         return;
@@ -1137,9 +1126,7 @@ void Context::onProjectAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
 }
 
 void Context::setOnline(const std::string &reason) {
-    std::stringstream ss;
-    ss << "setOnline, reason:" << reason;
-    logger().debug(ss.str());
+    logger.debug("setOnline, reason:", reason);
 
     if (quit_) {
         return;
@@ -1151,7 +1138,7 @@ void Context::setOnline(const std::string &reason) {
 }
 
 void Context::switchWebSocketOff() {
-    logger().debug("switchWebSocketOff");
+    logger.debug("switchWebSocketOff");
 
     Poco::Util::TimerTask::Ptr ptask =
         new Poco::Util::TimerTaskAdapter<Context>(
@@ -1162,20 +1149,18 @@ void Context::switchWebSocketOff() {
 }
 
 void Context::onSwitchWebSocketOff(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onSwitchWebSocketOff");
+    logger.debug("onSwitchWebSocketOff");
 
     Poco::Mutex::ScopedLock lock(ws_client_m_);
     ws_client_.Shutdown();
 }
 
 error Context::LoadUpdateFromJSONString(const std::string &json) {
-    std::stringstream ss;
-    ss << "LoadUpdateFromJSONString json=" << json;
-    logger().debug(ss.str());
+    logger.debug("LoadUpdateFromJSONString json=", json);
 
     Poco::Mutex::ScopedLock lock(user_m_);
     if (!user_) {
-        logger().warning("User is logged out, cannot update");
+        logger.warning("User is logged out, cannot update");
         return noError;
     }
 
@@ -1197,7 +1182,7 @@ error Context::LoadUpdateFromJSONString(const std::string &json) {
 }
 
 void Context::switchWebSocketOn() {
-    logger().debug("switchWebSocketOn");
+    logger.debug("switchWebSocketOn");
 
     Poco::Util::TimerTask::Ptr ptask =
         new Poco::Util::TimerTaskAdapter<Context>(
@@ -1208,7 +1193,7 @@ void Context::switchWebSocketOn() {
 }
 
 void Context::onSwitchWebSocketOn(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onSwitchWebSocketOn");
+    logger.debug("onSwitchWebSocketOn");
 
     std::string apitoken("");
 
@@ -1220,7 +1205,7 @@ void Context::onSwitchWebSocketOn(Poco::Util::TimerTask&) {  // NOLINT
     }
 
     if (apitoken.empty()) {
-        logger().error("No API token, cannot switch Websocket on");
+        logger.error("No API token, cannot switch Websocket on");
         return;
     }
 
@@ -1232,7 +1217,7 @@ void Context::onSwitchWebSocketOn(Poco::Util::TimerTask&) {  // NOLINT
 
 // Start/stop timeline recording on local machine
 void Context::switchTimelineOff() {
-    logger().debug("switchTimelineOff");
+    logger.debug("switchTimelineOff");
 
     Poco::Util::TimerTask::Ptr ptask =
         new Poco::Util::TimerTaskAdapter<Context>(
@@ -1243,7 +1228,7 @@ void Context::switchTimelineOff() {
 }
 
 void Context::onSwitchTimelineOff(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onSwitchTimelineOff");
+    logger.debug("onSwitchTimelineOff");
 
     {
         Poco::Mutex::ScopedLock lock(timeline_uploader_m_);
@@ -1255,7 +1240,7 @@ void Context::onSwitchTimelineOff(Poco::Util::TimerTask&) {  // NOLINT
 }
 
 void Context::switchTimelineOn() {
-    logger().debug("switchTimelineOn");
+    logger.debug("switchTimelineOn");
 
     Poco::Util::TimerTask::Ptr ptask =
         new Poco::Util::TimerTaskAdapter<Context>(
@@ -1270,7 +1255,7 @@ void Context::switchTimelineOn() {
 }
 
 void Context::onSwitchTimelineOn(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onSwitchTimelineOn");
+    logger.debug("onSwitchTimelineOn");
 
     if (quit_) {
         return;
@@ -1294,7 +1279,7 @@ void Context::onSwitchTimelineOn(Poco::Util::TimerTask&) {  // NOLINT
 }
 
 void Context::fetchUpdates() {
-    logger().debug("fetchUpdates");
+    logger.debug("fetchUpdates");
 
     next_fetch_updates_at_ =
         postpone(kRequestThrottleSeconds * kOneSecondInMicros);
@@ -1305,16 +1290,13 @@ void Context::fetchUpdates() {
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_fetch_updates_at_);
 
-    std::stringstream ss;
-    ss << "Next update fetch at "
-       << Formatter::Format8601(next_fetch_updates_at_);
-    logger().debug(ss.str());
+    logger.debug("Next update fetch at ", Formatter::Format8601(next_fetch_updates_at_));
 }
 
 void Context::onFetchUpdates(Poco::Util::TimerTask&) {  // NOLINT
     if (isPostponed(next_fetch_updates_at_,
                     kRequestThrottleSeconds * kOneSecondInMicros)) {
-        logger().debug("onFetchUpdates postponed");
+        logger.debug("onFetchUpdates postponed");
         return;
     }
 
@@ -1322,7 +1304,7 @@ void Context::onFetchUpdates(Poco::Util::TimerTask&) {  // NOLINT
 }
 
 void Context::startPeriodicSync() {
-    logger().trace("startPeriodicSync");
+    logger.trace("startPeriodicSync");
 
     Poco::Util::TimerTask::Ptr ptask =
         new Poco::Util::TimerTaskAdapter<Context>
@@ -1335,14 +1317,11 @@ void Context::startPeriodicSync() {
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_periodic_sync_at_);
 
-    std::stringstream ss;
-    ss << "Next periodic sync at "
-       << Formatter::Format8601(next_periodic_sync_at_);
-    logger().debug(ss.str());
+    logger.debug("Next periodic sync at ", Formatter::Format8601(next_periodic_sync_at_));
 }
 
 void Context::onPeriodicSync(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onPeriodicSync");
+    logger.debug("onPeriodicSync");
 
     scheduleSync();
 
@@ -1350,7 +1329,7 @@ void Context::onPeriodicSync(Poco::Util::TimerTask&) {  // NOLINT
 }
 
 void Context::startPeriodicUpdateCheck() {
-    logger().debug("startPeriodicUpdateCheck");
+    logger.debug("startPeriodicUpdateCheck");
 
     Poco::Util::TimerTask::Ptr ptask =
         new Poco::Util::TimerTaskAdapter<Context>
@@ -1362,14 +1341,11 @@ void Context::startPeriodicUpdateCheck() {
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_periodic_check_at);
 
-    std::stringstream ss;
-    ss << "Next periodic update check at "
-       << Formatter::Format8601(next_periodic_check_at);
-    logger().debug(ss.str());
+    logger.debug("Next periodic update check at ", Formatter::Format8601(next_periodic_check_at));
 }
 
 void Context::onPeriodicUpdateCheck(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onPeriodicUpdateCheck");
+    logger.debug("onPeriodicUpdateCheck");
 
     executeUpdateCheck();
 
@@ -1377,7 +1353,7 @@ void Context::onPeriodicUpdateCheck(Poco::Util::TimerTask&) {  // NOLINT
 }
 
 void Context::startPeriodicInAppMessageCheck() {
-    logger().debug("startPeriodicInAppMessageCheck");
+    logger.debug("startPeriodicInAppMessageCheck");
 
     Poco::Util::TimerTask::Ptr ptask =
         new Poco::Util::TimerTaskAdapter<Context>
@@ -1389,14 +1365,11 @@ void Context::startPeriodicInAppMessageCheck() {
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_periodic_check_at);
 
-    std::stringstream ss;
-    ss << "Next periodic in-app message check at "
-       << Formatter::Format8601(next_periodic_check_at);
-    logger().debug(ss.str());
+    logger.debug("Next periodic in-app message check at ", Formatter::Format8601(next_periodic_check_at));
 }
 
 void Context::onPeriodicInAppMessageCheck(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onPeriodicInAppMessageChec");
+    logger.debug("onPeriodicInAppMessageChec");
 
     fetchMessage(1);
 }
@@ -1430,7 +1403,7 @@ std::string Context::UserEmail() {
 }
 
 void Context::executeUpdateCheck() {
-    logger().debug("executeUpdateCheck");
+    logger.debug("executeUpdateCheck");
 
     displayError(downloadUpdate());
 }
@@ -1443,7 +1416,7 @@ error Context::downloadUpdate() {
 
         // To test updater in development, comment this block out:
         if ("production" != environment_) {
-            logger().debug("Not in production, will not download updates");
+            logger.debug("Not in production, will not download updates");
             return noError;
         }
 
@@ -1494,12 +1467,9 @@ error Context::downloadUpdate() {
             version_number = versionNumberJsonToken.asString();
 
             if (lessThanVersion(HTTPSClient::Config.AppVersion, version_number)) {
-                std::stringstream ss;
-                ss << "Found update " << version_number
-                   << " (" << url << ")";
-                logger().debug(ss.str());
+                logger.debug("Found update ", version_number, " (", url, ")");
             } else {
-                logger().debug("The app is up to date");
+                logger.debug("The app is up to date");
                 if (UI()->CanDisplayUpdate()) {
                     UI()->DisplayUpdate("");
                 }
@@ -1522,7 +1492,7 @@ error Context::downloadUpdate() {
         // Ignore update if not compatible with this client version
         // only windows .exe installers are supported atm
         if (url.find(".exe") == std::string::npos) {
-            logger().debug("Update is not compatible with this client,"
+            logger.debug("Update is not compatible with this client,"
                            " will ignore");
             return noError;
         }
@@ -1540,7 +1510,7 @@ error Context::downloadUpdate() {
 
             Poco::File f(file);
             if (f.exists()) {
-                logger().debug("File already exists: " + file);
+                logger.debug("File already exists: " + file);
                 return noError;
             }
 
@@ -1580,13 +1550,13 @@ error Context::fetchMessage(const bool periodic) {
 
         // Check if in-app messaging is supported and show
         if (!UI()->CanDisplayMessage()) {
-            logger().debug("In-app messages not supported on this platform");
+            logger.debug("In-app messages not supported on this platform");
             return noError;
         }
 
         // To test in-app message fetch in development, comment this block out:
         if ("production" != environment_) {
-            logger().debug("Not in production, will not fetch in-app messages");
+            logger.debug("Not in production, will not fetch in-app messages");
             return noError;
         }
 
@@ -1640,7 +1610,7 @@ error Context::fetchMessage(const bool periodic) {
                     !root.isMember("url-mac") ||
                     !root.isMember("url-win") ||
                     !root.isMember("url-linux")) {
-                logger().debug("Required fields are missing in in-app message JSON");
+                logger.debug("Required fields are missing in in-app message JSON");
                 return noError;
             }
 
@@ -1796,7 +1766,7 @@ bool Context::lessThanVersion(const std::string& version1, const std::string& ve
 }
 
 void Context::TimelineUpdateServerSettings() {
-    logger().debug("TimelineUpdateServerSettings");
+    logger.debug("TimelineUpdateServerSettings");
 
     next_update_timeline_settings_at_ =
         postpone(kRequestThrottleSeconds * kOneSecondInMicros);
@@ -1807,10 +1777,7 @@ void Context::TimelineUpdateServerSettings() {
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_update_timeline_settings_at_);
 
-    std::stringstream ss;
-    ss << "Next timeline settings update at "
-       << Formatter::Format8601(next_update_timeline_settings_at_);
-    logger().debug(ss.str());
+    logger.debug("Next timeline settings update at ", Formatter::Format8601(next_update_timeline_settings_at_));
 }
 
 const std::string kRecordTimelineEnabledJSON = "{\"record_timeline\": true}";
@@ -1819,11 +1786,11 @@ const std::string kRecordTimelineDisabledJSON = "{\"record_timeline\": false}";
 void Context::onTimelineUpdateServerSettings(Poco::Util::TimerTask&) {  // NOLINT
     if (isPostponed(next_update_timeline_settings_at_,
                     kRequestThrottleSeconds * kOneSecondInMicros)) {
-        logger().debug("onTimelineUpdateServerSettings postponed");
+        logger.debug("onTimelineUpdateServerSettings postponed");
         return;
     }
 
-    logger().debug("onTimelineUpdateServerSettings executing");
+    logger.debug("onTimelineUpdateServerSettings executing");
 
     std::string apitoken("");
     std::string json(kRecordTimelineDisabledJSON);
@@ -1851,14 +1818,14 @@ void Context::onTimelineUpdateServerSettings(Poco::Util::TimerTask&) {  // NOLIN
     HTTPSResponse resp = client.Post(req);
     if (resp.err != noError) {
         displayError(resp.err);
-        logger().error(resp.body);
-        logger().error(resp.err);
+        logger.error(resp.body);
+        logger.error(resp.err);
     }
 }
 
 error Context::SendFeedback(const Feedback &fb) {
     if (!user_) {
-        logger().warning("Cannot send feedback, user logged out");
+        logger.warning("Cannot send feedback, user logged out");
         return noError;
     }
 
@@ -1882,7 +1849,7 @@ error Context::SendFeedback(const Feedback &fb) {
 }
 
 void Context::onSendFeedback(Poco::Util::TimerTask&) {  // NOLINT
-    logger().debug("onSendFeedback");
+    logger.debug("onSendFeedback");
 
     std::string api_token_value("");
     std::string api_token_name("");
@@ -1955,7 +1922,7 @@ void Context::onSendFeedback(Poco::Util::TimerTask&) {  // NOLINT
 
     TogglClient client(UI());
     HTTPSResponse resp = client.Post(req);
-    logger().debug("Feedback result: " + resp.err);
+    logger.debug("Feedback result: " + resp.err);
     if (resp.err != noError) {
         displayError(resp.err);
         return;
@@ -2338,7 +2305,7 @@ error Context::SetProxySettings(
 }
 
 void Context::OpenSettings() {
-    logger().debug("OpenSettings");
+    logger.debug("OpenSettings");
 
     UIElements render;
     render.display_settings = true;
@@ -2349,13 +2316,11 @@ void Context::OpenSettings() {
 error Context::SetDBPath(
     const std::string &path) {
     try {
-        std::stringstream ss;
-        ss << "SetDBPath " << path;
-        logger().debug(ss.str());
+        logger.debug("SetDBPath ", path);
 
         Poco::Mutex::ScopedLock lock(db_m_);
         if (db_) {
-            logger().debug("delete db_ from SetDBPath()");
+            logger.debug("delete db_ from SetDBPath()");
             delete db_;
             db_ = nullptr;
         }
@@ -2374,12 +2339,10 @@ void Context::SetEnvironment(const std::string &value) {
     if (!("production" == value ||
             "development" == value ||
             "test" == value)) {
-        std::stringstream ss;
-        ss << "Invalid environment '" << value << "'!";
-        logger().error(ss.str());
+        logger.error("Invalid environment '", value, "'!");
         return;
     }
-    logger().debug("SetEnvironment " + value);
+    logger.debug("SetEnvironment " + value);
     environment_ = value;
 
     HTTPSClient::Config.IgnoreCert = ("development" == environment_);
@@ -2419,13 +2382,13 @@ error Context::attemptOfflineLogin(const std::string &email,
 
     if (!user->ID()) {
         delete user;
-        logger().debug("User data not found in local database for " + email);
+        logger.debug("User data not found in local database for " + email);
         return error(kEmailNotFoundCannotLogInOffline);
     }
 
     if (user->OfflineData().empty()) {
         delete user;
-        logger().debug("Offline data not found in local database for "
+        logger.debug("Offline data not found in local database for "
                        + email);
         return error(kEmailNotFoundCannotLogInOffline);
     }
@@ -2476,10 +2439,7 @@ error Context::Login(
             // Indicate we're offline
             displayError(err);
 
-            std::stringstream ss;
-            ss << "Got networking error " << err
-               << " will attempt offline login";
-            logger().debug(ss.str());
+            logger.debug("Got networking error ", err, " will attempt offline login");
 
             return displayError(attemptOfflineLogin(email, password));
         }
@@ -2502,7 +2462,7 @@ error Context::Login(
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().error("cannot enable offline login, no user");
+                logger.error("cannot enable offline login, no user");
                 return noError;
             }
 
@@ -2570,11 +2530,7 @@ error Context::AsyncGoogleSignup(const std::string &access_token,
 }
 
 void Context::setUser(User *value, const bool logged_in) {
-    {
-        std::stringstream ss;
-        ss << "setUser user_logged_in=" << logged_in;
-        logger().debug(ss.str());
-    }
+    logger.debug("setUser user_logged_in=", logged_in);
 
     Poco::UInt64 user_id(0);
 
@@ -2705,13 +2661,13 @@ error Context::SetLoggedInUserFromJSON(
     // Fetch OBM experiments..
     err = pullObmExperiments();
     if (err != noError) {
-        logger().error("Error pulling OBM experiments: " + err);
+        logger.error("Error pulling OBM experiments: " + err);
     }
 
     // ..and run the OBM experiments
     err = runObmExperiments();
     if (err != noError) {
-        logger().error("Error running OBM experiments: " + err);
+        logger.error("Error running OBM experiments: " + err);
     }
 
     return noError;
@@ -2720,7 +2676,7 @@ error Context::SetLoggedInUserFromJSON(
 error Context::Logout() {
     try {
         if (!user_) {
-            logger().warning("User is logged out, cannot logout again");
+            logger.warning("User is logged out, cannot logout again");
             return noError;
         }
 
@@ -2729,7 +2685,7 @@ error Context::Logout() {
             return displayError(err);
         }
 
-        logger().debug("setUser from Logout");
+        logger.debug("setUser from Logout");
         overlay_visible_ = false;
         setUser(nullptr);
 
@@ -2760,7 +2716,7 @@ error Context::ClearCache() {
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("User is logged out, cannot clear cache");
+                logger.warning("User is logged out, cannot clear cache");
                 return noError;
             }
             err = db()->DeleteUser(user_, true);
@@ -2809,7 +2765,7 @@ TimeEntry *Context::Start(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot start tracking, user logged out");
+            logger.warning("Cannot start tracking, user logged out");
             return nullptr;
         }
 
@@ -2868,7 +2824,7 @@ void Context::OpenTimeEntryEditor(
     const bool edit_running_entry,
     const std::string &focused_field_name) {
     if (!edit_running_entry && GUID.empty()) {
-        logger().error("Cannot edit time entry without a GUID");
+        logger.error("Cannot edit time entry without a GUID");
         return;
     }
 
@@ -2877,7 +2833,7 @@ void Context::OpenTimeEntryEditor(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot edit time entry, user logged out");
+            logger.warning("Cannot edit time entry, user logged out");
             return;
         }
 
@@ -2889,7 +2845,7 @@ void Context::OpenTimeEntryEditor(
     }
 
     if (!te) {
-        logger().warning("Time entry not found for edit " + GUID);
+        logger.warning("Time entry not found for edit " + GUID);
         return;
     }
 
@@ -2933,7 +2889,7 @@ TimeEntry *Context::ContinueLatest(const bool prevent_on_app) {
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot continue tracking, user logged out");
+            logger.warning("Cannot continue tracking, user logged out");
             return nullptr;
         }
 
@@ -3007,7 +2963,7 @@ TimeEntry *Context::Continue(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot continue time entry, user logged out");
+            logger.warning("Cannot continue time entry, user logged out");
             return nullptr;
         }
 
@@ -3052,13 +3008,13 @@ error Context::DeleteTimeEntryByGUID(const std::string &GUID) {
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot delete time entry, user logged out");
+            logger.warning("Cannot delete time entry, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3091,12 +3047,12 @@ error Context::SetTimeEntryDuration(
 
     Poco::Mutex::ScopedLock lock(user_m_);
     if (!user_) {
-        logger().warning("Cannot set duration, user logged out");
+        logger.warning("Cannot set duration, user logged out");
         return noError;
     }
     TimeEntry *te = user_->related.TimeEntryByGUID(GUID);
     if (!te) {
-        logger().warning("Time entry not found: " + GUID);
+        logger.warning("Time entry not found: " + GUID);
         return noError;
     }
 
@@ -3126,13 +3082,13 @@ error Context::SetTimeEntryProject(
 
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot set project, user logged out");
+            logger.warning("Cannot set project, user logged out");
             return noError;
         }
 
         TimeEntry *te = user_->related.TimeEntryByGUID(GUID);
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3195,13 +3151,13 @@ error Context::SetTimeEntryDate(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot change date, user logged out");
+            logger.warning("Cannot change date, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3247,13 +3203,13 @@ error Context::SetTimeEntryStart(const std::string GUID,
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot change start time, user logged out");
+            logger.warning("Cannot change start time, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3281,13 +3237,13 @@ error Context::SetTimeEntryStart(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot change start time, user logged out");
+            logger.warning("Cannot change start time, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3334,13 +3290,13 @@ error Context::SetTimeEntryStop(const std::string GUID,
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot change stop time, user logged out");
+            logger.warning("Cannot change stop time, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3367,13 +3323,13 @@ error Context::SetTimeEntryStop(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot change stop time, user logged out");
+            logger.warning("Cannot change stop time, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3430,13 +3386,13 @@ error Context::SetTimeEntryTags(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot set tags, user logged out");
+            logger.warning("Cannot set tags, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3467,13 +3423,13 @@ error Context::SetTimeEntryBillable(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot set billable, user logged out");
+            logger.warning("Cannot set billable, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3504,13 +3460,13 @@ error Context::SetTimeEntryDescription(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot set description, user logged out");
+            logger.warning("Cannot set description, user logged out");
             return noError;
         }
         te = user_->related.TimeEntryByGUID(GUID);
 
         if (!te) {
-            logger().warning("Time entry not found: " + GUID);
+            logger.warning("Time entry not found: " + GUID);
             return noError;
         }
 
@@ -3540,7 +3496,7 @@ error Context::Stop(const bool prevent_on_app) {
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot stop tracking, user logged out");
+            logger.warning("Cannot stop tracking, user logged out");
             return noError;
         }
         user_->Stop(&stopped);
@@ -3549,7 +3505,7 @@ error Context::Stop(const bool prevent_on_app) {
     }
 
     if (stopped.empty()) {
-        logger().warning("No time entry was found to stop");
+        logger.warning("No time entry was found to stop");
         return noError;
     }
 
@@ -3577,15 +3533,15 @@ error Context::DiscardTimeAt(
 
     // Tracking action
     if ("production" == environment_) {
-        std::stringstream ss;
+        std::string method;
         if (split_into_new_entry) {
-            ss << "idle-as-new-entry";
+            method = "idle-as-new-entry";
         } else {
-            ss << "discard-and-stop";
+            method = "discard-and-stop";
         }
 
         analytics_.TrackIdleDetectionClick(db_->AnalyticsClientID(),
-                                           ss.str());
+                                           method);
     }
 
     TimeEntry *split = nullptr;
@@ -3593,7 +3549,7 @@ error Context::DiscardTimeAt(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot stop time entry, user logged out");
+            logger.warning("Cannot stop time entry, user logged out");
             return noError;
         }
 
@@ -3633,7 +3589,7 @@ TimeEntry *Context::DiscardTimeAndContinue(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot stop time entry, user logged out");
+            logger.warning("Cannot stop time entry, user logged out");
             return nullptr;
         }
         user_->DiscardTimeAt(guid, at, false);
@@ -3651,7 +3607,7 @@ TimeEntry *Context::DiscardTimeAndContinue(
 TimeEntry *Context::RunningTimeEntry() {
     Poco::Mutex::ScopedLock lock(user_m_);
     if (!user_) {
-        logger().warning("Cannot fetch time entry, user logged out");
+        logger.warning("Cannot fetch time entry, user logged out");
         return nullptr;
     }
     return user_->RunningTimeEntry();
@@ -3660,7 +3616,7 @@ TimeEntry *Context::RunningTimeEntry() {
 error Context::ToggleTimelineRecording(const bool record_timeline) {
     Poco::Mutex::ScopedLock lock(user_m_);
     if (!user_) {
-        logger().warning("Cannot toggle timeline, user logged out");
+        logger.warning("Cannot toggle timeline, user logged out");
         return noError;
     }
     try {
@@ -3713,7 +3669,7 @@ error Context::SetDefaultProject(
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("Cannot set default PID, user logged out");
+                logger.warning("Cannot set default PID, user logged out");
                 return noError;
             }
 
@@ -3770,7 +3726,7 @@ error Context::DefaultProjectName(std::string *name) {
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("Cannot get default PID, user logged out");
+                logger.warning("Cannot get default PID, user logged out");
                 return noError;
             }
             if (user_->DefaultPID()) {
@@ -3798,7 +3754,7 @@ error Context::DefaultPID(Poco::UInt64 *result) {
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("Cannot get default PID, user logged out");
+                logger.warning("Cannot get default PID, user logged out");
                 return noError;
             }
             *result = user_->DefaultPID();
@@ -3820,7 +3776,7 @@ error Context::DefaultTID(Poco::UInt64 *result) {
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("Cannot get default PID, user logged out");
+                logger.warning("Cannot get default PID, user logged out");
                 return noError;
             }
             *result = user_->DefaultTID();
@@ -3858,7 +3814,7 @@ error Context::AddAutotrackerRule(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("cannot add autotracker rule, user logged out");
+            logger.warning("cannot add autotracker rule, user logged out");
             return noError;
         }
         if (user_->related.HasMatchingAutotrackerRule(lowercase)) {
@@ -3923,7 +3879,7 @@ error Context::DeleteAutotrackerRule(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("cannot delete rule, user is logged out");
+            logger.warning("cannot delete rule, user is logged out");
             return noError;
         }
 
@@ -3965,7 +3921,7 @@ Project *Context::CreateProject(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot add project, user logged out");
+            logger.warning("Cannot add project, user logged out");
             return nullptr;
         }
         for (std::vector<Project *>::iterator it =
@@ -4061,7 +4017,7 @@ error Context::AddObmAction(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot create a OBM action, user logged out");
+            logger.warning("Cannot create a OBM action, user logged out");
             return noError;
         }
         ObmAction *action = new ObmAction();
@@ -4099,7 +4055,7 @@ Client *Context::CreateClient(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("Cannot create a client, user logged out");
+            logger.warning("Cannot create a client, user logged out");
             return nullptr;
         }
         for (std::vector<Client *>::iterator it =
@@ -4130,7 +4086,7 @@ void Context::SetSleep() {
 
     // Set Sleep as usual
     if (!isHandled) {
-        logger().debug("SetSleep");
+        logger.debug("SetSleep");
         idle_.SetSleep();
         if (window_change_recorder_) {
             window_change_recorder_->SetIsSleeping(true);
@@ -4261,7 +4217,7 @@ error Context::runObmExperiments() {
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("User logged out, cannot OBM experiment");
+                logger.warning("User logged out, cannot OBM experiment");
                 return noError;
             }
             for (std::vector<ObmExperiment *>::const_iterator it =
@@ -4302,7 +4258,7 @@ error Context::runObmExperiments() {
 }
 
 void Context::SetWake() {
-    logger().debug("SetWake");
+    logger.debug("SetWake");
 
     Poco::Timestamp::TimeDiff delay = 0;
     if (next_wake_at_ > 0) {
@@ -4316,19 +4272,16 @@ void Context::SetWake() {
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_wake_at_);
 
-    std::stringstream ss;
-    ss << "Next wake at "
-       << Formatter::Format8601(next_wake_at_);
-    logger().debug(ss.str());
+    logger.debug("Next wake at ", Formatter::Format8601(next_wake_at_));
 }
 
 void Context::onWake(Poco::Util::TimerTask&) {  // NOLINT
     if (isPostponed(next_wake_at_,
                     kRequestThrottleSeconds * kOneSecondInMicros)) {
-        logger().debug("onWake postponed");
+        logger.debug("onWake postponed");
         return;
     }
-    logger().debug("onWake executing");
+    logger.debug("onWake executing");
 
     try {
         Poco::LocalDateTime now;
@@ -4348,32 +4301,32 @@ void Context::onWake(Poco::Util::TimerTask&) {  // NOLINT
         Sync();
     }
     catch (const Poco::Exception& exc) {
-        logger().error(exc.displayText());
+        logger.error(exc.displayText());
     }
     catch (const std::exception& ex) {
-        logger().error(ex.what());
+        logger.error(ex.what());
     }
     catch (const std::string & ex) {
-        logger().error(ex);
+        logger.error(ex);
     }
 }
 
 void Context::SetLocked() {
-    logger().debug("SetLocked");
+    logger.debug("SetLocked");
     if (window_change_recorder_) {
         window_change_recorder_->SetIsLocked(true);
     }
 }
 
 void Context::SetUnlocked() {
-    logger().debug("SetUnlocked");
+    logger.debug("SetUnlocked");
     if (window_change_recorder_) {
         window_change_recorder_->SetIsLocked(false);
     }
 }
 
 void Context::SetOnline() {
-    logger().debug("SetOnline");
+    logger.debug("SetOnline");
     Sync();
 }
 
@@ -4424,7 +4377,7 @@ void Context::displayReminder() {
         (Poco::DateTime::FRIDAY == wday && !settings_.remind_fri) ||
         (Poco::DateTime::SATURDAY == wday && !settings_.remind_sat) ||
         (Poco::DateTime::SUNDAY == wday && !settings_.remind_sun)) {
-        logger().debug("reminder is not enabled on this weekday");
+        logger.debug("reminder is not enabled on this weekday");
         return;
     }
 
@@ -4435,11 +4388,7 @@ void Context::displayReminder() {
             Poco::LocalDateTime start(
                 now.year(), now.month(), now.day(), h, m, now.second());
             if (now < start) {
-                std::stringstream ss;
-                ss << "Reminder - its too early for reminders"
-                   << " [" << now.hour() << ":" << now.minute() << "]"
-                   << " (allowed from " << h << ":" << m << ")";
-                logger().debug(ss.str());
+                logger.debug("Reminder - its too early for reminders", " [", now.hour(), ":", now.minute(), "]", " (allowed from ", h, ":", m, ")");
                 return;
             }
         }
@@ -4447,14 +4396,9 @@ void Context::displayReminder() {
     if (!settings_.remind_ends.empty()) {
         int h(0), m(0);
         if (toggl::Formatter::ParseTimeInput(settings_.remind_ends, &h, &m)) {
-            Poco::LocalDateTime end(
-                now.year(), now.month(), now.day(), h, m, now.second());
+            Poco::LocalDateTime end(now.year(), now.month(), now.day(), h, m, now.second());
             if (now > end) {
-                std::stringstream ss;
-                ss << "Reminder - its too late for reminders"
-                   << " [" << now.hour() << ":" << now.minute() << "]"
-                   << " (allowed until " << h << ":" << m << ")";
-                logger().debug(ss.str());
+                logger.debug("Reminder - its too late for reminders", " [", now.hour(), ":", now.minute(), "]", " (allowed until ", h, ":", m, ")");
                 return;
             }
         }
@@ -4613,7 +4557,7 @@ error Context::CreateCompressedTimelineBatchForUpload(TimelineBatch *batch) {
     try {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("cannot create timeline batch, user logged out");
+            logger.warning("cannot create timeline batch, user logged out");
             return noError;
         }
 
@@ -4672,7 +4616,7 @@ error Context::MarkTimelineBatchAsUploaded(
     try {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("cannot mark timeline events as uploaded, "
+            logger.warning("cannot mark timeline events as uploaded, "
                              "user is already logged out");
             return noError;
         }
@@ -4794,7 +4738,7 @@ void Context::syncerActivity() {
                 err = pushObmAction();
                 if (err != noError) {
                     std::cout << "SYNC: sync-pushObm ERROR\n";
-                    logger().error("Error pushing OBM action: " + err);
+                    logger.error("Error pushing OBM action: " + err);
                 }
 
                 displayError(save(false));
@@ -4821,7 +4765,7 @@ void Context::syncerActivity() {
                 err = pushObmAction();
                 if (err != noError) {
                     std::cout << "SYNC: pushObm ERROR\n";
-                    logger().error("Error pushing OBM action: " + err);
+                    logger.error("Error pushing OBM action: " + err);
                 }
 
                 displayError(save(false));
@@ -4858,7 +4802,7 @@ void Context::onLoadMore(Poco::Util::TimerTask&) {
     }
 
     if (api_token.empty()) {
-        return logger().warning(
+        return logger.warning(
             "cannot load more time entries without API token");
     }
 
@@ -4867,9 +4811,7 @@ void Context::onLoadMore(Poco::Util::TimerTask&) {
         ss << "/api/v9/me/time_entries?since="
            << (Poco::Timestamp() - Poco::Timespan(60, 0, 0, 0, 0)).epochTime();
 
-        std::stringstream l;
-        l << "loading more: " << ss.str();
-        logger().debug(l.str());
+        logger.debug("loading more: ", ss.str());
 
         TogglClient client(UI());
         HTTPSRequest req;
@@ -4880,7 +4822,7 @@ void Context::onLoadMore(Poco::Util::TimerTask&) {
 
         HTTPSResponse resp = client.Get(req);
         if (resp.err != noError) {
-            logger().warning(resp.err);
+            logger.warning(resp.err);
             return;
         }
 
@@ -4893,7 +4835,7 @@ void Context::onLoadMore(Poco::Util::TimerTask&) {
             error err = user_->LoadTimeEntriesFromJSONString(json);
 
             if (err != noError) {
-                logger().error(err);
+                logger.error(err);
                 return;
             }
 
@@ -4910,13 +4852,13 @@ void Context::onLoadMore(Poco::Util::TimerTask&) {
         displayError(save(false));
     }
     catch (const Poco::Exception& exc) {
-        logger().warning(exc.displayText());
+        logger.warning(exc.displayText());
     }
     catch (const std::exception& ex) {
-        logger().warning(ex.what());
+        logger.warning(ex.what());
     }
     catch (const std::string & ex) {
-        logger().warning(ex);
+        logger.warning(ex);
     }
 }
 
@@ -4943,10 +4885,6 @@ void Context::SetLogPath(const std::string &path) {
     log_path_ = path;
 }
 
-Poco::Logger &Context::logger() const {
-    return Poco::Logger::get("context");
-}
-
 error Context::pullAllUserData(
     TogglClient *toggl_client) {
 
@@ -4955,7 +4893,7 @@ error Context::pullAllUserData(
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("cannot pull user data when logged out");
+            logger.warning("cannot pull user data when logged out");
             return noError;
         }
         api_token = user_->APIToken();
@@ -5014,10 +4952,7 @@ error Context::pullAllUserData(
         pullUserPreferences(toggl_client);
 
         stopwatch.stop();
-        std::stringstream ss;
-        ss << "User with related data JSON fetched and parsed in "
-           << stopwatch.elapsed() / 1000 << " ms";
-        logger().debug(ss.str());
+        logger.debug("User with related data JSON fetched and parsed in ", stopwatch.elapsed() / 1000, " ms");
     } catch(const Poco::Exception& exc) {
         return exc.displayText();
     } catch(const std::exception& ex) {
@@ -5050,7 +4985,7 @@ error Context::pushChanges(
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("cannot push changes when logged out");
+                logger.warning("cannot push changes when logged out");
                 return noError;
             }
 
@@ -5151,7 +5086,7 @@ error Context::pushChanges(
 
         stopwatch.stop();
         ss << ") Total = " << stopwatch.elapsed() / 1000 << " ms";
-        logger().debug(ss.str());
+        logger.debug(ss.str());
     } catch(const Poco::Exception& exc) {
         return exc.displayText();
     } catch(const std::exception& ex) {
@@ -5373,7 +5308,7 @@ error Context::pushEntries(
 
         auto id = root["id"].asUInt64();
         if (!id) {
-            logger().error("Backend is sending invalid data: ignoring update without an ID");
+            logger.error("Backend is sending invalid data: ignoring update without an ID");
             continue;
         }
 
@@ -5399,17 +5334,17 @@ error Context::pushEntries(
 error Context::pullObmExperiments() {
     try {
         if (HTTPSClient::Config.OBMExperimentNrs.empty()) {
-            logger().debug("No OBM experiment enabled by UI");
+            logger.debug("No OBM experiment enabled by UI");
             return noError;
         }
 
-        logger().trace("Fetching OBM experiments from backend");
+        logger.trace("Fetching OBM experiments from backend");
 
         std::string apitoken("");
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("Cannot fetch OBM experiments without user");
+                logger.warning("Cannot fetch OBM experiments without user");
                 return noError;
             }
             apitoken = user_->APIToken();
@@ -5436,7 +5371,7 @@ error Context::pullObmExperiments() {
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("Cannot apply OBM experiments without user");
+                logger.warning("Cannot apply OBM experiments without user");
                 return noError;
             }
             user_->LoadObmExperiments(json);
@@ -5463,7 +5398,7 @@ error Context::pushObmAction() {
         {
             Poco::Mutex::ScopedLock lock(user_m_);
             if (!user_) {
-                logger().warning("cannot push changes when logged out");
+                logger.warning("cannot push changes when logged out");
                 return noError;
             }
 
@@ -5497,7 +5432,7 @@ error Context::pushObmAction() {
             req.payload = Json::StyledWriter().write(root);
         }
 
-        logger().debug(req.payload);
+        logger.debug(req.payload);
 
         TogglClient toggl_client;
         HTTPSResponse resp = toggl_client.Post(req);
@@ -5586,7 +5521,7 @@ bool Context::canChangeProjectTo(TimeEntry* te, Project* p) {
 }
 
 error Context::logAndDisplayUserTriedEditingLockedEntry() {
-    logger().warning("User tried editing locked time entry");
+    logger.warning("User tried editing locked time entry");
     return displayError(error("Cannot change locked time entry"));
 }
 
@@ -5613,12 +5548,9 @@ error Context::pullWorkspaces(TogglClient* toggl_client) {
     std::string json("");
 
     try {
-        std::stringstream ss;
-        ss << "/api/v9/me/workspaces";
-
         HTTPSRequest req;
         req.host = urls::API();
-        req.relative_url = ss.str();
+        req.relative_url = "/api/v9/me/workspaces";
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
@@ -5652,7 +5584,7 @@ error Context::pullWorkspacePreferences(TogglClient* toggl_client) {
     std::vector<Workspace*> workspaces;
     {
         Poco::Mutex::ScopedLock lock(user_m_);
-        logger().debug("user mutex lock success - c:pullWorkspacePreferences");
+        logger.debug("user mutex lock success - c:pullWorkspacePreferences");
 
         user_->related.WorkspaceList(&workspaces);
     }
@@ -5739,12 +5671,10 @@ error Context::pullUserPreferences(
 
     try {
         std::string json("");
-        std::stringstream ss;
-        ss << "/api/v9/me/preferences/desktop";
 
         HTTPSRequest req;
         req.host = urls::API();
-        req.relative_url = ss.str();
+        req.relative_url = "/api/v9/me/preferences/desktop";
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
@@ -5896,7 +5826,7 @@ error Context::signup(
 }
 
 void Context::OpenTimelineDataView() {
-    logger().debug("OpenTimelineDataView");
+    logger.debug("OpenTimelineDataView");
 
     UI()->SetTimelineDateAt(Poco::LocalDateTime());
 

--- a/src/context.h
+++ b/src/context.h
@@ -16,6 +16,7 @@
 #include "gui.h"
 #include "help_article.h"
 #include "idle.h"
+#include "util/logger.h"
 #include "model_change.h"
 #include "timeline_event.h"
 #include "timeline_notifications.h"
@@ -533,7 +534,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     static void parseVersion(int result[4], const std::string& input);
     static bool lessThanVersion(const std::string& version1, const std::string& version2);
 
-    Poco::Logger &logger() const;
+    Logger logger { "context" };
 
     void sync(const bool full_sync);
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -29,7 +29,6 @@
 #include <Poco/Data/SQLite/Utility.h>
 #include <Poco/Data/Statement.h>
 #include <Poco/FileStream.h>
-#include <Poco/Logger.h>
 #include <Poco/Stopwatch.h>
 #include <Poco/StreamCopier.h>
 #include <Poco/UUID.h>
@@ -53,37 +52,31 @@ Database::Database(const std::string &db_path)
     {
         int is_sqlite_threadsafe = Poco::Data::SQLite::Utility::isThreadSafe();
 
-        std::stringstream ss;
-        ss << "sqlite3_threadsafe()=" << is_sqlite_threadsafe;
-        logger().debug(ss.str());
+        logger.debug("sqlite3_threadsafe()=", is_sqlite_threadsafe);
 
         if (!is_sqlite_threadsafe) {
-            logger().error("Database is not thread safe!");
+            logger.error("Database is not thread safe!");
             return;
         }
     }
 
     error err = setJournalMode("wal");
     if (err != noError) {
-        logger().error("Failed to set journal mode to wal!");
+        logger.error("Failed to set journal mode to wal!");
         return;
     }
 
     std::string mode("");
     err = journalMode(&mode);
     if (err != noError) {
-        logger().error("Could not detect journal mode!");
+        logger.error("Could not detect journal mode!");
         return;
     }
 
-    {
-        std::stringstream ss;
-        ss << "PRAGMA journal_mode=" << mode;
-        logger().debug(ss.str());
-    }
+    logger.debug("PRAGMA journal_mode=", mode);
 
     if ("wal" != mode) {
-        logger().error("Failed to enable wal journal mode!");
+        logger.error("Failed to enable wal journal mode!");
         return;
     }
 
@@ -97,7 +90,7 @@ Database::Database(const std::string &db_path)
         "time_entries", start.timestamp());
 
     if (err != noError) {
-        logger().error("failed to clean Up Time Entries Data: " + err);
+        logger.error("failed to clean Up Time Entries Data: " + err);
         // but will continue, its not vital
     }
 
@@ -109,13 +102,13 @@ Database::Database(const std::string &db_path)
         timeline_start.timestamp());
 
     if (err != noError) {
-        logger().error("failed to clean Up Timeline Events Data: " + err);
+        logger.error("failed to clean Up Timeline Events Data: " + err);
         // but will continue, its not vital
     }
 
     err = vacuum();
     if (err != noError) {
-        logger().error("failed to vacuum: " + err);
+        logger.error("failed to vacuum: " + err);
         // but will continue, its not vital
     }
 
@@ -124,19 +117,14 @@ Database::Database(const std::string &db_path)
 
     err = initialize_tables();
     if (err != noError) {
-        logger().error(err);
+        logger.error(err);
         // We're doomed now; cannot continue without a DB
         throw(err);
     }
 
     stopwatch.stop();
 
-    {
-        std::stringstream ss;
-        ss  << "Migrated in "
-            << stopwatch.elapsed() / 1000 << " ms";
-        logger().debug(ss.str());
-    }
+    logger.debug("Migrated in ", stopwatch.elapsed() / 1000, " ms");
 }
 
 Database::~Database() {
@@ -354,10 +342,6 @@ error Database::vacuum() {
     return last_error("vacuum");
 }
 
-Poco::Logger &Database::logger() const {
-    return Poco::Logger::get("database");
-}
-
 error Database::DeleteFromTable(
     const std::string &table_name,
     const Poco::Int64 &local_id) {
@@ -370,11 +354,7 @@ error Database::DeleteFromTable(
         return noError;
     }
 
-
-    std::stringstream ss;
-    ss << "Deleting from table " << table_name
-       << ", local ID: " << local_id;
-    logger().debug(ss.str());
+    logger.debug( "Deleting from table ", table_name, ", local ID: ", local_id);
 
     try {
         Poco::Mutex::ScopedLock lock(session_m_);
@@ -416,7 +396,7 @@ std::string Database::GenerateGUID() {
 error Database::LoadCurrentUser(User *user) {
     poco_check_ptr(user);
 
-    logger().debug("LoadCurrentUser");
+    logger.debug("LoadCurrentUser");
 
     std::string api_token("");
     Poco::UInt64 uid(0);
@@ -1274,9 +1254,7 @@ error Database::LoadUserByID(
     }
 
     stopwatch.stop();
-    std::stringstream ss;
-    ss << "User loaded in " << stopwatch.elapsed() / 1000 << " ms";
-    logger().debug(ss.str());
+    logger.debug("User loaded in ", stopwatch.elapsed() / 1000, " ms");
 
     return noError;
 }
@@ -2080,10 +2058,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating time entry " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().debug(ss.str());
+            logger.debug("Updating time entry ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             if (model->ID()) {
                 *session_ <<
@@ -2175,10 +2150,7 @@ error Database::saveModel(
                     model->GUID()));
             }
         } else {
-            std::stringstream ss;
-            ss << "Inserting time entry " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().debug(ss.str());
+            logger.debug("Inserting time entry ", model->String(), " in thread ", Poco::Thread::currentTid());
             if (model->ID()) {
                 *session_ <<
                           "insert into time_entries(id, uid, description, "
@@ -2322,10 +2294,7 @@ error Database::saveModel(
         Poco::Int64 end_time(model->EndTime());
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating timeline event " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating timeline event ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             *session_ <<
                       "update timeline_events set "
@@ -2369,10 +2338,7 @@ error Database::saveModel(
                     model->GUID()));
             }
         } else {
-            std::stringstream ss;
-            ss << "Inserting timeline event " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting timeline event ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             *session_ <<
                       "insert into timeline_events("
@@ -2453,10 +2419,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating autotracker rule " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating autotracker rule ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             *session_ <<
                       "update autotracker_settings set "
@@ -2488,10 +2451,7 @@ error Database::saveModel(
             }
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting autotracker rule " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting autotracker rule ", model->String(), " in thread ", Poco::Thread::currentTid());
             *session_ <<
                       "insert into autotracker_settings(uid, term, pid, tid) "
                       "values(:uid, :term, :pid, :tid)",
@@ -2547,10 +2507,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating OBM action " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating OBM action ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             *session_ <<
                       "update obm_actions set "
@@ -2584,10 +2541,7 @@ error Database::saveModel(
             }
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting OBM action " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting OBM action ", model->String(), " in thread ", Poco::Thread::currentTid());
             *session_ <<
                       "insert into obm_actions(uid, experiment_id, key, value) "
                       "values(:uid, :experiment_id, :key, :value)",
@@ -2644,10 +2598,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating workspace " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating workspace ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             *session_ <<
                       "update workspaces set "
@@ -2678,10 +2629,7 @@ error Database::saveModel(
                 model->ModelName(), kChangeTypeUpdate, model->ID(), ""));
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting workspace " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting workspace ", model->String(), " in thread ", Poco::Thread::currentTid());
             *session_ <<
                       "insert into workspaces(id, uid, name, premium, "
                       "only_admins_may_create_projects, admin, "
@@ -2754,10 +2702,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating client " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating client ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             if (model->GUID().empty()) {
                 *session_ <<
@@ -2795,10 +2740,7 @@ error Database::saveModel(
                 model->GUID()));
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting client " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting client ", model->String(), " in thread ", Poco::Thread::currentTid());
             if (model->GUID().empty()) {
                 *session_ <<
                           "insert into clients(id, uid, name, wid) "
@@ -2875,10 +2817,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating project " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().debug(ss.str());
+            logger.debug("Updating project ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             if (model->ID()) {
                 if (model->GUID().empty()) {
@@ -2973,10 +2912,7 @@ error Database::saveModel(
                 model->GUID()));
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting project " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().debug(ss.str());
+            logger.debug("Inserting project ", model->String(), " in thread ", Poco::Thread::currentTid());
             if (model->ID()) {
                 if (model->GUID().empty()) {
                     *session_ <<
@@ -3112,10 +3048,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating task " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating task ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             *session_ <<
                       "update tasks set "
@@ -3138,10 +3071,7 @@ error Database::saveModel(
                 model->ModelName(), kChangeTypeUpdate, model->ID(), ""));
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting task " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting task ", model->String(), " in thread ", Poco::Thread::currentTid());
             *session_ <<
                       "insert into tasks(id, uid, name, wid, pid, active) "
                       "values(:id, :uid, :name, :wid, :pid, :active)",
@@ -3195,10 +3125,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating tag " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating tag ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             if (model->GUID().empty()) {
                 *session_ <<
@@ -3236,10 +3163,7 @@ error Database::saveModel(
                 model->GUID()));
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting tag " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting tag ", model->String(), " in thread ", Poco::Thread::currentTid());
             if (model->GUID().empty()) {
                 *session_ <<
                           "insert into tags(id, uid, name, wid) "
@@ -3300,7 +3224,7 @@ error Database::SaveUser(
 
     // Do nothing, if user has already logged out
     if (!user) {
-        logger().warning("Cannot save user, user is logged out");
+        logger.warning("Cannot save user, user is logged out");
         return noError;
     }
 
@@ -3328,10 +3252,7 @@ error Database::SaveUser(
     if (!user->LocalID() || user->Dirty()) {
         try {
             if (user->LocalID()) {
-                std::stringstream ss;
-                ss << "Updating user " + user->String()
-                   << " in thread " << Poco::Thread::currentTid();
-                logger().trace(ss.str());
+                logger.trace("Updating user ", user->String(), " in thread ", Poco::Thread::currentTid());
 
                 *session_ <<
                           "update users set "
@@ -3370,10 +3291,7 @@ error Database::SaveUser(
                 changes->push_back(ModelChange(
                     user->ModelName(), kChangeTypeUpdate, user->ID(), ""));
             } else {
-                std::stringstream ss;
-                ss << "Inserting user " + user->String()
-                   << " in thread " << Poco::Thread::currentTid();
-                logger().trace(ss.str());
+                logger.trace("Inserting user ", user->String(), " in thread ", Poco::Thread::currentTid());
                 *session_ <<
                           "insert into users("
                           "id, default_wid, since, fullname, email, "
@@ -3585,13 +3503,7 @@ error Database::SaveUser(
 
     stopwatch.stop();
 
-    {
-        std::stringstream ss;
-        ss  << "User with_related_data=" << with_related_data << " saved in "
-            << stopwatch.elapsed() / 1000 << " ms in thread "
-            << Poco::Thread::currentTid();
-        logger().debug(ss.str());
-    }
+    logger.debug("User with_related_data=", with_related_data, " saved in ", stopwatch.elapsed() / 1000, " ms in thread ", Poco::Thread::currentTid());
 
     return noError;
 }
@@ -3905,11 +3817,7 @@ error Database::Migrate(
             return noError;
         }
 
-        std::stringstream ss;
-        ss  << "Migrating" << "\n"
-            << name << "\n"
-            << sql << "\n";
-        logger().debug(ss.str());
+        logger.debug("Migrating", "\n", name, "\n", sql, "\n");
 
         err = execute(sql);
         if (err != noError) {
@@ -4056,10 +3964,7 @@ error Database::saveModel(
         poco_check_ptr(session_);
 
         if (model->LocalID()) {
-            std::stringstream ss;
-            ss << "Updating OBM experiment " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Updating OBM experiment ", model->String(), " in thread ", Poco::Thread::currentTid());
 
             *session_ <<
                       "update obm_experiments set "
@@ -4095,10 +4000,7 @@ error Database::saveModel(
             }
 
         } else {
-            std::stringstream ss;
-            ss << "Inserting OBM action " + model->String()
-               << " in thread " << Poco::Thread::currentTid();
-            logger().trace(ss.str());
+            logger.trace("Inserting OBM action ", model->String(), " in thread ", Poco::Thread::currentTid());
             *session_ <<
                       "insert into obm_experiments("
                       "uid, nr, included, has_seen, actions "

--- a/src/database.h
+++ b/src/database.h
@@ -17,14 +17,13 @@
 #include "model_change.h"
 #include "timeline_event.h"
 #include "types.h"
+#include "util/logger.h"
 
 namespace Poco {
-class Logger;
-
-namespace Data {
-class Session;
-class Statement;
-}
+    namespace Data {
+        class Session;
+        class Statement;
+    }
 }
 
 namespace toggl {
@@ -405,7 +404,7 @@ class TOGGL_INTERNAL_EXPORT Database {
         const Poco::UInt64 &user_id,
         std::vector<TimelineEvent> *timeline_events);
 
-    Poco::Logger &logger() const;
+    Logger logger { "database" };
 
     Poco::Mutex session_m_;
     Poco::Data::Session *session_;

--- a/src/formatter.cc
+++ b/src/formatter.cc
@@ -13,12 +13,12 @@
 #include "task.h"
 #include "time_entry.h"
 #include "workspace.h"
+#include "util/logger.h"
 
 #include <Poco/DateTimeFormat.h>
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/DateTimeParser.h>
 #include <Poco/LocalDateTime.h>
-#include <Poco/Logger.h>
 #include <Poco/NumberFormatter.h>
 #include <Poco/NumberParser.h>
 #include <Poco/String.h>
@@ -513,20 +513,12 @@ std::time_t Formatter::Parse8601(const std::string &iso_8601_formatted_date) {
 
     // Sun  9 Sep 2001 03:46:40 EET
     if (epoch_time < 1000000000) {
-        Poco::Logger &logger = Poco::Logger::get("Formatter");
-        std::stringstream ss;
-        ss  << "Parsed timestamp is too small, will interpret as 0: "
-            << epoch_time;
-        logger.warning(ss.str());
+        Logger("Formatter").warning("Parsed timestamp is too small, will interpret as 0: ", epoch_time);
         return 0;
     }
 
     if (epoch_time > 2000000000) {
-        Poco::Logger &logger = Poco::Logger::get("Formatter");
-        std::stringstream ss;
-        ss  << "Parsed timestamp is too large, will interpret as 0: "
-            << epoch_time;
-        logger.warning(ss.str());
+        Logger("Formatter").warning("Parsed timestamp is too large, will interpret as 0: ", epoch_time);
         return 0;
     }
 

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -17,7 +17,6 @@
 #include "user.h"
 #include "workspace.h"
 
-#include <Poco/Logger.h>
 #include <Poco/Stopwatch.h>
 
 namespace toggl {
@@ -141,9 +140,7 @@ void GUI::DisplayLogin(const bool open, const uint64_t user_id) {
     if (open == lastDisplayLoginOpen && user_id == lastDisplayLoginUserID) {
         return;
     }
-    std::stringstream ss;
-    ss << "DisplayLogin open=" << open << ", user_id=" << user_id;
-    logger().debug(ss.str());
+    logger.debug("DisplayLogin open=", open, ", user_id=", user_id);
 
     on_display_login_(open, user_id);
 
@@ -156,11 +153,10 @@ error GUI::DisplayError(const error &err) {
         return noError;
     }
 
-    logger().error(err);
+    logger.error(err);
 
     if (IsNetworkingError(err)) {
-        std::stringstream ss;
-        ss << "You are offline (" << err << ")";
+        logger.debug("You are offline (", err, ")");
         if (kBackendIsDownError == err) {
             DisplayOnlineState(kOnlineStateBackendDown);
         }
@@ -173,13 +169,7 @@ error GUI::DisplayError(const error &err) {
     std::string actionable = MakeErrorActionable(err);
     bool is_user_error = IsUserError(err);
 
-    {
-        std::stringstream ss;
-        ss << "DisplayError err=" << err
-           << " actionable=" << actionable
-           << " is_user_error=" << is_user_error;
-        logger().debug(ss.str());
-    }
+    logger.debug("DisplayError err=", err, " actionable=", actionable, " is_user_error=", is_user_error);
 
     char_t *err_s = copy_string(actionable);
     on_display_error_(err_s, is_user_error);
@@ -201,10 +191,10 @@ error GUI::DisplayTosAccept() {
 }
 
 error GUI::VerifyCallbacks() {
-    logger().debug("VerifyCallbacks");
+    logger.debug("VerifyCallbacks");
     error err = findMissingCallbacks();
     if (err != noError) {
-        logger().error(err);
+        logger.error(err);
     }
     return err;
 }
@@ -271,7 +261,7 @@ error GUI::findMissingCallbacks() {
 }
 
 void GUI::DisplayReminder() {
-    logger().debug("DisplayReminder");
+    logger.debug("DisplayReminder");
 
     char_t *s1 = copy_string("Reminder from Toggl Desktop");
     char_t *s2 = copy_string("Don't forget to track your time!");
@@ -281,7 +271,7 @@ void GUI::DisplayReminder() {
 }
 
 void GUI::DisplayPomodoro(const Poco::Int64 minutes) {
-    logger().debug("DisplayPomodoro");
+    logger.debug("DisplayPomodoro");
     char_t *s1 = copy_string("Pomodoro Timer");
 
     std::stringstream ss;
@@ -294,7 +284,7 @@ void GUI::DisplayPomodoro(const Poco::Int64 minutes) {
 }
 
 void GUI::DisplayPomodoroBreak(const Poco::Int64 minutes) {
-    logger().debug("DisplayPomodoroBreak");
+    logger.debug("DisplayPomodoroBreak");
     char_t *s1 = copy_string("Pomodoro Break Timer");
 
     std::stringstream ss;
@@ -309,18 +299,15 @@ void GUI::DisplayPomodoroBreak(const Poco::Int64 minutes) {
 void GUI::DisplayAutotrackerNotification(Project *const p, Task *const t) {
     poco_check_ptr(p);
 
-    std::stringstream ss;
-    ss << "DisplayAutotrackerNotification ";
     if (p) {
-        ss << "project " << p->Name() << ", " << p->ID() << ", " << p->GUID();
+        logger.debug("DisplayAutotrackerNotification project ", p->Name(), ", ", p->ID(), ", ", p->GUID());
     }
     if (t) {
-        ss << " task " << t->Name() << ", " << t->ID();
+        logger.debug("DisplayAutotrackerNotification task ", t->Name(), ", ", t->ID());
     }
-    logger().debug(ss.str());
 
     if (!p && !t) {
-        logger().error(
+        logger.error(
             "Need project ID or task ID for autotracker notification");
         return;
     }
@@ -352,27 +339,21 @@ void GUI::DisplayOnlineState(const Poco::Int64 state) {
     if (!(kOnlineStateOnline == state
             || kOnlineStateNoNetwork == state
             || kOnlineStateBackendDown == state)) {
-        std::stringstream ss;
-        ss << "Invalid online state " << state;
-        logger().error(ss.str());
+        logger.error("Invalid online state ", state);
         return;
     }
 
-    std::stringstream ss;
-    ss << "DisplayOnlineState ";
-
     switch (state) {
     case kOnlineStateOnline:
-        ss << "online";
+        logger.debug("DisplayOnlineState online");
         break;
     case kOnlineStateNoNetwork:
-        ss << "no network";
+        logger.debug("DisplayOnlineState no network");
         break;
     case kOnlineStateBackendDown:
-        ss << "backend is down";
+        logger.debug("DisplayOnlineState backend is down");
         break;
     }
-    logger().debug(ss.str());
 
     on_display_online_state_(state);
 
@@ -381,7 +362,7 @@ void GUI::DisplayOnlineState(const Poco::Int64 state) {
 
 void GUI::DisplayTimeEntryAutocomplete(
     std::vector<toggl::view::Autocomplete> *items) {
-    logger().debug("DisplayTimeEntryAutocomplete");
+    logger.debug("DisplayTimeEntryAutocomplete");
 
     TogglAutocompleteView *first = autocomplete_list_init(items);
     on_display_time_entry_autocomplete_(first);
@@ -390,7 +371,7 @@ void GUI::DisplayTimeEntryAutocomplete(
 
 void GUI::DisplayHelpArticles(
     const std::vector<HelpArticle> &articles) {
-    logger().debug("DisplayHelpArticles");
+    logger.debug("DisplayHelpArticles");
 
     if (!on_display_help_articles_) {
         return;
@@ -403,7 +384,7 @@ void GUI::DisplayHelpArticles(
 
 void GUI::DisplayMinitimerAutocomplete(
     std::vector<toggl::view::Autocomplete> *items) {
-    logger().debug("DisplayMinitimerAutocomplete");
+    logger.debug("DisplayMinitimerAutocomplete");
 
     TogglAutocompleteView *first = autocomplete_list_init(items);
     on_display_mini_timer_autocomplete_(first);
@@ -412,7 +393,7 @@ void GUI::DisplayMinitimerAutocomplete(
 
 void GUI::DisplayProjectAutocomplete(
     std::vector<toggl::view::Autocomplete> *items) {
-    logger().debug("DisplayProjectAutocomplete");
+    logger.debug("DisplayProjectAutocomplete");
 
     TogglAutocompleteView *first = autocomplete_list_init(items);
     on_display_project_autocomplete_(first);
@@ -441,10 +422,7 @@ void GUI::DisplayTimeEntryList(const bool open,
             // Otherwise, just get from the list
             renderList = list;
         }
-        std::stringstream ss;
-        ss << "DisplayTimeEntryList open=" << open
-           << ", has items=" << renderList.size();
-        logger().debug(ss.str());
+        logger.debug("DisplayTimeEntryList open=", open, ", has items=", renderList.size());
     }
 
     // Render
@@ -468,12 +446,7 @@ void GUI::DisplayTimeEntryList(const bool open,
     time_entry_view_list_clear(first);
 
     stopwatch.stop();
-    {
-        std::stringstream ss;
-        ss << "DisplayTimeEntryList done in "
-           << stopwatch.elapsed() / 1000 << " ms";
-        logger().debug(ss.str());
-    }
+    logger.debug("DisplayTimeEntryList done in ", stopwatch.elapsed() / 1000, " ms");
 }
 
 void GUI::DisplayTimeline(
@@ -674,7 +647,7 @@ TogglTimelineEventView* GUI::SortList(TogglTimelineEventView *head) {
 }
 
 void GUI::DisplayTags(const std::vector<view::Generic> list) {
-    logger().debug("DisplayTags");
+    logger.debug("DisplayTags");
 
     TogglGenericView *first = generic_to_view_item_list(list);
     on_display_tags_(first);
@@ -716,7 +689,7 @@ void GUI::DisplayAutotrackerRules(
 
 void GUI::DisplayClientSelect(
     const std::vector<view::Generic> &list) {
-    logger().debug("DisplayClientSelect");
+    logger.debug("DisplayClientSelect");
 
     TogglGenericView *first = generic_to_view_item_list(list);
     on_display_client_select_(first);
@@ -725,7 +698,7 @@ void GUI::DisplayClientSelect(
 
 void GUI::DisplayWorkspaceSelect(
     const std::vector<view::Generic> &list) {
-    logger().debug("DisplayWorkspaceSelect");
+    logger.debug("DisplayWorkspaceSelect");
 
     TogglGenericView *first = generic_to_view_item_list(list);
     on_display_workspace_select_(first);
@@ -736,7 +709,7 @@ void GUI::DisplayTimeEntryEditor(const bool open,
                                  const view::TimeEntry &te,
                                  const std::string &focused_field_name) {
 
-    logger().debug(
+    logger.debug(
         "DisplayTimeEntryEditor focused_field_name=" + focused_field_name);
 
     TogglTimeEntryView *view = time_entry_view_item_init(te);
@@ -749,7 +722,7 @@ void GUI::DisplayTimeEntryEditor(const bool open,
 }
 
 void GUI::DisplayURL(const std::string &URL) {
-    logger().debug("DisplayURL " + URL);
+    logger.debug("DisplayURL " + URL);
 
     char_t *url = copy_string(URL);
     on_display_url_(url);
@@ -757,7 +730,7 @@ void GUI::DisplayURL(const std::string &URL) {
 }
 
 void GUI::DisplayUpdate(const std::string &URL) {
-    logger().debug("DisplayUpdate " + URL);
+    logger.debug("DisplayUpdate " + URL);
 
     char_t *url = copy_string(URL);
     on_display_update_(url);
@@ -769,15 +742,10 @@ void GUI::DisplayUpdateDownloadState(
     const Poco::Int64 download_state) {
 
     if (!CanDisplayUpdateDownloadState()) {
-        logger().debug("Update download state display not supported by UI");
+        logger.debug("Update download state display not supported by UI");
         return;
     }
-    {
-        std::stringstream ss;
-        ss << "DisplayUpdateDownloadState version=" << version
-           << " state=" << download_state;
-        logger().debug(ss.str());
-    }
+    logger.debug("DisplayUpdateDownloadState version=", version, " state=", download_state);
     char_t *version_string = copy_string(version);
     on_display_update_download_state_(version_string, download_state);
     free(version_string);
@@ -787,7 +755,7 @@ void GUI::DisplayMessage(const std::string &title,
                          const std::string &text,
                          const std::string &button,
                          const std::string &url) {
-    logger().debug("DisplayMessage: " + title);
+    logger.debug("DisplayMessage: " + title);
 
     char_t *tmp_title = copy_string(title);
     char_t *tmp_text = copy_string(text);
@@ -811,7 +779,7 @@ void GUI::DisplaySettings(const bool open,
                           const Settings &settings,
                           const bool use_proxy,
                           const Proxy &proxy) {
-    logger().debug("DisplaySettings");
+    logger.debug("DisplaySettings");
 
     TogglSettingsView *view = settings_view_item_init(
         record_timeline,
@@ -831,12 +799,12 @@ void GUI::DisplayTimerState(
     on_display_timer_state_(view);
     time_entry_view_list_clear(view);
 
-    logger().debug("DisplayTimerState");
+    logger.debug("DisplayTimerState");
 }
 
 void GUI::DisplayEmptyTimerState() {
     on_display_timer_state_(nullptr);
-    logger().debug("DisplayEmptyTimerState");
+    logger.debug("DisplayEmptyTimerState");
 }
 
 void GUI::DisplayIdleNotification(const std::string &guid,
@@ -857,10 +825,6 @@ void GUI::DisplayIdleNotification(const std::string &guid,
     free(since_s);
     free(duration_s);
     free(description_s);
-}
-
-Poco::Logger &GUI::logger() const {
-    return Poco::Logger::get("ui");
 }
 
 }  // namespace toggl

--- a/src/gui.h
+++ b/src/gui.h
@@ -14,12 +14,9 @@
 #include "toggl_api.h"
 #include "toggl_api_private.h"
 #include "types.h"
+#include "util/logger.h"
 
 #include <Poco/LocalDateTime.h>
-
-namespace Poco {
-class Logger;
-}
 
 namespace toggl {
 
@@ -742,7 +739,7 @@ class TOGGL_INTERNAL_EXPORT GUI : public SyncStateMonitor {
 
     Poco::LocalDateTime timeline_date_at_;
 
-    Poco::Logger &logger() const;
+    Logger logger { "ui" };
 };
 
 }  // namespace toggl

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -11,21 +11,16 @@
 #include "const.h"
 #include "proxy.h"
 #include "types.h"
+#include "util/logger.h"
 
 #include <Poco/Activity.h>
 #include <Poco/Timestamp.h>
 
 namespace Poco {
-
-class Logger;
-
-namespace Net {
-
-class HTMLForm;
-
-}
-
-}  // namespace Poco
+    namespace Net {
+        class HTMLForm;
+    } // namespace Poco::Net
+} // namespace Poco
 
 namespace toggl {
 
@@ -61,7 +56,7 @@ class TOGGL_INTERNAL_EXPORT ServerStatus {
     void stopStatusCheck(const std::string &reason);
     bool checkingStatus();
 
-    Poco::Logger &logger() const;
+    Logger logger() const;
 };
 
 class TOGGL_INTERNAL_EXPORT HTTPSClientConfig {
@@ -160,7 +155,7 @@ class TOGGL_INTERNAL_EXPORT HTTPSClient {
     virtual HTTPSResponse request(
         HTTPSRequest req) const;
 
-    virtual Poco::Logger &logger() const;
+    virtual Logger logger() const;
 
  private:
     // We only make requests if this timestamp lies in the past.
@@ -192,7 +187,7 @@ class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPSClient {
     virtual HTTPSResponse request(
         HTTPSRequest req) const override;
 
-    virtual Poco::Logger &logger() const override;
+    virtual Logger logger() const override;
 
  private:
     SyncStateMonitor *monitor_;

--- a/src/idle.cc
+++ b/src/idle.cc
@@ -12,8 +12,6 @@
 #include "gui.h"
 #include "time_entry.h"
 
-#include <Poco/Logger.h>
-
 namespace toggl {
 
 Idle::Idle(GUI *ui)
@@ -30,7 +28,7 @@ void Idle::SetIdleSeconds(
     {
         std::stringstream ss;
         ss << "SetIdleSeconds idle_seconds=" << idle_seconds;
-        logger().debug(ss.str());
+        logger.debug(ss.str());
     }
     */
     if (!current_user) {
@@ -41,11 +39,11 @@ void Idle::SetIdleSeconds(
             computeIdleState(idle_seconds, current_user);
         }
     } catch(const Poco::Exception& exc) {
-        logger().error(exc.displayText());
+        logger.error(exc.displayText());
     } catch(const std::exception& ex) {
-        return logger().error(ex.what());
+        return logger.error(ex.what());
     } catch(const std::string & ex) {
-        return logger().error(ex);
+        return logger.error(ex);
     }
     last_idle_seconds_reading_ = idle_seconds;
 }
@@ -58,9 +56,7 @@ void Idle::computeIdleState(
             !last_idle_started_) {
         last_idle_started_ = time(nullptr) - idle_seconds;
 
-        std::stringstream ss;
-        ss << "User is idle since " << last_idle_started_;
-        logger().debug(ss.str());
+        logger.debug("User is idle since ", last_idle_started_);
 
         return;
     }
@@ -71,10 +67,10 @@ void Idle::computeIdleState(
 
         TimeEntry *te = current_user->RunningTimeEntry();
         if (!te) {
-            logger().warning("Time entry is not tracking, ignoring idleness");
+            logger.warning("Time entry is not tracking, ignoring idleness");
         } else if (Formatter::AbsDuration(te->DurationInSeconds())
                    < last_idle_seconds_reading_) {
-            logger().warning("Time entry duration is less than idle, ignoring");
+            logger.warning("Time entry duration is less than idle, ignoring");
         } else if (settings_.use_idle_detection) {
             std::stringstream since;
             since << "You have been idle since "
@@ -89,8 +85,8 @@ void Idle::computeIdleState(
             }
             duration << ")";
 
-            logger().debug(since.str());
-            logger().debug(duration.str());
+            logger.debug(since.str());
+            logger.debug(duration.str());
 
             poco_check_ptr(ui_);
             ui_->DisplayIdleNotification(te->GUID(),
@@ -100,16 +96,10 @@ void Idle::computeIdleState(
                                          te->Description());
         }
 
-        std::stringstream ss;
-        ss << "User is not idle since " << now;
-        logger().debug(ss.str());
+        logger.debug("User is not idle since ", now);
 
         last_idle_started_ = 0;
     }
-}
-
-Poco::Logger &Idle::logger() const {
-    return Poco::Logger::get("idle");
 }
 
 }  // namespace toggl

--- a/src/idle.h
+++ b/src/idle.h
@@ -7,6 +7,7 @@
 
 #include "settings.h"
 #include "user.h"
+#include "util/logger.h"
 
 #include <Poco/Types.h>
 
@@ -46,7 +47,7 @@ class TOGGL_INTERNAL_EXPORT Idle {
     void computeIdleState(const Poco::Int64 idle_seconds,
                           User *current_user);
 
-    Poco::Logger &logger() const;
+    Logger logger { "idle" };
 
     // Idle detection related values
     Poco::Int64 last_idle_seconds_reading_;

--- a/src/netconf.cc
+++ b/src/netconf.cc
@@ -98,7 +98,7 @@ error Netconf::ConfigureProxy(
     const std::string &encoded_url,
     Poco::Net::HTTPSClientSession *session) {
 
-    Poco::Logger &logger = Poco::Logger::get("ConfigureProxy");
+    Logger logger { "ConfigureProxy" };
 
     std::string proxy_url("");
     if (HTTPSClient::Config.AutodetectProxy) {
@@ -131,11 +131,9 @@ error Netconf::ConfigureProxy(
             }
             Poco::URI proxy_uri(proxy_url);
 
-            std::stringstream ss;
-            ss << "Using proxy URI=" + proxy_uri.toString()
-               << " host=" << proxy_uri.getHost()
-               << " port=" << proxy_uri.getPort();
-            logger.debug(ss.str());
+            logger.debug("Using proxy URI=", proxy_uri.toString(),
+                         " host=", proxy_uri.getHost(),
+                         " port=", proxy_uri.getPort());
 
             session->setProxy(
                 proxy_uri.getHost(),
@@ -148,8 +146,8 @@ error Netconf::ConfigureProxy(
                     credentials.getUsername(),
                     credentials.getPassword());
 
-                logger.debug("Proxy credentials detected username="
-                             + credentials.getUsername());
+                logger.debug("Proxy credentials detected username=",
+                             credentials.getUsername());
             }
         }
     }
@@ -162,19 +160,17 @@ error Netconf::ConfigureProxy(
             static_cast<Poco::UInt16>(
                 HTTPSClient::Config.ProxySettings.Port()));
 
-        std::stringstream ss;
-        ss << "Proxy configured "
-           << " host=" << HTTPSClient::Config.ProxySettings.Host()
-           << " port=" << HTTPSClient::Config.ProxySettings.Port();
-        logger.debug(ss.str());
+        logger.debug("Proxy configured ",
+                     " host=", HTTPSClient::Config.ProxySettings.Host(),
+                     " port=", HTTPSClient::Config.ProxySettings.Port());
 
         if (HTTPSClient::Config.ProxySettings.HasCredentials()) {
             session->setProxyCredentials(
                 HTTPSClient::Config.ProxySettings.Username(),
                 HTTPSClient::Config.ProxySettings.Password());
 
-            logger.debug("Proxy credentials configured username="
-                         + HTTPSClient::Config.ProxySettings.Username());
+            logger.debug("Proxy credentials configured username=",
+                         HTTPSClient::Config.ProxySettings.Username());
         }
     }
 

--- a/src/timeline_uploader.cc
+++ b/src/timeline_uploader.cc
@@ -17,8 +17,8 @@
 
 namespace toggl {
 
-Poco::Logger &TimelineUploader::logger() const {
-    return Poco::Logger::get("timeline_uploader");
+Logger TimelineUploader::logger() const {
+    return { "timeline_uploader" };
 }
 
 void TimelineUploader::sleep() {
@@ -42,12 +42,7 @@ void TimelineUploader::upload_loop_activity() {
 }
 
 error TimelineUploader::process() {
-    {
-        std::stringstream out;
-        out << "upload_loop_activity (current interval "
-            << current_upload_interval_seconds_ << "s)";
-        logger().debug(out.str());
-    }
+    logger().debug("upload_loop_activity (current interval ", current_upload_interval_seconds_, "s)");
 
     if (uploading_.isStopped()) {
         return noError;
@@ -74,12 +69,7 @@ error TimelineUploader::process() {
         return err;
     }
 
-    {
-        std::stringstream out;
-        out << "Sync of " << batch.Events().size()
-            << " event(s) was successful.";
-        logger().debug(out.str());
-    }
+    logger().debug("Sync of ", batch.Events().size(), " event(s) was successful.");
 
     reset_backoff();
 
@@ -89,10 +79,7 @@ error TimelineUploader::process() {
 error TimelineUploader::upload(TimelineBatch *batch) {
     TogglClient client;
 
-    std::stringstream ss;
-    ss << "Uploading " << batch->Events().size()
-       << " event(s) of user " << batch->UserID();
-    logger().debug(ss.str());
+    logger().debug("Uploading ", batch->Events().size(), " event(s) of user ", batch->UserID());
 
     std::string json = convertTimelineToJSON(
         batch->Events(),
@@ -136,9 +123,7 @@ void TimelineUploader::backoff() {
         logger().warning("Max upload interval reached.");
         current_upload_interval_seconds_ = kTimelineUploadMaxBackoffSeconds;
     }
-    std::stringstream out;
-    out << "Upload interval set to " << current_upload_interval_seconds_ << "s";
-    logger().debug(out.str());
+    logger().debug("Upload interval set to ", current_upload_interval_seconds_, "s");
 }
 
 void TimelineUploader::reset_backoff() {

--- a/src/timeline_uploader.h
+++ b/src/timeline_uploader.h
@@ -9,12 +9,9 @@
 #include "timeline_event.h"
 #include "timeline_notifications.h"
 #include "types.h"
+#include "util/logger.h"
 
 #include <Poco/Activity.h>
-
-namespace Poco {
-class Logger;
-}
 
 namespace toggl {
 
@@ -52,7 +49,7 @@ class TOGGL_INTERNAL_EXPORT TimelineUploader {
     void backoff();
     void reset_backoff();
 
-    Poco::Logger &logger() const;
+    Logger logger() const;
 
     error process();
     void sleep();

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -652,9 +652,7 @@ bool_t toggl_continue(
     void *context,
     const char_t *guid) {
 
-    std::stringstream ss;
-    ss << "toggl_continue guid=" << guid;
-    logger().debug(ss.str());
+    logger().debug("toggl_continue guid=", guid);
 
     toggl::TimeEntry *result = app(context)->Continue(to_string(guid));
     if (!result) {
@@ -697,11 +695,7 @@ void toggl_edit(
     const bool_t edit_running_entry,
     const char_t *focused_field_name) {
 
-    std::stringstream ss;
-    ss << "toggl_edit guid=" << guid
-       << ", edit_running_entry = " << edit_running_entry
-       << ", focused_field_name = " << focused_field_name;
-    logger().debug(ss.str());
+    logger().debug("toggl_edit guid=", guid, ", edit_running_entry = ", edit_running_entry, ", focused_field_name = ", focused_field_name);
 
     app(context)->OpenTimeEntryEditor(
         to_string(guid),
@@ -730,9 +724,7 @@ bool_t toggl_delete_time_entry(
     void *context,
     const char_t *guid) {
 
-    std::stringstream ss;
-    ss << "toggl_delete_time_entry guid=" << guid;
-    logger().debug(ss.str());
+    logger().debug("toggl_delete_time_entry guid=", guid);
 
     return toggl::noError == app(context)->
            DeleteTimeEntryByGUID(to_string(guid));
@@ -743,10 +735,7 @@ bool_t toggl_set_time_entry_duration(
     const char_t *guid,
     const char_t *value) {
 
-    std::stringstream ss;
-    ss  << "toggl_set_time_entry_duration guid=" << guid
-        << ", value=" << value;
-    logger().debug(ss.str());
+    logger().debug("toggl_set_time_entry_duration guid=", guid, ", value=", value);
 
     return toggl::noError == app(context)->SetTimeEntryDuration(
         to_string(guid),

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -12,7 +12,6 @@
 #include "timeline_event.h"
 #include "workspace.h"
 
-#include <Poco/Logger.h>
 #include <Poco/UnicodeConverter.h>
 
 TogglAutocompleteView *autocomplete_item_init(const toggl::view::Autocomplete &item) {
@@ -633,12 +632,12 @@ void timeline_event_view_clear(
     delete event_view;
 }
 
-Poco::Logger &logger() {
-    return Poco::Logger::get("toggl_api");
-}
-
 toggl::Context *app(void *context) {
     poco_check_ptr(context);
 
     return reinterpret_cast<toggl::Context *>(context);
+}
+
+toggl::Logger logger() {
+    return { "toggl_api" };
 }

--- a/src/toggl_api_private.h
+++ b/src/toggl_api_private.h
@@ -11,10 +11,7 @@
 #include "proxy.h"
 #include "settings.h"
 #include "toggl_api.h"
-
-namespace Poco {
-class Logger;
-}
+#include "util/logger.h"
 
 namespace toggl {
 class Client;
@@ -118,7 +115,7 @@ void timeline_event_view_update_duration(TogglTimelineEventView *event_view, con
 void timeline_event_view_clear(
     TogglTimelineEventView *event_view);
 
-Poco::Logger &logger();
+toggl::Logger logger();
 
 toggl::Context *app(void *context);
 

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -1,0 +1,75 @@
+// Copyright 2020 Toggl Desktop developers.
+
+#ifndef SRC_LOGGER_H_
+#define SRC_LOGGER_H_
+
+#include <Poco/Logger.h>
+#include <string>
+#include <utility>
+#include <sstream>
+
+namespace toggl {
+
+/*
+ * Beware, template black magic ahead
+ *
+ * Use Logger like this:
+ *  Logger logger("myclass");
+ *  logger.log("Running sync", foo, bar, "baz", 123);
+ * and as long as all of the used types have a stringstream conversion, it'll run.
+ * You can also declare your own stringstream << operator if you want to debug custom classes.
+ */
+class Logger {
+public:
+    Logger(const std::string &context)
+        : context_(context)
+    {}
+
+    template <typename... Args>
+    void trace(Args&&... args) const {
+        std::stringstream ss;
+        prepareOutput(ss, std::forward<Args>(args)...);
+        Poco::Logger::get(context_).trace(ss.str());
+    }
+    template <typename... Args>
+    void log(Args&&... args) const {
+        std::stringstream ss;
+        prepareOutput(ss, std::forward<Args>(args)...);
+        Poco::Logger::get(context_).log(ss.str());
+    }
+    template <typename... Args>
+    void debug(Args&&... args) const {
+        std::stringstream ss;
+        prepareOutput(ss, std::forward<Args>(args)...);
+        Poco::Logger::get(context_).debug(ss.str());
+    }
+    template <typename... Args>
+    void warning(Args&&... args) const {
+        std::stringstream ss;
+        prepareOutput(ss, std::forward<Args>(args)...);
+        Poco::Logger::get(context_).warning(ss.str());
+    }
+    template <typename... Args>
+    void error(Args&&... args) const {
+        std::stringstream ss;
+        prepareOutput(ss, std::forward<Args>(args)...);
+        Poco::Logger::get(context_).error(ss.str());
+    }
+
+private:
+    template <typename Arg>
+    void prepareOutput(std::stringstream &ss, Arg&& arg) const {
+        ss << std::forward<Arg>(arg);
+    }
+    template <typename Arg, typename... Args>
+    void prepareOutput(std::stringstream &ss, Arg&& arg, Args&&... args) const {
+        ss << std::forward<Arg>(arg);
+        prepareOutput(ss, std::forward<Args>(args)...);
+    }
+private:
+    std::string context_;
+};
+
+} // namespace toggl
+
+#endif // SRC_LOGGER_H_

--- a/src/websocket_client.cc
+++ b/src/websocket_client.cc
@@ -88,10 +88,7 @@ error WebSocketClient::createSession() {
 
     error err = TogglClient::TogglStatus.Status();
     if (err != noError) {
-        std::stringstream ss;
-        ss << "Will not start Websocket sessions, ";
-        ss << "because of known bad Toggl status: " << err;
-        logger().error(ss.str());
+        logger().error("Will not start Websocket sessions, ", "because of known bad Toggl status: ", err);
         return err;
     }
 
@@ -219,9 +216,7 @@ error WebSocketClient::poll() {
         if (json.empty()) {
             return error("WebSocket closed the connection");
         }
-        std::stringstream ss;
-        ss << "WebSocket message: " << json;
-        logger().trace(ss.str());
+        logger().trace("WebSocket message: ", json);
 
         last_connection_at_ = time(nullptr);
 
@@ -317,15 +312,13 @@ void WebSocketClient::deleteSession() {
     logger().debug("session deleted");
 }
 
-Poco::Logger &WebSocketClient::logger() const {
-    return Poco::Logger::get("websocket_client");
+Logger WebSocketClient::logger() const {
+    return { "websocket_client" };
 }
 
 int WebSocketClient::nextWebsocketRestartInterval() {
     int res = static_cast<int>(Random::next(kWebsocketRestartRangeSeconds)) + 1;
-    std::stringstream ss;
-    ss << "Next websocket restart in " << res << " seconds";
-    logger().trace(ss.str());
+    logger().trace("Next websocket restart in ", res, " seconds");
     return res;
 }
 

--- a/src/websocket_client.h
+++ b/src/websocket_client.h
@@ -10,17 +10,16 @@
 #include <Poco/Activity.h>
 
 #include "types.h"
+#include "util/logger.h"
 
 namespace Poco {
-class Logger;
-
-namespace Net {
-class HTTPSClientSession;
-class HTTPRequest;
-class HTTPResponse;
-class WebSocket;
-}
-}
+    namespace Net {
+        class HTTPSClientSession;
+        class HTTPRequest;
+        class HTTPResponse;
+        class WebSocket;
+    } // namespace Poco::Net
+} // namespace Poco
 
 namespace toggl {
 
@@ -66,7 +65,7 @@ class TOGGL_INTERNAL_EXPORT WebSocketClient {
 
     int nextWebsocketRestartInterval();
 
-    Poco::Logger &logger() const;
+    Logger logger() const;
 
     Poco::Activity<WebSocketClient> activity_;
     Poco::Net::HTTPSClientSession *session_;

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -7,7 +7,6 @@
 #include "get_focused_window.h"
 #include "const.h"
 
-#include <Poco/Logger.h>
 #include <Poco/Thread.h>
 
 #if defined(__APPLE__)
@@ -15,10 +14,6 @@ extern bool isCatalinaOSX(void);
 #endif
 
 namespace toggl {
-
-Poco::Logger &WindowChangeRecorder::logger() {
-    return Poco::Logger::get("WindowChangeRecorder");
-}
 
 bool WindowChangeRecorder::hasWindowChanged(
     const std::string &title,
@@ -41,9 +36,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
         int count = 1;
 
         if (it == timeline_errors_.end()) {
-            std::stringstream ss;
-            ss << "Failed to get focused window info, error code: " << err;
-            logger().error(ss.str());
+            logger.error("Failed to get focused window info, error code: ", err);
         } else {
             count += timeline_errors_[err];
         }
@@ -51,10 +44,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
         timeline_errors_[err] = count;
 
         if (count % 100 == 0) {
-            std::stringstream ss;
-            ss << "Failed to get focused window info, error code: "
-               << err << " [" << count << " times]";
-            logger().error(ss.str());
+            logger.error("Failed to get focused window info, error code: ", err, " [", count, " times]");
         }
 
         // Allow erroneous timeline event in Windows
@@ -126,7 +116,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
             event->SetIdle(false);
             error err = timeline_datasource_->StartTimelineEvent(event);
             if (err != noError) {
-                logger().error(err);
+                logger.error(err);
             }
         }
     }

--- a/src/window_change_recorder.h
+++ b/src/window_change_recorder.h
@@ -8,16 +8,13 @@
 
 #include "timeline_notifications.h"
 #include "types.h"
+#include "util/logger.h"
 
 #include <Poco/Activity.h>
 
 #if defined(__APPLE__)
 extern bool isCatalinaOSX(void);
 #endif
-
-namespace Poco {
-class Logger;
-}
 
 namespace toggl {
 
@@ -73,7 +70,7 @@ class TOGGL_INTERNAL_EXPORT WindowChangeRecorder {
 
     bool hasIdlenessChanged(const bool &idle) const;
 
-    Poco::Logger &logger();
+    Logger logger { "WindowChangeRecorder" };
 
     bool getIsLocked() {
         Poco::Mutex::ScopedLock lock(isLocked_m_);


### PR DESCRIPTION
### 📒 Description
Reduces a lot of boilerplate code all around the library. It uses a bit of template magic to reimplement how we used this boilerplate all around the library (verbatim, including the braces to limit the scope of `ss`:
```c++
{
    std::stringstream ss;
    ss << "Some message: " << some_value << " and something else=" << foo;
    Poco::Logger::get("context").log(ss.str());
}
```
Now the same thing can be written this way:
```c++
toggl::Logger("context").log("Some message: ", some_value, " and something else=", foo);
```
I also removed a few `std::stringstream` uses that weren't related to the `Logger` directly but did seem unnecessary when we have `std::to_string()` to convert numbers to `std::string`.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
Check if build passes. Then run the app and check if the log looks the same as before this. There should be no changes at all.
I did this thing manually (really hard to find a regexp for this) so it's possible there are typos.

