### PR TITLE
Clear auth info before logging

### DIFF
--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -410,6 +410,9 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         // Request gzip unless downloading files
         poco_req.set("Accept-Encoding", "gzip");
 
+        // Remove Auth info
+        poco_req.set("Authorization", "");
+
         // Log out request contents
         std::stringstream request_string;
         poco_req.write(request_string);

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -411,7 +411,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         poco_req.set("Accept-Encoding", "gzip");
 
         // Remove Auth info
-        poco_req.set("Authorization", "");
+        poco_req.erase("Authorization");
 
         // Log out request contents
         std::stringstream request_string;


### PR DESCRIPTION
### 📒 Description
Removed the auth info from logs

### 🔎 Review hints
No auth info should be present in the logs.

