### PR TITLE
Change the Shortcut to switch to next/previous Timeline Day

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -231,11 +231,13 @@
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="KUm-TA-aKU"/>
                             <menuItem title="Next Day" tag="3" keyEquivalent="" toolTip="Change a current Timeliine day to next day" id="HEB-2o-715">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="nextDayMenuOnClick:" target="-1" id="uVN-Lv-UoP"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Previous Day" tag="3" keyEquivalent="" toolTip="Change a current Timeliine day to previous day" id="kdC-8f-3ea">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="previouosDayMenuOnClick:" target="-1" id="kIq-Tb-6ik"/>
                                 </connections>


### PR DESCRIPTION
### 📒 Description
This PR changes the switch day shortcut in order to prevent the conflict with the macOS shortcut in NSTextField (CMD + Left/Right to move the cursor to the begin or end of the word)

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### How does it fix?
Since all NSTextField has their own shortcut (CMD+Arrow or Option+Arrow), so it's better to change the Timeline Shortcut to different one.

### 🤯 List of changes
- [x] Change Day Timeline Shortcut to CMD+SHIFT+Arrow

### 👫 Relationships
Closes #3755

### 🔎 Review hints
1. Open Editor and focus on any TextField (Description, Project, ...)
2. Verify that CMD+Arrow to move the cursor to the start/end of the text
3. Verify that CMD+SHIFT+Arrow will switch the Timeline day.
4. Verify that both actions are not conflicted.

