### PR TITLE
Correct Arrow position of the Activity Popover

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -212,6 +212,9 @@ extension TimelineDashboardViewController {
         datePickerView.setBackgroundForTimeline()
         emptyActivityLbl.frameCenterRotation = -90
         activityRecorderInfoImageView.delegate = self
+        
+        // Forect Render the view
+        _ = activityHoverController.view
     }
 
     fileprivate func initNotifications() {
@@ -393,10 +396,17 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
         timeEntryHoverController.render(with: timeEntry)
     }
 
-    func shouldPresentActivityHover(in view: NSView, activity: TimelineActivity) {
+    func shouldPresentActivityHover(in cell: TimelineBaseCell, activity: TimelineActivity) {
         guard !editorPopover.isShown else { return }
-        activityHoverPopover.show(relativeTo: view.bounds, of: view, preferredEdge: .maxX)
+
+        // Update new content and force render to get fit size
         activityHoverController.render(activity)
+        activityHoverController.view.setNeedsDisplay(activityHoverController.view.bounds)
+        activityHoverController.view.displayIfNeeded()
+
+        // Udate size and present
+        activityHoverPopover.contentSize = activityHoverController.view.frame.size
+        activityHoverPopover.show(relativeTo: cell.view.bounds, of: cell.view, preferredEdge: .maxX)
     }
 
     func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -73,7 +73,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                             </constraints>
                             <buttonCell key="cell" type="bevel" title="Permission required!" bezelStyle="regularSquare" image="NSCaution" imagePosition="left" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="Uj3-3t-CiG">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system" size="10"/>
+                                <font key="font" metaFont="menu" size="10"/>
                             </buttonCell>
                             <connections>
                                 <action selector="permissionBtnOnClicked:" target="-2" id="z5L-tH-fof"/>
@@ -135,7 +135,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                                             <rect key="frame" x="33" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSAddTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="as8-De-WrX">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="label" size="13"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelIncreaseOnChange:" target="-2" id="QsV-0i-5La"/>
@@ -145,7 +145,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                                             <rect key="frame" x="10" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="kr9-Ry-BUy">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="label" size="13"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelDecreaseOnChange:" target="-2" id="ksx-ak-4he"/>
@@ -227,7 +227,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                                 <constraint firstAttribute="width" constant="140" id="mdj-ct-y7d"/>
                             </constraints>
                             <textFieldCell key="cell" alignment="center" title="No entries here…  Go ahead and track some time!" id="rM7-R2-ABZ">
-                                <font key="font" metaFont="label" size="13"/>
+                                <font key="font" metaFont="system"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -235,7 +235,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                         <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3EE-on-mJF">
                             <rect key="frame" x="327" y="287" width="252" height="16"/>
                             <textFieldCell key="cell" alignment="center" title="Turn on activity recording to see results." id="PUb-OL-l5z">
-                                <font key="font" metaFont="label" size="13"/>
+                                <font key="font" metaFont="system"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -12,7 +12,7 @@ protocol TimelineDatasourceDelegate: class {
 
     func shouldPresentTimeEntryEditor(in view: NSView, timeEntry: TimeEntryViewItem, cell: TimelineTimeEntryCell)
     func shouldPresentTimeEntryHover(in view: NSView, timeEntry: TimelineTimeEntry)
-    func shouldPresentActivityHover(in view: NSView, activity: TimelineActivity)
+    func shouldPresentActivityHover(in view: TimelineBaseCell, activity: TimelineActivity)
     func startNewTimeEntry(at started: TimeInterval, ended: TimeInterval)
     func shouldUpdatePanelSize(with activityFrame: CGRect)
 }
@@ -295,7 +295,7 @@ extension TimelineDatasource: TimelineBaseCellDelegate {
             delegate?.shouldPresentTimeEntryHover(in: timeEntryCell.popoverView, timeEntry: timeEntry)
         case let activityCell as TimelineActivityCell:
             guard let activity = activityCell.activity else { return }
-            delegate?.shouldPresentActivityHover(in: sender.view, activity: activity)
+            delegate?.shouldPresentActivityHover(in: sender, activity: activity)
         default:
             break
         }


### PR DESCRIPTION
### 📒 Description
This PR introduces some fix to resolve the issue that the Arrow is mis-position when hovering in several Timeline Events.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Force update the Activity Popover to compute the proper size before showing.

### 👫 Relationships
Closes #3675

### 🔎 Review hints
1. Prepare some small chunk of events.
2. Hover to see the Activity Popover.
Verify that:
- The position of the popover is correct (Point to the middle of the Event Pill)

![2020-02-04 17 33 36](https://user-images.githubusercontent.com/5878421/73737381-19ee1300-4775-11ea-8ed3-9bcb9af691bf.gif)


