### PR TITLE
Track active view by OS

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -326,16 +326,16 @@ void GoogleAnalyticsSettingsEvent::makeReq() {
     }
 }
 
-void Analytics::TrackStartTimeEntry(const std::string &client_id, const uint8_t tab_index) {
-    TrackTimeEntryActivity(client_id, "start", tab_index);
+void Analytics::TrackStartTimeEntry(const std::string &client_id, const std::string& os, const uint8_t tab_index) {
+    TrackTimeEntryActivity(client_id, os, "start", tab_index);
 }
 
-void Analytics::TrackEditTimeEntry(const std::string &client_id, const uint8_t tab_index) {
-    TrackTimeEntryActivity(client_id, "edit", tab_index);
+void Analytics::TrackEditTimeEntry(const std::string &client_id, const std::string& os, const uint8_t tab_index) {
+    TrackTimeEntryActivity(client_id, os, "edit", tab_index);
 }
 
-void Analytics::TrackDeleteTimeEntry(const std::string &client_id, const uint8_t tab_index) {
-    TrackTimeEntryActivity(client_id, "delete", tab_index);
+void Analytics::TrackDeleteTimeEntry(const std::string &client_id, const std::string& os, const uint8_t tab_index) {
+    TrackTimeEntryActivity(client_id, os, "delete", tab_index);
 }
 
 void Analytics::TrackLoginWithUsernamePassword(const std::string &client_id) {
@@ -354,10 +354,13 @@ void Analytics::TrackSignupWithGoogle(const std::string &client_id) {
     TrackUserAuthentication(client_id, "signup", "google");
 }
 
-void Analytics::TrackTimeEntryActivity(const std::string &client_id, const std::string &action, const uint8_t tab_index) {
+void Analytics::TrackTimeEntryActivity(const std::string &client_id,
+                                       const std::string& os,
+                                       const std::string &action,
+                                       const uint8_t tab_index) {
     std::string active_view = tab_index == 0 ? "list-view" : "timeline-view";
     std::stringstream ss;
-    ss << active_view << "/" << action;
+    ss << os << "/" << active_view << "/" << action;
     Track(client_id, active_view, ss.str());
 }
 

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -67,10 +67,13 @@ class Analytics : public Poco::TaskManager {
                        const toggl::Rectangle rect);
 
     void TrackStartTimeEntry(const std::string &client_id,
+                             const std::string& os,
                              const uint8_t tab_index);
     void TrackEditTimeEntry(const std::string &client_id,
+                            const std::string& os,
                             const uint8_t tab_index);
     void TrackDeleteTimeEntry(const std::string &client_id,
+                              const std::string& os,
                               const uint8_t tab_index);
 
     void TrackLoginWithUsernamePassword(const std::string &client_id);
@@ -87,6 +90,7 @@ class Analytics : public Poco::TaskManager {
                    const toggl::Rectangle rect);
 
     void TrackTimeEntryActivity(const std::string &client_id,
+                                const std::string& os,
                                 const std::string &action,
                                 const uint8_t tab_index);
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -2807,7 +2807,7 @@ TimeEntry *Context::Start(
     if ("production" == environment_) {
         analytics_.TrackAutocompleteUsage(db_->AnalyticsClientID(),
                                           task_id || project_id);
-        analytics_.TrackStartTimeEntry(db_->AnalyticsClientID(), GetActiveTab());
+        analytics_.TrackStartTimeEntry(db_->AnalyticsClientID(), shortOSName(), GetActiveTab());
     }
 
     OpenTimeEntryList();
@@ -2878,7 +2878,7 @@ void Context::OpenTimeEntryEditor(
     }
 
     if ("production" == environment_) {
-        analytics_.TrackEditTimeEntry(db_->AnalyticsClientID(), GetActiveTab());
+        analytics_.TrackEditTimeEntry(db_->AnalyticsClientID(), shortOSName(), GetActiveTab());
     }
 
     updateUI(render);
@@ -3051,7 +3051,7 @@ error Context::DeleteTimeEntryByGUID(const std::string &GUID) {
     te->Delete();
 
     if ("production" == environment_) {
-        analytics_.TrackDeleteTimeEntry(db_->AnalyticsClientID(), GetActiveTab());
+        analytics_.TrackDeleteTimeEntry(db_->AnalyticsClientID(), shortOSName(), GetActiveTab());
     }
 
     return displayError(save(true));


### PR DESCRIPTION
### 📒 Description
Track active view by OS

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
A follow-up to #3741. Adds OS name to active view tracking.

### 👫 Relationships
Closes #3788 

### 🔎 Review hints
Do Start / Open Editor / Delete TimeEntry
in Production mode and make sure the analytic data is sent together with the OS name

