### PR TITLE
Edit view Part 1 - layout

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -208,6 +208,7 @@
     </Compile>
     <Compile Include="ui\Behaviors\ButtonHelper.cs" />
     <Compile Include="ui\Behaviors\CloseWindowOnEscBehavior.cs" />
+    <Compile Include="ui\Behaviors\DatePickerKeyboardHandlingBehavior.cs" />
     <Compile Include="ui\Behaviors\FocusHelper.cs" />
     <Compile Include="ui\Behaviors\FocusParentWindowOnClosingBehavior.cs" />
     <Compile Include="ui\Behaviors\HideWindowOnClosingBehavior.cs" />
@@ -687,6 +688,7 @@
     <Page Include="ui\Resources\DesignUpdate\ComboBox.xaml" />
     <Page Include="ui\Resources\DesignUpdate\ContextMenu.xaml" />
     <Page Include="ui\Resources\DesignUpdate\Controls.xaml" />
+    <Page Include="ui\Resources\DesignUpdate\DatePicker.xaml" />
     <Page Include="ui\Resources\DesignUpdate\ErrorTemplate.xaml" />
     <Page Include="ui\Resources\DesignUpdate\HotKeyBox.xaml" />
     <Page Include="ui\Resources\DesignUpdate\Hyperlink.xaml" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/DatePickerKeyboardHandlingBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/DatePickerKeyboardHandlingBehavior.cs
@@ -1,0 +1,50 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interactivity;
+
+namespace TogglDesktop.Behaviors
+{
+    public class DatePickerKeyboardHandlingBehavior : Behavior<DatePicker>
+    {
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            AssociatedObject.PreviewKeyDown += OnDatePickerPreviewKeyDown;
+        }
+
+        private void OnDatePickerPreviewKeyDown(object sender, KeyEventArgs args)
+        {
+            if (args.Key == Key.Enter)
+            {
+                if (AssociatedObject.IsDropDownOpen == false)
+                {
+                    args.Handled = true;
+                    AssociatedObject.IsDropDownOpen = true;
+                }
+            }
+
+            if (!AssociatedObject.SelectedDate.HasValue)
+            {
+                return;
+            }
+
+            var date = AssociatedObject.SelectedDate.Value;
+            if (args.Key == Key.Up)
+            {
+                args.Handled = true;
+                AssociatedObject.SelectedDate = date.AddDays(1);
+            }
+            else if (args.Key == Key.Down)
+            {
+                args.Handled = true;
+                AssociatedObject.SelectedDate = date.AddDays(-1);
+            }
+        }
+
+        protected override void OnDetaching()
+        {
+            AssociatedObject.PreviewKeyDown -= OnDatePickerPreviewKeyDown;
+            base.OnDetaching();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
@@ -1,0 +1,313 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+                    xmlns:behaviours="http://metro.mahapps.com/winfx/xaml/shared">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style TargetType="{x:Type DatePicker}">
+        <Setter Property="FontFamily" Value="{DynamicResource BaseFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource NormalFontSize}" />
+        <Setter Property="Background" Value="{DynamicResource Toggl.SelectionElements.Background}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource Toggl.TextBox.Border}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CalendarStyle" Value="{DynamicResource MahApps.Metro.Styles.BaseMetroCalendar}" />
+        <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource Toggl.AccentBrush}" />
+        <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource Toggl.TextBox.MouseOverBorder}" />
+        <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
+        <Setter Property="Padding" Value="5 3" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="24" />
+        <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
+        <Setter Property="IsTodayHighlighted" Value="True" />
+        <Setter Property="MinHeight" Value="26" />
+        <Setter Property="SelectedDateFormat" Value="Long" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type DatePicker}">
+                    <Grid x:Name="PART_Root">
+                        <Border x:Name="Base"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding Padding}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition x:Name="ButtonRow" Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <Button x:Name="PART_Button"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="1"
+                                    Foreground="{TemplateBinding Foreground}"
+                                    IsTabStop="False"
+                                    Style="{DynamicResource ChromelessButtonStyle}">
+                                <!--  PackIconModern - Calendar14  -->
+                                <ContentControl Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
+                                                Height="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
+                                                Padding="2"
+                                                Content="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z"
+                                                Style="{DynamicResource PathIconContentControlStyle}" />
+                            </Button>
+
+                            <DatePickerTextBox x:Name="PART_TextBox"
+                                               Grid.Row="1"
+                                               Grid.Column="0"
+                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                               mah:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.Watermark), Mode=OneWay}"
+                                               mah:TextBoxHelper.WatermarkAlignment="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.WatermarkAlignment), Mode=OneWay}"
+                                               mah:TextBoxHelper.WatermarkTrimming="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.WatermarkTrimming), Mode=OneWay}"
+                                               CaretBrush="{DynamicResource Toggl.PrimaryTextBrush}"
+                                               Focusable="{TemplateBinding Focusable}"
+                                               FontSize="{TemplateBinding FontSize}"
+                                               Foreground="{TemplateBinding Foreground}"
+                                               SelectionBrush="{DynamicResource HighlightBrush}">
+                                <i:Interaction.Behaviors>
+                                    <behaviours:DatePickerTextBoxBehavior />
+                                </i:Interaction.Behaviors>
+                            </DatePickerTextBox>
+
+                            <ContentControl x:Name="PART_FloatingMessageContainer"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{behaviours:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
+                                <TextBlock x:Name="PART_FloatingMessage"
+                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Foreground="{TemplateBinding Foreground}"
+                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}"
+                                           Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
+                                           TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{behaviours:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
+                            </ContentControl>
+
+                            <Popup x:Name="PART_Popup"
+                                   Grid.Row="1"
+                                   Grid.Column="0"
+                                   AllowsTransparency="True"
+                                   Placement="Bottom"
+                                   PlacementTarget="{Binding ElementName=PART_Root}"
+                                   StaysOpen="False" />
+                        </Grid>
+                        <Border x:Name="DisabledVisualElement"
+                                Background="{DynamicResource ControlsDisabledBrush}"
+                                BorderBrush="{DynamicResource ControlsDisabledBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                IsHitTestVisible="False"
+                                Opacity="0"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Grid>
+
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="mah:ControlsHelper.IsReadOnly" Value="True">
+                            <Setter TargetName="PART_Button" Property="IsEnabled" Value="False" />
+                            <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="True" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.MouseOverBorderBrush)}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_TextBox" Property="IsFocused" Value="True">
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
+                            <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                            <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
+                        </Trigger>
+                        <Trigger SourceName="PART_Button" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_Button" Property="Background" Value="{DynamicResource GrayBrush8}" />
+                            <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_Button" Property="IsPressed" Value="True">
+                            <Setter TargetName="PART_Button" Property="Background" Value="{DynamicResource BlackBrush}" />
+                            <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
+                        </Trigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
+                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
+                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
+                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource Toggl.DisabledTextBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource Toggl.DisabledElementBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MetroDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
+        <Setter Property="Background" Value="{DynamicResource Toggl.SelectionElements.Background}" />
+        <Setter Property="ContextMenu" Value="{DynamicResource TextBoxMetroContextMenu}" />
+        <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FontFamily" Value="{DynamicResource BaseFont}" />
+        <Setter Property="FontSize" Value="{DynamicResource NormalFontSize}" />
+        <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
+        <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type DatePickerTextBox}">
+                    <ControlTemplate.Resources>
+                        <Storyboard x:Key="EnterGotFocus">
+                            <DoubleAnimation Storyboard.TargetName="PART_Watermark"
+                                             Storyboard.TargetProperty="Opacity"
+                                             To=".2"
+                                             Duration="0:0:0.2" />
+                            <DoubleAnimation Storyboard.TargetName="PART_Message"
+                                             Storyboard.TargetProperty="Opacity"
+                                             To=".2"
+                                             Duration="0:0:0.2" />
+                        </Storyboard>
+                        <Storyboard x:Key="ExitGotFocus">
+                            <DoubleAnimation Storyboard.TargetName="PART_Watermark"
+                                             Storyboard.TargetProperty="Opacity"
+                                             Duration="0:0:0.2" />
+                            <DoubleAnimation Storyboard.TargetName="PART_Message"
+                                             Storyboard.TargetProperty="Opacity"
+                                             Duration="0:0:0.2" />
+                        </Storyboard>
+
+                        <Storyboard x:Key="EnterHasText">
+                            <DoubleAnimation Storyboard.TargetName="PART_Watermark"
+                                             Storyboard.TargetProperty="Opacity"
+                                             From=".2"
+                                             To="0"
+                                             Duration="0:0:0.2" />
+                            <DoubleAnimation Storyboard.TargetName="PART_Message"
+                                             Storyboard.TargetProperty="Opacity"
+                                             From=".2"
+                                             To="0"
+                                             Duration="0:0:0.2" />
+                        </Storyboard>
+                        <Storyboard x:Key="ExitHasText">
+                            <DoubleAnimation Storyboard.TargetName="PART_Watermark"
+                                             Storyboard.TargetProperty="Opacity"
+                                             Duration="0:0:0.2" />
+                            <DoubleAnimation Storyboard.TargetName="PART_Message"
+                                             Storyboard.TargetProperty="Opacity"
+                                             Duration="0:0:0.2" />
+                        </Storyboard>
+                    </ControlTemplate.Resources>
+                    <Grid x:Name="PART_InnerGrid" Margin="2">
+
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      VerticalAlignment="Stretch"
+                                      Background="{x:Null}"
+                                      BorderThickness="0"
+                                      FocusVisualStyle="{x:Null}"
+                                      IsTabStop="False" />
+                        <ContentControl x:Name="PART_Watermark"
+                                        Margin="4 0 0 0"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        mah:TextBoxHelper.WatermarkAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
+                                        mah:TextBoxHelper.WatermarkTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
+                                        Focusable="False"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        IsHitTestVisible="False"
+                                        Opacity="0.6"
+                                        Visibility="Hidden">
+                            <ContentControl.Template>
+                                <ControlTemplate TargetType="{x:Type ContentControl}">
+                                    <TextBlock HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                               Text="{TemplateBinding Content}"
+                                               TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
+                                               TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}" />
+                                </ControlTemplate>
+                            </ContentControl.Template>
+                        </ContentControl>
+                        <TextBlock x:Name="PART_Message"
+                                   Margin="4 0 0 0"
+                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                   Foreground="{TemplateBinding Foreground}"
+                                   Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
+                                   Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
+                                   TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
+                                   TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.HasText" Value="False" />
+                                <Condition Property="IsFocused" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource EnterGotFocus}" />
+                            </MultiTrigger.EnterActions>
+                            <MultiTrigger.ExitActions>
+                                <BeginStoryboard Storyboard="{StaticResource ExitGotFocus}" />
+                            </MultiTrigger.ExitActions>
+                        </MultiTrigger>
+
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.Watermark)}" Value="">
+                            <Setter TargetName="PART_Watermark" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+
+                        <Trigger Property="mah:TextBoxHelper.HasText" Value="True">
+                            <Trigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource EnterHasText}" />
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard Storyboard="{StaticResource ExitHasText}" />
+                            </Trigger.ExitActions>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
@@ -7,6 +7,37 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
+    <Style TargetType="Button" x:Key="Toggl.DateIconButton">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="FontSize" Value="{DynamicResource NormalFontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource BaseFont}" />
+        <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Canvas Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
+                            Height="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
+                            Background="{TemplateBinding Background}">
+                        <Path Fill="{TemplateBinding Foreground}" Data="M8 5v1h8V5h1v1h3v14H4V6h3V5h1zm11 5H5v9h14v-9zm-5 7v1h-1v-1h1zm-3 0v1h-1v-1h1zm-3 0v1H7v-1h1zm3-2v1h-1v-1h1zm-3 0v1H7v-1h1zm9 0v1h-1v-1h1zm-3 0v1h-1v-1h1zm-3-2v1h-1v-1h1zm-3 0v1H7v-1h1zm9 0v1h-1v-1h1zm-3 0v1h-1v-1h1zm-3-2v1h-1v-1h1zm6 0v1h-1v-1h1zm-3 0v1h-1v-1h1zM7 7H5v2h14V7h-2v1h-1V7H8v1H7V7z"/>
+                    </Canvas>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource Toggl.Button.Primary.Background}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource Toggl.CardBackground}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Foreground" Value="{DynamicResource Toggl.DisabledTextBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style TargetType="{x:Type DatePicker}">
         <Setter Property="FontFamily" Value="{DynamicResource BaseFont}" />
         <Setter Property="FontSize" Value="{DynamicResource NormalFontSize}" />
@@ -48,16 +79,9 @@
                             <Button x:Name="PART_Button"
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource ChromelessButtonStyle}">
-                                <!--  PackIconModern - Calendar14  -->
-                                <ContentControl Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                                Height="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                                Padding="2"
-                                                Content="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z"
-                                                Style="{DynamicResource PathIconContentControlStyle}" />
-                            </Button>
+                                    Style="{StaticResource Toggl.DateIconButton}"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center" />
 
                             <DatePickerTextBox x:Name="PART_TextBox"
                                                Grid.Row="1"
@@ -151,14 +175,6 @@
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
-                        </Trigger>
-                        <Trigger SourceName="PART_Button" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_Button" Property="Background" Value="{DynamicResource GrayBrush8}" />
-                            <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_Button" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_Button" Property="Background" Value="{DynamicResource BlackBrush}" />
-                            <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
                         </Trigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Icons.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Icons.xaml
@@ -10,4 +10,11 @@
     <Geometry x:Key="StopButtonGeometry">
         M24 22.504C24 23.33 23.32 24 22.504 24h-9.008C12.67 24 12 23.32 12 22.504v-9.008c0-.826.68-1.496 1.496-1.496h9.008c.826 0 1.496.68 1.496 1.496v9.008z
     </Geometry>
+    <Geometry x:Key="ArrowGeometry">
+        M7.812.16C7.363-.166 7 .023 7 .567v6.006c0 .55.36.735.812.407l3.876-2.82c.449-.326.451-.852 0-1.18L7.812.16z
+    </Geometry>
+    <Canvas x:Key="Toggl.ArrowIcon" x:Shared="False" Width="12" Height="7">
+        <Path Fill="{DynamicResource Toggl.DisabledTextBrush}" Data="{StaticResource ArrowGeometry}"/>
+        <Path StrokeThickness="2" Stroke="{DynamicResource Toggl.DisabledTextBrush}" StrokeLineJoin="Round" StrokeStartLineCap="Round" StrokeEndLineCap="Round" Data="M8 3.57H1"/>
+    </Canvas>
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/EditViewControllerStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/EditViewControllerStyles.xaml
@@ -140,94 +140,10 @@
 
     <Style TargetType="UserControl" x:Key="EditView">
         <Style.Resources>
-
-            <Style TargetType="DatePicker" BasedOn="{StaticResource EditViewControlBase}">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type DatePicker}">
-                            <Grid x:Name="PART_Root"
-                              Background="White">
-                                <DatePickerTextBox x:Name="PART_TextBox">
-                                    <DatePickerTextBox.Style>
-                                        <Style TargetType="DatePickerTextBox" BasedOn="{StaticResource EditViewControlBase}">
-                                            <Setter Property="Margin" Value="0, 0, 20, 0" />
-                                            <Setter Property="Padding" Value="20, 0, 0, 0" />
-                                            <Setter Property="FontSize" Value="10"/>
-                                            <Setter Property="HorizontalContentAlignment" Value="Center" />
-                                            <Setter Property="HorizontalAlignment" Value="Stretch" />
-                                            <Setter Property="VerticalAlignment" Value="Stretch" />
-                                            <Setter Property="Template">
-                                                <Setter.Value>
-                                                    <ControlTemplate x:Name="dptext" TargetType="{x:Type DatePickerTextBox}">
-                                                        <ScrollViewer x:Name="PART_ContentHost"/>
-                                                    </ControlTemplate>
-                                                </Setter.Value>
-                                            </Setter>
-                                            <Style.Triggers>
-                                                <Trigger Property="IsEnabled" Value="False">
-                                                    <Setter Property="Foreground" Value="#B2252525"></Setter>
-                                                </Trigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </DatePickerTextBox.Style>
-                                </DatePickerTextBox>
-                                <Button x:Name="PART_Button" Content="/TogglDesktop;component/Resources/ic_calendar_2x.png">
-                                    <Button.Style>
-                                        <Style TargetType="Button" BasedOn="{StaticResource EditViewTextFieldImageButtonBase}">
-                                            <Setter Property="Margin" Value="0"/>
-                                            <Style.Triggers>
-                                                <Trigger Property="IsEnabled" Value="False">
-                                                    <Setter Property="Visibility" Value="Hidden" />
-                                                </Trigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Button.Style>
-                                </Button>
-                                <Popup x:Name="PART_Popup" StaysOpen="False" AllowsTransparency="True" />
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
             
             <Style TargetType="Button" BasedOn="{StaticResource FlatButton}">
                 <Setter Property="Margin" Value="8"/>
             </Style>
-            
-            <!-- <Style TargetType="CheckBox" BasedOn="{StaticResource EditViewControlBase}"> -->
-            <!--     <Setter Property="Padding" Value="0"/> -->
-            <!--     <Setter Property="Template"> -->
-            <!--         <Setter.Value> -->
-            <!--             <ControlTemplate TargetType="{x:Type CheckBox}"> -->
-            <!--                 <BulletDecorator Background="Transparent" SnapsToDevicePixels="true" > -->
-            <!--                     <BulletDecorator.Bullet> -->
-            <!--                         <Border x:Name="border" -->
-            <!--                         Width="16" Height="16" Background="White"> -->
-            <!--                             <Path x:Name="checkMark" -->
-            <!--                               Width="12" -->
-            <!--                               Height="9.5" -->
-            <!--                               HorizontalAlignment="Center" -->
-            <!--                               VerticalAlignment="Center" -->
-            <!--                               Data="M -1 -1 L 0 0 L 2 -2" -->
-            <!--                               Stretch="Fill" -->
-            <!--                               Stroke="#252525" -->
-            <!--                               StrokeThickness="2" /> -->
-            <!--                         </Border> -->
-            <!--                     </BulletDecorator.Bullet> -->
-            <!--                     <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="4, 1, 0, -1" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/> -->
-            <!--                 </BulletDecorator> -->
-            <!--                 <ControlTemplate.Triggers> -->
-            <!--                     <Trigger Property="IsChecked" Value="False"> -->
-            <!--                         <Setter TargetName="checkMark" Property="Visibility" Value="Hidden"/> -->
-            <!--                     </Trigger> -->
-            <!--                     <Trigger Property="IsMouseOver" Value="True"> -->
-            <!--                         <Setter TargetName="border" Property="Background" Value="#F4F4F4"/> -->
-            <!--                     </Trigger> -->
-            <!--                 </ControlTemplate.Triggers> -->
-            <!--             </ControlTemplate> -->
-            <!--         </Setter.Value> -->
-            <!--     </Setter> -->
-            <!-- </Style> -->
 
         </Style.Resources>
     </Style>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/EditViewControllerStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/EditViewControllerStyles.xaml
@@ -95,26 +95,6 @@
         <Setter Property="Background" Value="#999999" />
     </Style>
 
-    <Style TargetType="TextBox" x:Key="TimeBox" BasedOn="{StaticResource {x:Type TextBox}}">
-        <Setter Property="Margin" Value="8"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="Padding" Value="0"/>
-        <Setter Property="Background">
-            <Setter.Value>
-                <SolidColorBrush Color="{toggl:Opacity White, 0.6}"/>
-            </Setter.Value>
-        </Setter>
-        <Style.Triggers>
-            <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Background" Value="White"/>
-            </Trigger>
-        </Style.Triggers>
-    </Style>
-    <Style TargetType="TextBox" x:Key="DurationBox" BasedOn="{StaticResource TimeBox}">
-        <Setter Property="FontWeight" Value="Bold"/>
-        <Setter Property="Background" Value="White"/>
-    </Style>
     <Style x:Key="EditViewNewButton" TargetType="Button" BasedOn="{StaticResource EditViewControlBase}">
         <Setter Property="Template">
             <Setter.Value>
@@ -214,52 +194,40 @@
                 <Setter Property="Margin" Value="8"/>
             </Style>
             
-            <Style TargetType="CheckBox" BasedOn="{StaticResource EditViewControlBase}">
-                <Setter Property="Padding" Value="0"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type CheckBox}">
-                            <BulletDecorator Background="Transparent" SnapsToDevicePixels="true" >
-                                <BulletDecorator.Bullet>
-                                    <Border x:Name="border"
-                                    Width="16" Height="16" Background="White">
-                                        <Path x:Name="checkMark"
-                                          Width="12"
-                                          Height="9.5"
-                                          HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"
-                                          Data="M -1 -1 L 0 0 L 2 -2"
-                                          Stretch="Fill"
-                                          Stroke="#252525"
-                                          StrokeThickness="2" />
-                                    </Border>
-                                </BulletDecorator.Bullet>
-                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="4, 1, 0, -1" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                            </BulletDecorator>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsChecked" Value="False">
-                                    <Setter TargetName="checkMark" Property="Visibility" Value="Hidden"/>
-                                </Trigger>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="border" Property="Background" Value="#F4F4F4"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
-                <Setter Property="Margin" Value="8"/>
-                <Setter Property="VerticalContentAlignment" Value="Center"/>
-                <Setter Property="Padding" Value="8, 0, 0, 0"/>
-            </Style>
-
-            <Style TargetType="toggl:ExtendedTextBox" BasedOn="{StaticResource {x:Type toggl:ExtendedTextBox}}">
-                <Setter Property="Margin" Value="8"/>
-                <Setter Property="VerticalContentAlignment" Value="Center"/>
-                <Setter Property="Padding" Value="8, 0, 0, 0"/>
-            </Style>
+            <!-- <Style TargetType="CheckBox" BasedOn="{StaticResource EditViewControlBase}"> -->
+            <!--     <Setter Property="Padding" Value="0"/> -->
+            <!--     <Setter Property="Template"> -->
+            <!--         <Setter.Value> -->
+            <!--             <ControlTemplate TargetType="{x:Type CheckBox}"> -->
+            <!--                 <BulletDecorator Background="Transparent" SnapsToDevicePixels="true" > -->
+            <!--                     <BulletDecorator.Bullet> -->
+            <!--                         <Border x:Name="border" -->
+            <!--                         Width="16" Height="16" Background="White"> -->
+            <!--                             <Path x:Name="checkMark" -->
+            <!--                               Width="12" -->
+            <!--                               Height="9.5" -->
+            <!--                               HorizontalAlignment="Center" -->
+            <!--                               VerticalAlignment="Center" -->
+            <!--                               Data="M -1 -1 L 0 0 L 2 -2" -->
+            <!--                               Stretch="Fill" -->
+            <!--                               Stroke="#252525" -->
+            <!--                               StrokeThickness="2" /> -->
+            <!--                         </Border> -->
+            <!--                     </BulletDecorator.Bullet> -->
+            <!--                     <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="4, 1, 0, -1" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/> -->
+            <!--                 </BulletDecorator> -->
+            <!--                 <ControlTemplate.Triggers> -->
+            <!--                     <Trigger Property="IsChecked" Value="False"> -->
+            <!--                         <Setter TargetName="checkMark" Property="Visibility" Value="Hidden"/> -->
+            <!--                     </Trigger> -->
+            <!--                     <Trigger Property="IsMouseOver" Value="True"> -->
+            <!--                         <Setter TargetName="border" Property="Background" Value="#F4F4F4"/> -->
+            <!--                     </Trigger> -->
+            <!--                 </ControlTemplate.Triggers> -->
+            <!--             </ControlTemplate> -->
+            <!--         </Setter.Value> -->
+            <!--     </Setter> -->
+            <!-- </Style> -->
 
         </Style.Resources>
     </Style>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
@@ -19,9 +19,6 @@
 
     <sys:Double x:Key="TimerHeight">68</sys:Double>
 
-    <sys:Double x:Key="EditViewMarginH">28</sys:Double>
-    <sys:Double x:Key="EditViewMarginV">40</sys:Double>
-
     <Style TargetType="Control">
         <Setter Property="FontFamily" Value="{StaticResource DefaultFont}" />
         <Setter Property="FontSize" Value="13.3" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
@@ -19,7 +19,7 @@
 
     <sys:Double x:Key="TimerHeight">68</sys:Double>
 
-    <sys:Double x:Key="EditViewMarginH">12</sys:Double>
+    <sys:Double x:Key="EditViewMarginH">28</sys:Double>
     <sys:Double x:Key="EditViewMarginV">40</sys:Double>
 
     <Style TargetType="Control">
@@ -62,20 +62,6 @@
         </Setter>
 
     </Style>
-
-    <Style TargetType="toggl:ExtendedTextBox" BasedOn="{StaticResource {x:Type TextBox}}" />
-
-        <!-- <Style TargetType="TextBlock"> -->
-    <!--     <Setter Property="FontFamily" Value="{StaticResource DefaultFont}" /> -->
-    <!--     <Setter Property="FontSize" Value="13.3" /> -->
-    <!--     <Setter Property="Foreground" Value="#252525"/> -->
-    <!--     <Setter Property="UseLayoutRounding" Value="True" /> -->
-    <!--     <Style.Triggers> -->
-    <!--         <Trigger Property="IsEnabled" Value="False"> -->
-    <!--             <Setter Property="Foreground" Value="#B2252525"/> -->
-    <!--         </Trigger> -->
-    <!--     </Style.Triggers> -->
-    <!-- </Style> -->
 
     <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type Control}}">
         <Setter Property="BorderThickness" Value="1" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -4,10 +4,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:toggl="clr-namespace:TogglDesktop"
+             xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              mc:Ignorable="d" MinWidth="370"
              Style="{StaticResource EditView}"
              >
-    <Grid Background="{StaticResource ViewBackgroundLight}">
+    <Grid Background="{DynamicResource Toggl.CardBackground}">
         <Grid Name="contentGrid" x:FieldModifier="private">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -271,7 +272,11 @@
                     Content="/TogglDesktop;component/Resources/ic_delete_grey600_36dp.png"
                     Click="deleteButton_OnClick"/>
 
-        
         </Grid>
+        <Button Style="{DynamicResource Toggl.CrossButton}"
+                HorizontalAlignment="Right" VerticalAlignment="Top"
+                Width="32" Height="32"
+                Focusable="False"
+                behaviors:ButtonHelper.IsCloseWindowButton="True"/>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -54,7 +54,7 @@
                     </Grid.RowDefinitions>
                 
                     <!-- project -->
-                    <Grid Grid.Row="0" Height="50">
+                    <Grid Grid.Row="0" Height="32" Margin="0 8 0 0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="AddButtons"
@@ -63,6 +63,7 @@
 
                         <toggl:ProjectTextBox x:Name="projectTextBox" x:FieldModifier="private" Grid.Column="0"
                                                 LostKeyboardFocus="projectTextBox_OnLostKeyboardFocus"
+                                                Margin="0"
                                                 Padding="27, 0, 34, 0"
                                                 PreviewKeyDown="projectTextBox_OnPreviewKeyDown"/>
 
@@ -89,10 +90,11 @@
 
                         <toggl:ProjectColorPicker
                             x:Name="projectColorSelector" x:FieldModifier="private" Grid.Column="0"
-                            Margin="8" Width="28"/>
+                            Width="28"/>
 
                         <ToggleButton x:Name="projectDropDownButton" x:FieldModifier="private" Grid.Column="0"
-                                            Style="{StaticResource EditViewAutoCompleteTextFieldButton}"/>
+                                            Style="{StaticResource EditViewAutoCompleteTextFieldButton}"
+                                            Margin="0"/>
 
                         <Button x:Name ="newProjectCancelButton" x:FieldModifier="private" Grid.Column="1"
                                 Style="{StaticResource EditViewTextFieldImageButtonBase}"
@@ -188,8 +190,8 @@
                 </Grid>
 
                 <!-- tags -->
-                <Grid MinHeight="50">
-                    <toggl:TagList x:Name="tagList" x:FieldModifier="private" Margin="8"
+                <Grid MinHeight="32" Margin="0 8 0 0">
+                    <toggl:TagList x:Name="tagList" x:FieldModifier="private"
                                    LostKeyboardFocus="tagList_OnLostKeyboardFocus"
                                    GotKeyboardFocus="tagList_OnGotKeybardFocus"
                                    TagAdded="tagList_TagAdded"
@@ -201,6 +203,7 @@
 
                 <!-- billable? -->
                 <CheckBox Name="billableCheckBox" x:FieldModifier="private"
+                          Margin="0 8 0 0"
                           Click="billableCheckBox_OnClick" Content="Billable" />
             
                 <!-- times, duration -->

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -273,11 +273,5 @@
 
         
         </Grid>
-        <Button Style="{StaticResource EditViewImageButton}"
-                HorizontalAlignment="right" VerticalAlignment="top" Margin="0"
-                Width="32" Height="32"
-                Focusable="False"
-                Content="/TogglDesktop;component/Resources/ic_close_grey600_36dp.png"
-                Click="backButton_OnClick"/>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -5,9 +5,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:toggl="clr-namespace:TogglDesktop"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
-             mc:Ignorable="d" MinWidth="370"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             mc:Ignorable="d" MinWidth="300"
              Style="{StaticResource EditView}"
              >
+    <UserControl.Resources>
+        <ResourceDictionary Source="../Resources/DesignUpdate/Controls.xaml" />
+    </UserControl.Resources>
     <Grid Background="{DynamicResource Toggl.CardBackground}">
         <Grid Name="contentGrid" x:FieldModifier="private">
             <Grid.ColumnDefinitions>
@@ -34,32 +38,20 @@
             <!-- content -->
             <StackPanel Orientation="Vertical" Grid.Column="1" Grid.Row="1">
 
+                <TextBlock Style="{DynamicResource Toggl.BodyText}" Text="Details" />
                 <!-- description -->
-                <Grid Height="50">
+                <Grid Margin="0 8 0 0">
                     <toggl:ExtendedTextBox x:Name="descriptionTextBox" x:FieldModifier="private"
+                                           Style="{StaticResource {x:Type TextBox}}"
+                                           mah:TextBoxHelper.Watermark="Description"
                         LostKeyboardFocus="descriptionTextBox_OnLostKeyboardFocus"
                                            SelectAllOnKeyboardFocus="False"
                                            KeyDown="descriptionTextBox_OnKeyDown"/>
-                    <TextBlock>No description
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock" BasedOn="{StaticResource TextboxEmptyText}">
-                                <Style.Triggers>
-                                    <MultiDataTrigger>
-                                        <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding ElementName=descriptionTextBox, Path=(Text)}" Value=""/>
-                                            <Condition Binding="{Binding ElementName=descriptionTextBox, Path=(IsKeyboardFocused)}" Value="False"/>
-                                        </MultiDataTrigger.Conditions>
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </MultiDataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
                     <toggl:AutoCompletionPopup x:Name="descriptionAutoComplete" x:FieldModifier="private"
-                        Target="{Binding ElementName=descriptionTextBox}" TextBox="{Binding ElementName=descriptionTextBox}"
-                        EmptyText="No matching entries found."
-                        ConfirmCompletion="descriptionAutoComplete_OnConfirmCompletion"
-                        ConfirmWithoutCompletion="descriptionAutoComplete_OnConfirmWithoutCompletion"/>
+                                               Target="{Binding ElementName=descriptionTextBox}" TextBox="{Binding ElementName=descriptionTextBox}"
+                                               EmptyText="No matching entries found."
+                                               ConfirmCompletion="descriptionAutoComplete_OnConfirmCompletion"
+                                               ConfirmWithoutCompletion="descriptionAutoComplete_OnConfirmWithoutCompletion"/>
                 </Grid>
 
                 <!-- project, client, workspace -->
@@ -205,33 +197,45 @@
                         <Button Click="projectCancelButton_Click">CANCEL</Button>
                     </StackPanel>
                 </Grid>
+
+                <!-- billable? -->
+                <CheckBox Name="billableCheckBox" x:FieldModifier="private"
+                          Click="billableCheckBox_OnClick" Content="Billable" />
             
                 <!-- times, duration -->
-                <Grid>
+                <Grid Margin="0 22 0 0">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="50"/>
-                        <RowDefinition Height="22"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="2*"/>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <toggl:ExtendedTextBox x:Name="startTimeTextBox" x:FieldModifier="private" Grid.Column="0" Grid.Row="0"
-                             Style="{StaticResource TimeBox}"
-                             LostKeyboardFocus="startTimeTextBox_OnLostKeyboardFocus"
-                             KeyDown="startTimeTextBox_OnKeyDown">12:45</toggl:ExtendedTextBox>
-                    <toggl:ExtendedTextBox x:Name="durationTextBox" x:FieldModifier="private"  Grid.Column="1" Grid.Row="0"
-                             Style="{StaticResource DurationBox}"
-                             LostKeyboardFocus="durationTextBox_OnLostKeyboardFocus"
-                             KeyDown="durationTextBox_OnKeyDown">10:12 min</toggl:ExtendedTextBox>
-                    <toggl:ExtendedTextBox x:Name="endTimeTextBox" x:FieldModifier="private"  Grid.Column="2" Grid.Row="0"
-                             Style="{StaticResource TimeBox}"
-                             LostKeyboardFocus="endTimeTextBox_OnLostKeyboardFocus"
-                             KeyDown="endTimeTextBox_OnKeyDown">12:55</toggl:ExtendedTextBox>
-
-                    <DatePicker Name="startDatePicker" x:FieldModifier="private" Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                             Height="20" VerticalAlignment="Bottom" SelectedDate="05.01.2015" SelectedDateChanged="startDatePicker_SelectedDateChanged"/>
+                    <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 0 0 8" Text="Duration" />
+                    <toggl:ExtendedTextBox x:Name="durationTextBox" x:FieldModifier="private" Grid.Row="1" Grid.Column="0"
+                                           Margin="0 0 12 0"
+                                           Style="{StaticResource {x:Type TextBox}}"
+                                           LostKeyboardFocus="durationTextBox_OnLostKeyboardFocus"
+                                           KeyDown="durationTextBox_OnKeyDown">10:12 min</toggl:ExtendedTextBox>
+                    <StackPanel Orientation="Horizontal"
+                                Grid.Row="1" Grid.Column="1">
+                        <toggl:ExtendedTextBox x:Name="startTimeTextBox" x:FieldModifier="private"
+                                               Style="{StaticResource {x:Type TextBox}}"
+                                               Margin="0 0 8 0" Width="64"
+                                               LostKeyboardFocus="startTimeTextBox_OnLostKeyboardFocus"
+                                               KeyDown="startTimeTextBox_OnKeyDown">12:45</toggl:ExtendedTextBox>
+                        <ContentControl Focusable="False" Content="{StaticResource Toggl.ArrowIcon}" />
+                        <toggl:ExtendedTextBox x:Name="endTimeTextBox" x:FieldModifier="private"
+                                               Style="{StaticResource {x:Type TextBox}}"
+                                               Margin="7 0 0 0" Width="64"
+                                               LostKeyboardFocus="endTimeTextBox_OnLostKeyboardFocus"
+                                               KeyDown="endTimeTextBox_OnKeyDown">12:55</toggl:ExtendedTextBox>
+                    </StackPanel>
+                    <DatePicker Name="startDatePicker" x:FieldModifier="private" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                Margin="0 8 0 0"
+                             Height="32" SelectedDate="05.01.2015" SelectedDateChanged="startDatePicker_SelectedDateChanged"/>
                 </Grid>
             
                 <!-- tags -->
@@ -245,19 +249,6 @@
                     <TextBlock x:Name="emptyTagListText" x:FieldModifier="private"
                                Style="{StaticResource TextboxEmptyText}">No tags</TextBlock>
                 </Grid>
-            
-            
-            
-                <!-- billable? -->
-                <CheckBox Name="billableCheckBox" x:FieldModifier="private"
-                          Click="billableCheckBox_OnClick">
-                    <StackPanel Orientation="Horizontal" Margin="0 -1 0 1">
-                    <Image Source="/TogglDesktop;component/Resources/icon-billable.png"
-                           Stretch="UniformToFill" Margin="1, -1, 3, -1" Height="18"/>
-                        <TextBlock>Billable</TextBlock>
-                    </StackPanel>
-                </CheckBox>
-            
             </StackPanel>
         
             <TextBlock Name="lastUpdatedText" x:FieldModifier="private"
@@ -273,7 +264,7 @@
                     Click="deleteButton_OnClick"/>
 
         </Grid>
-        <Button Style="{DynamicResource Toggl.CrossButton}"
+        <Button Style="{StaticResource Toggl.CrossButton}"
                 HorizontalAlignment="Right" VerticalAlignment="Top"
                 Width="32" Height="32"
                 Focusable="False"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -210,8 +210,10 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
+                        <ColumnDefinition Width="23*" />
+                        <ColumnDefinition Width="16*"/>
                         <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="16*" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 0 0 8" Text="Duration" />
                     <toggl:ExtendedTextBox x:Name="durationTextBox" x:FieldModifier="private" Grid.Row="1" Grid.Column="0"
@@ -219,21 +221,21 @@
                                            Style="{StaticResource {x:Type TextBox}}"
                                            LostKeyboardFocus="durationTextBox_OnLostKeyboardFocus"
                                            KeyDown="durationTextBox_OnKeyDown">10:12 min</toggl:ExtendedTextBox>
-                    <StackPanel Orientation="Horizontal"
-                                Grid.Row="1" Grid.Column="1">
-                        <toggl:ExtendedTextBox x:Name="startTimeTextBox" x:FieldModifier="private"
-                                               Style="{StaticResource {x:Type TextBox}}"
-                                               Margin="0 0 8 0" Width="64"
-                                               LostKeyboardFocus="startTimeTextBox_OnLostKeyboardFocus"
-                                               KeyDown="startTimeTextBox_OnKeyDown">12:45</toggl:ExtendedTextBox>
-                        <ContentControl Focusable="False" Content="{StaticResource Toggl.ArrowIcon}" />
-                        <toggl:ExtendedTextBox x:Name="endTimeTextBox" x:FieldModifier="private"
-                                               Style="{StaticResource {x:Type TextBox}}"
-                                               Margin="7 0 0 0" Width="64"
-                                               LostKeyboardFocus="endTimeTextBox_OnLostKeyboardFocus"
-                                               KeyDown="endTimeTextBox_OnKeyDown">12:55</toggl:ExtendedTextBox>
-                    </StackPanel>
-                    <DatePicker Name="startDatePicker" x:FieldModifier="private" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                    <toggl:ExtendedTextBox x:Name="startTimeTextBox" x:FieldModifier="private"
+                                           Grid.Row="1" Grid.Column="1"
+                                           Style="{StaticResource {x:Type TextBox}}"
+                                           LostKeyboardFocus="startTimeTextBox_OnLostKeyboardFocus"
+                                           KeyDown="startTimeTextBox_OnKeyDown">12:45</toggl:ExtendedTextBox>
+                    <ContentControl Focusable="False"
+                                    Margin="6 0"
+                                    Grid.Row="1" Grid.Column="2"
+                                    Content="{StaticResource Toggl.ArrowIcon}" />
+                    <toggl:ExtendedTextBox x:Name="endTimeTextBox" x:FieldModifier="private"
+                                           Grid.Row="1" Grid.Column="3"
+                                           Style="{StaticResource {x:Type TextBox}}"
+                                           LostKeyboardFocus="endTimeTextBox_OnLostKeyboardFocus"
+                                           KeyDown="endTimeTextBox_OnKeyDown">12:55</toggl:ExtendedTextBox>
+                    <DatePicker Name="startDatePicker" x:FieldModifier="private" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4"
                                 Margin="0 8 0 0"
                              Height="32" SelectedDate="05.01.2015" SelectedDateChanged="startDatePicker_SelectedDateChanged"/>
                 </Grid>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -13,30 +13,14 @@
         <ResourceDictionary Source="../Resources/DesignUpdate/Controls.xaml" />
     </UserControl.Resources>
     <Grid Background="{DynamicResource Toggl.CardBackground}">
-        <Grid Name="contentGrid" x:FieldModifier="private">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+        <Grid Name="contentGrid" x:FieldModifier="private" Margin="28 20">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <FrameworkElement Grid.Row="0" Grid.Column="0"
-                Width="{StaticResource EditViewMarginH}"
-                Height="{StaticResource EditViewMarginV}"
-                />
-            <FrameworkElement Grid.Row="3" Grid.Column="2"
-                Width="{StaticResource EditViewMarginH}"
-                Height="{StaticResource EditViewMarginV}"
-                />
-
             <!-- content -->
-            <StackPanel Orientation="Vertical" Grid.Column="1" Grid.Row="1">
+            <StackPanel Orientation="Vertical" Margin="0 20 0 0">
 
                 <TextBlock Style="{DynamicResource Toggl.BodyText}" Text="Details" />
                 <!-- description -->
@@ -198,6 +182,18 @@
                     </StackPanel>
                 </Grid>
 
+                <!-- tags -->
+                <Grid MinHeight="50">
+                    <toggl:TagList x:Name="tagList" x:FieldModifier="private" Margin="8"
+                                   LostKeyboardFocus="tagList_OnLostKeyboardFocus"
+                                   GotKeyboardFocus="tagList_OnGotKeybardFocus"
+                                   TagAdded="tagList_TagAdded"
+                                   TagRemoved="tagList_TagRemoved"/>
+
+                    <TextBlock x:Name="emptyTagListText" x:FieldModifier="private"
+                               Style="{StaticResource TextboxEmptyText}">No tags</TextBlock>
+                </Grid>
+
                 <!-- billable? -->
                 <CheckBox Name="billableCheckBox" x:FieldModifier="private"
                           Click="billableCheckBox_OnClick" Content="Billable" />
@@ -239,31 +235,21 @@
                                 Margin="0 8 0 0"
                              Height="32" SelectedDate="05.01.2015" SelectedDateChanged="startDatePicker_SelectedDateChanged"/>
                 </Grid>
-            
-                <!-- tags -->
-                <Grid MinHeight="50">
-                    <toggl:TagList x:Name="tagList" x:FieldModifier="private" Margin="8"
-                                   LostKeyboardFocus="tagList_OnLostKeyboardFocus"
-                                   GotKeyboardFocus="tagList_OnGotKeybardFocus"
-                                   TagAdded="tagList_TagAdded"
-                                   TagRemoved="tagList_TagRemoved"/>
 
-                    <TextBlock x:Name="emptyTagListText" x:FieldModifier="private"
-                               Style="{StaticResource TextboxEmptyText}">No tags</TextBlock>
-                </Grid>
+                <TextBlock Margin="0 14 0 0" LineHeight="20">
+                    <Hyperlink Foreground="{DynamicResource Toggl.ValidationErrorBackground}"
+                               Click="deleteButton_OnClick"
+                               TextDecorations="{x:Null}">Delete</Hyperlink>
+                </TextBlock>
+
             </StackPanel>
-        
-            <TextBlock Name="lastUpdatedText" x:FieldModifier="private"
-                       Grid.Column="1" Grid.Row="3"
-                       Style="{StaticResource SmallText}"
-                       HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="10">Last update N/A</TextBlock>
 
-            <Button Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="3"
-                    Style="{StaticResource EditViewImageButton}"
-                    HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0"
-                    Width="32" Height="32"
-                    Content="/TogglDesktop;component/Resources/ic_delete_grey600_36dp.png"
-                    Click="deleteButton_OnClick"/>
+            <Button Grid.Row="1"
+                    Style="{StaticResource Toggl.PrimaryButton}"
+                    HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                    Width="88" Height="32"
+                    Content="Done"
+                    behaviors:ButtonHelper.IsCloseWindowButton="True" />
 
         </Grid>
         <Button Style="{StaticResource Toggl.CrossButton}"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -6,11 +6,16 @@
              xmlns:toggl="clr-namespace:TogglDesktop"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              mc:Ignorable="d" MinWidth="300"
-             Style="{StaticResource EditView}"
-             >
+             Style="{StaticResource EditView}">
     <UserControl.Resources>
-        <ResourceDictionary Source="../Resources/DesignUpdate/Controls.xaml" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Resources/DesignUpdate/Controls.xaml" />
+                <ResourceDictionary Source="../Resources/DesignUpdate/DatePicker.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
     <Grid Background="{DynamicResource Toggl.CardBackground}">
         <Grid Name="contentGrid" x:FieldModifier="private" Margin="28 20">
@@ -233,7 +238,13 @@
                                            KeyDown="endTimeTextBox_OnKeyDown">12:55</toggl:ExtendedTextBox>
                     <DatePicker Name="startDatePicker" x:FieldModifier="private" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4"
                                 Margin="0 8 0 0"
-                             Height="32" SelectedDate="05.01.2015" SelectedDateChanged="startDatePicker_SelectedDateChanged"/>
+                                Height="32"
+                                SelectedDate="05.01.2015"
+                                LostKeyboardFocus="startDatePicker_LostKeyboardFocus">
+                        <i:Interaction.Behaviors>
+                            <behaviors:DatePickerKeyboardHandlingBehavior />
+                        </i:Interaction.Behaviors>
+                    </DatePicker>
                 </Grid>
 
                 <TextBlock Margin="0 14 0 0" LineHeight="20">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -248,6 +248,7 @@
                     Style="{StaticResource Toggl.PrimaryButton}"
                     HorizontalAlignment="Right" VerticalAlignment="Bottom"
                     Width="88" Height="32"
+                    Margin="0 12 0 0"
                     Content="Done"
                     behaviors:ButtonHelper.IsCloseWindowButton="True" />
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -401,9 +401,12 @@ namespace TogglDesktop
 
         private void startDatePicker_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
-            if (this.dateSet)
+            if (!startDatePicker.IsKeyboardFocusWithin)
             {
-                this.saveDate();
+                if (this.dateSet)
+                {
+                    this.saveDate();
+                }
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -132,18 +132,6 @@ namespace TogglDesktop
                 this.billableCheckBox.ShowOnlyIf(timeEntry.CanSeeBillable);
                 this.billableCheckBox.IsChecked = timeEntry.Billable;
 
-                if (timeEntry.UpdatedAt > 0)
-                {
-                    var updatedAt = Toggl.DateTimeFromUnix(timeEntry.UpdatedAt);
-                    this.lastUpdatedText.Text = "Last update " + updatedAt.ToShortDateString() + " at " +
-                                                updatedAt.ToLongTimeString();
-                    this.lastUpdatedText.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    this.lastUpdatedText.Visibility = Visibility.Collapsed;
-                }
-
                 if (open || !this.tagList.IsKeyboardFocusWithin)
                 {
                     this.tagList.Clear(open);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -399,7 +399,7 @@ namespace TogglDesktop
             }
         }
 
-        private void startDatePicker_SelectedDateChanged(object sender, SelectionChangedEventArgs e)
+        private void startDatePicker_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
             if (this.dateSet)
             {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -518,7 +518,7 @@ namespace TogglDesktop
             }
             else
             {
-                // TODO: reset project? add new? switch to 'add project mode'?   
+                // TODO: reset project? add new? switch to 'add project mode'?
             }
         }
 
@@ -526,7 +526,7 @@ namespace TogglDesktop
         {
             if(this.isInNewProjectMode)
                 return;
-            
+
             if (this.projectTextBox.Text == "")
             {
                 this.setProjectIfDifferent(0, 0, "", "");
@@ -772,7 +772,7 @@ namespace TogglDesktop
         private void newClientCancelButton_OnClick(object sender, RoutedEventArgs e)
         {
             this.disableNewClientMode();
-            
+
             this.clientTextBox.SetText(this.timeEntry.ClientLabel);
             if (!string.IsNullOrEmpty(this.timeEntry.ClientLabel))
             {
@@ -983,19 +983,6 @@ namespace TogglDesktop
             timer.RunningTimeEntrySecondPulse += this.durationUpdateTimerTick;
         }
 
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            switch (e.Key)
-            {
-                case Key.Escape:
-                {
-                    this.close();
-                    e.Handled = true;
-                    return;
-                }
-            }
-        }
-
         public void FocusField(string focusedFieldName)
         {
             UIElement focus = null;
@@ -1020,16 +1007,6 @@ namespace TogglDesktop
             {
                 focus.Focus();
             }
-        }
-
-        private void backButton_OnClick(object sender, RoutedEventArgs e)
-        {
-            this.close();
-        }
-
-        private void close()
-        {
-            Toggl.ViewTimeEntryList();
         }
 
         public void EnsureSaved()
@@ -1074,6 +1051,5 @@ namespace TogglDesktop
         }
 
         #endregion
-
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
@@ -1,54 +1,30 @@
-﻿<Window x:Class="TogglDesktop.EditViewPopup"
+﻿<mah:MetroWindow x:Class="TogglDesktop.EditViewPopup"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:toggl="clr-namespace:TogglDesktop"
+        xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d"
         d:DesignWidth="400" d:DesignHeight="520"
-        WindowStyle="None" ResizeMode="NoResize"
-        MouseMove="onWindowMouseMove"
-        Background="Transparent"
         ShowInTaskbar="False"
+        ResizeMode="CanResize"
+        BorderThickness="0"
+        ShowTitleBar="False"
+        SaveWindowPosition="False"
+        ShowCloseButton="False"
+        ShowMaxRestoreButton="False"
+        ShowMinButton="False"
+        ShowSystemMenuOnRightClick="False"
+        WindowStyle="None"
+        WindowTransitionsEnabled="False"
+        Background="Transparent"
+        ResizeBorderThickness="0 0 4 0"
         AllowsTransparency="True"
         UseLayoutRounding="True">
-    
-    <WindowChrome.WindowChrome>
-        <WindowChrome
-            CaptionHeight="0"
-            CornerRadius="0"
-            ResizeBorderThickness="0"
-            GlassFrameThickness="0"
-            UseAeroCaptionButtons="False"
-            />
-    </WindowChrome.WindowChrome>
 
     <Grid ClipToBounds="True" Name="mainGrid" x:FieldModifier="private">
         <toggl:EditView
-            x:Name="EditView"
-            />
-        <Rectangle
-            x:Name="resizeHandle" x:FieldModifier="private"
-            Fill="Transparent"
-            Width="10" HorizontalAlignment="Right"
-            Margin="0 32"
-            Cursor="SizeWE"
-            IsHitTestVisible="True"
-            MouseLeftButtonDown="onResizeHandleLeftButtonDown"
-            MouseLeftButtonUp="onResizeHandleLeftButtonUp"
-            />
-
-        <Rectangle Name="mainFormShadow" x:FieldModifier="private"
-                   HorizontalAlignment="Left" VerticalAlignment="Top"
-                   Width="5" Margin="-5 0 -5 0" Height="300" Fill="Gray">
-            <Rectangle.Effect>
-                <DropShadowEffect 
-                    BlurRadius="20"
-                    Direction="180"
-                    ShadowDepth="0"
-                    Opacity="0.8"
-                    />
-            </Rectangle.Effect>
-        </Rectangle>
+            x:Name="EditView" />
     </Grid>
-</Window>
+</mah:MetroWindow>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
@@ -27,9 +27,6 @@
     <i:Interaction.Behaviors>
         <behaviors:CloseWindowOnEscBehavior />
     </i:Interaction.Behaviors>
-    <Window.Resources>
-        <ResourceDictionary Source="../Resources/DesignUpdate/Buttons.xaml" />
-    </Window.Resources>
     <Grid ClipToBounds="True" Name="mainGrid" x:FieldModifier="private">
         <Rectangle Name="mainFormShadow" x:FieldModifier="private"
                    Margin="8 0" Fill="Black">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
@@ -23,7 +23,8 @@
         Background="Transparent"
         ResizeBorderThickness="0 0 4 0"
         AllowsTransparency="True"
-        UseLayoutRounding="True">
+        UseLayoutRounding="True"
+        SizeToContent="Height">
     <i:Interaction.Behaviors>
         <behaviors:CloseWindowOnEscBehavior />
     </i:Interaction.Behaviors>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
@@ -31,12 +31,18 @@
         <ResourceDictionary Source="../Resources/DesignUpdate/Buttons.xaml" />
     </Window.Resources>
     <Grid ClipToBounds="True" Name="mainGrid" x:FieldModifier="private">
+        <Rectangle Name="mainFormShadow" x:FieldModifier="private"
+                   Margin="8 0" Fill="Black">
+            <Rectangle.Effect>
+                <DropShadowEffect
+                    Color="Black"
+                    BlurRadius="8"
+                    Direction="270"
+                    ShadowDepth="2"
+                    Opacity="0.2" />
+            </Rectangle.Effect>
+        </Rectangle>
         <toggl:EditView
             x:Name="EditView" />
-        <Button Style="{StaticResource Toggl.CrossButton}"
-                HorizontalAlignment="right" VerticalAlignment="top" Margin="0"
-                Width="32" Height="32"
-                Focusable="False"
-                behaviors:ButtonHelper.IsCloseWindowButton="True"/>
     </Grid>
 </mah:MetroWindow>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
@@ -30,7 +30,7 @@
     </i:Interaction.Behaviors>
     <Grid ClipToBounds="True" Name="mainGrid" x:FieldModifier="private">
         <Rectangle Name="mainFormShadow" x:FieldModifier="private"
-                   Margin="8 0" Fill="Black">
+                   Margin="8" Fill="Black">
             <Rectangle.Effect>
                 <DropShadowEffect
                     Color="Black"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
@@ -5,6 +5,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:toggl="clr-namespace:TogglDesktop"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
         mc:Ignorable="d"
         d:DesignWidth="400" d:DesignHeight="520"
         ShowInTaskbar="False"
@@ -22,9 +24,19 @@
         ResizeBorderThickness="0 0 4 0"
         AllowsTransparency="True"
         UseLayoutRounding="True">
-
+    <i:Interaction.Behaviors>
+        <behaviors:CloseWindowOnEscBehavior />
+    </i:Interaction.Behaviors>
+    <Window.Resources>
+        <ResourceDictionary Source="../Resources/DesignUpdate/Buttons.xaml" />
+    </Window.Resources>
     <Grid ClipToBounds="True" Name="mainGrid" x:FieldModifier="private">
         <toggl:EditView
             x:Name="EditView" />
+        <Button Style="{StaticResource Toggl.CrossButton}"
+                HorizontalAlignment="right" VerticalAlignment="top" Margin="0"
+                Width="32" Height="32"
+                Focusable="False"
+                behaviors:ButtonHelper.IsCloseWindowButton="True"/>
     </Grid>
 </mah:MetroWindow>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -81,8 +81,8 @@ namespace TogglDesktop
 
         protected override void OnClosing(CancelEventArgs e)
         {
-            this.ClosePopup();
             e.Cancel = true;
+            Toggl.ViewTimeEntryList();
         }
 
         #region animate

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -183,34 +183,28 @@ namespace TogglDesktop
 
         #endregion
 
-        public void SetPlacement(bool left,
-            double x, double y, double height, double maxWidth, bool fixHeight = false)
+        public void SetPlacement(bool left, double x, double y, double maxWidth)
         {
             this.ResizeBorderThickness = left ? _leftResizeBorderThickness : _rightResizeBorderThickness;
             this.EditView.Margin = left ? _leftEditViewMargin : _rightEditViewMargin;
-
-            this.skipAnimation = fixHeight;
-
-            if (!fixHeight)
-                height = Math.Min(700, Math.Max(520, height));
-
+            this.skipAnimation = false;
+            this.EditView.Height = double.NaN;
             this.isLeft = !left;
-            this.Height = height;
-
-
-            if (left)
-            {
-                x -= this.Width;
-            }
-
-            x += left ? 8 : -8;
-
+            x += left ? (8 - this.Width) : -8;
             this.Left = x;
             this.Top = y;
+            this.MaxWidth = maxWidth;
+        }
 
-            this.MinHeight = height;
-            this.MaxHeight = height;
-
+        public void SetPlacementMaximized(double x, double y, double height, double maxWidth)
+        {
+            this.ResizeBorderThickness = new Thickness(0);
+            this.EditView.Margin = new Thickness(0);
+            this.skipAnimation = true;
+            this.EditView.Height = height;
+            this.isLeft = false;
+            this.Left = x - this.Width;
+            this.Top = y;
             this.MaxWidth = maxWidth;
         }
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -29,7 +29,7 @@ namespace TogglDesktop
         {
             this.InitializeComponent();
 
-            this.MinWidth = this.EditView.MinWidth;
+            this.MinWidth = this.EditView.MinWidth + 8;
             this.mainGrid.Width = 0;
 
             Toggl.OnTimeEntryEditor += this.onTimeEntryEditor;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -22,8 +22,6 @@ namespace TogglDesktop
 
         private readonly Thickness _leftResizeBorderThickness = new Thickness(4, 0, 0, 0);
         private readonly Thickness _rightResizeBorderThickness = new Thickness(0, 0, 4, 0);
-        private readonly Thickness _leftEditViewMargin = new Thickness(0, 0, 8, 0);
-        private readonly Thickness _rightEditViewMargin = new Thickness(8, 0, 0, 0);
 
         public EditViewPopup()
         {
@@ -186,7 +184,7 @@ namespace TogglDesktop
         public void SetPlacement(bool left, double x, double y, double maxWidth)
         {
             this.ResizeBorderThickness = left ? _leftResizeBorderThickness : _rightResizeBorderThickness;
-            this.EditView.Margin = left ? _leftEditViewMargin : _rightEditViewMargin;
+            this.EditView.Margin = new Thickness(8);
             this.skipAnimation = false;
             this.EditView.Height = double.NaN;
             this.isLeft = !left;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Windows;
-using System.Windows.Input;
-using System.Windows.Interop;
 using System.Windows.Media.Animation;
 using TogglDesktop.Diagnostics;
 
@@ -18,17 +16,16 @@ namespace TogglDesktop
 
         private AnimationStates animationState = AnimationStates.Closing;
 
-        private readonly WindowInteropHelper interopHelper;
-
         private bool isLeft;
-        private bool isResizing;
         private bool skipAnimation;
         private object animationToken;
+
+        private readonly Thickness _leftResizeBorderThickness = new Thickness(4, 0, 0, 0);
+        private readonly Thickness _rightResizeBorderThickness = new Thickness(0, 0, 4, 0);
 
         public EditViewPopup()
         {
             this.InitializeComponent();
-            this.interopHelper = new WindowInteropHelper(this);
 
             this.MinWidth = this.EditView.MinWidth;
             this.mainGrid.Width = 0;
@@ -82,33 +79,11 @@ namespace TogglDesktop
             }
         }
 
-        #region ui events
-
-        private void onResizeHandleLeftButtonDown(object sender, MouseButtonEventArgs e)
-        {
-            this.startResizing();
-        }
-
-        private void onResizeHandleLeftButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            this.endResizing();
-        }
-
-        private void onWindowMouseMove(object sender, MouseEventArgs e)
-        {
-            if (e.LeftButton == MouseButtonState.Released)
-            {
-                this.endResizing();
-            }
-        }
-
         protected override void OnClosing(CancelEventArgs e)
         {
             this.ClosePopup();
             e.Cancel = true;
         }
-
-        #endregion
 
         #region animate
 
@@ -206,14 +181,10 @@ namespace TogglDesktop
 
         #endregion
 
-        #region controlling
-
         public void SetPlacement(bool left,
             double x, double y, double height, double maxWidth, bool fixHeight = false)
         {
-            this.setShadow(left ^ fixHeight, height);
-
-            this.resizeHandle.HorizontalAlignment = left ? HorizontalAlignment.Left : HorizontalAlignment.Right;
+            this.ResizeBorderThickness = left ? _leftResizeBorderThickness : _rightResizeBorderThickness;
 
             this.skipAnimation = fixHeight;
 
@@ -237,47 +208,5 @@ namespace TogglDesktop
 
             this.MaxWidth = maxWidth;
         }
-
-        private void setShadow(bool left, double height)
-        {
-            this.mainFormShadow.Height = height;
-            this.mainFormShadow.HorizontalAlignment = left ? HorizontalAlignment.Right : HorizontalAlignment.Left;
-        }
-
-        private void startResizing()
-        {
-            if (this.isResizing)
-                return;
-
-            const int htleft = 10;
-            const int htright = 11;
-
-            Mouse.Capture(null);
-
-            this.ResizeMode = ResizeMode.CanResize;
-
-            Win32.SendMessage(this.interopHelper.Handle,
-                Win32.wmNcLButtonDown,
-                this.isLeft ? htright : htleft,
-                0);
-
-            this.resizeHandle.CaptureMouse();
-
-            this.isResizing = true;
-        }
-
-        private void endResizing()
-        {
-            if (!this.isResizing)
-                return;
-
-            Mouse.Capture(null);
-            this.ResizeMode = ResizeMode.NoResize;
-            this.isResizing = false;
-        }
-
-
-        #endregion
-
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -22,6 +22,8 @@ namespace TogglDesktop
 
         private readonly Thickness _leftResizeBorderThickness = new Thickness(4, 0, 0, 0);
         private readonly Thickness _rightResizeBorderThickness = new Thickness(0, 0, 4, 0);
+        private readonly Thickness _leftEditViewMargin = new Thickness(0, 0, 8, 0);
+        private readonly Thickness _rightEditViewMargin = new Thickness(8, 0, 0, 0);
 
         public EditViewPopup()
         {
@@ -185,6 +187,7 @@ namespace TogglDesktop
             double x, double y, double height, double maxWidth, bool fixHeight = false)
         {
             this.ResizeBorderThickness = left ? _leftResizeBorderThickness : _rightResizeBorderThickness;
+            this.EditView.Margin = left ? _leftEditViewMargin : _rightEditViewMargin;
 
             this.skipAnimation = fixHeight;
 
@@ -199,6 +202,8 @@ namespace TogglDesktop
             {
                 x -= this.Width;
             }
+
+            x += left ? 8 : -8;
 
             this.Left = x;
             this.Top = y;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace TogglDesktop
     {
         #region fields
 
-        private const int WindowHeaderHeight = 32;
+        private const int WindowHeaderHeight = 30;
         private readonly DispatcherTimer idleDetectionTimer =
             new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
 
@@ -899,8 +899,7 @@ namespace TogglDesktop
                 y += headerHeight;
                 x += this.ActualWidth;
 
-                this.editPopup.SetPlacement(true, x, y, this.ActualHeight - headerHeight,
-                    this.ActualWidth - 300, true);
+                this.editPopup.SetPlacementMaximized(x, y, this.ActualHeight - headerHeight, this.ActualWidth - 300);
             }
             else
             {
@@ -915,7 +914,7 @@ namespace TogglDesktop
                     x += this.ActualWidth;
                 }
 
-                this.editPopup.SetPlacement(left, x, y, this.Height, s.Width * 0.5);
+                this.editPopup.SetPlacement(left, x, y, s.Width * 0.5);
             }
 
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -317,10 +317,7 @@
                             <TextBox Name="reminderStartTimeTextBox" x:FieldModifier="private"
                                      Margin="0 0 8 0" Width="64"
                                      HorizontalContentAlignment="Right" />
-                            <Canvas Width="12" Height="7">
-                                <Path Fill="{DynamicResource Toggl.DisabledTextBrush}" Data="M7.812.16C7.363-.166 7 .023 7 .567v6.006c0 .55.36.735.812.407l3.876-2.82c.449-.326.451-.852 0-1.18L7.812.16z"/>
-                                <Path StrokeThickness="2" Stroke="{DynamicResource Toggl.DisabledTextBrush}" StrokeLineJoin="Round" StrokeStartLineCap="Round" StrokeEndLineCap="Round" Data="M8 3.57H1"/>
-                            </Canvas>
+                            <ContentControl Focusable="False" Content="{StaticResource Toggl.ArrowIcon}" />
                             <TextBox Name="reminderEndTimeTextBox" x:FieldModifier="private"
                                      Margin="7 0 0 0" Width="64"
                                      HorizontalContentAlignment="Right" />


### PR DESCRIPTION
### 📒 Description
Implementation of the new design of the Edit view. This PR contains the layout of the Edit view and the basic components. It does not contain bigger components like project/client/tag selection/creation.

⚠️ Do not merge this PR before #3771 is merged ⚠️ 

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Positioning of the Edit view components according to the new design
- [x] Light and Dark mode support according to the new design
- [x] Outer shadow around the Edit view instead of inner shadow from the main window
- [x] Edit view height is now based on the content and not based on the main window size
- [x] New date picker design (but without the calendar yet)
- [x] Moved base window to `MetroWindow` class instead of custom code with low-level hacks

### 👫 Relationships
Closes #3702

### 🔎 Review hints
- Briefly check the overall Edit view functionality.
- Check the Description, Duration, Start/End time Textboxes, Date picker, Delete button, Done button, Close button.
- Check that the overall layout and the beforementioned components correspond to the design in Zeplin.
- Do not focus on Project/Client/Tags/Color picker/Calendar as these things still have the old design and will be implemented separately.

⚠️ Do not merge this PR before #3771 is merged ⚠️ 

