### PR TITLE
ESC in Touch Bar

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -80,6 +80,8 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
         }
     }
 
+    var isAutoCompleteShowing: Bool { return state == .expand }
+    
     // MARK: Init
 
     override init(frame frameRect: NSRect) {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -108,7 +108,12 @@ final class EditorViewController: NSViewController {
         super.viewDidLoad()
 
         initCommon()
+        initNotifications()
         initDatasource()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidAppear() {
@@ -249,6 +254,10 @@ extension EditorViewController {
 
         // Tags
         tagAddButton.keyboardDelegate = self
+    }
+
+    private func initNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(self.escTouchBarBtnOnClickNoti), name: .escTouchBarButtonOnClick, object: nil)
     }
 
     fileprivate func initDatasource() {
@@ -467,6 +476,24 @@ extension EditorViewController {
             if shouldFocusByDefault {
                 view.window?.makeFirstResponder(descriptionTextField)
             }
+        }
+    }
+
+    @objc private func escTouchBarBtnOnClickNoti() {
+
+        // Close auto complete if need
+        let views: [AutoCompleteTextField] = [descriptionTextField, projectTextField, tagTextField]
+        var isClosed = false
+        views.forEach { view in
+            if view.isAutoCompleteShowing {
+                view.closeSuggestion()
+                isClosed = true
+            }
+        }
+
+        // Close Editor if there is no auto complection view is closed
+        if !isClosed {
+            closeBtnOnTap(self)
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService+Name.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService+Name.swift
@@ -18,6 +18,7 @@ extension NSTouchBar.CustomizationIdentifier {
 @available(OSX 10.12.2, *)
 extension NSTouchBarItem.Identifier {
 
+    static let escButtonItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.escButtonItem")
     static let timeEntryItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.timeentryitems")
     static let runningTimeEntry = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.runningtimeentry")
     static let startStopItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.startstopbutton")

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -254,7 +254,7 @@ extension TouchBarService {
     }
 
     @objc private func escButtonTouchBarOnClick(_ sender: Any) {
-
+        NotificationCenter.default.postNotificationOnMainThread(NSNotification.Name.escTouchBarButtonOnClick, object: nil)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -50,7 +50,7 @@ final class TouchBarService: NSObject {
         let touchBar = NSTouchBar()
         touchBar.delegate = self
         touchBar.customizationIdentifier = .mainTouchBar
-        touchBar.defaultItemIdentifiers = [.timeEntryItem, .startStopItem]
+        touchBar.defaultItemIdentifiers = touchBarItems
         return touchBar
     }()
 
@@ -72,6 +72,13 @@ final class TouchBarService: NSObject {
         view.scrubberLayout = layout
         return view
     }()
+
+    private var touchBarItems: [NSTouchBarItem.Identifier] {
+        #if APP_STORE
+            return [.timeEntryItem, .startStopItem]
+        #endif
+        return [.escButtonItem, .timeEntryItem, .startStopItem]
+    }
 
     // MARK: Init
 
@@ -213,6 +220,10 @@ extension TouchBarService: NSTouchBarDelegate {
 
     func touchBar(_ touchBar: NSTouchBar, makeItemForIdentifier identifier: NSTouchBarItem.Identifier) -> NSTouchBarItem? {
         switch identifier {
+        case NSTouchBarItem.Identifier.escButtonItem:
+            let item = NSCustomTouchBarItem(identifier: identifier)
+            item.view = NSButton(title: "esc", target: self, action: #selector(self.escButtonTouchBarOnClick(_:)))
+            return item
         case NSTouchBarItem.Identifier.timeEntryItem:
             let item = NSCustomTouchBarItem(identifier: identifier)
             item.view = scrubberView
@@ -240,6 +251,10 @@ extension TouchBarService {
 
     @objc fileprivate func startBtnOnTap(_ sender: NSButton) {
         delegate?.touchBarServiceStartTimeEntryOnTap()
+    }
+
+    @objc private func escButtonTouchBarOnClick(_ sender: Any) {
+
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -254,7 +254,7 @@ extension TouchBarService {
     }
 
     @objc private func escButtonTouchBarOnClick(_ sender: Any) {
-        NotificationCenter.default.postNotificationOnMainThread(NSNotification.Name.escTouchBarButtonOnClick, object: nil)
+        NotificationCenter.default.postNotificationOnMainThread(.escTouchBarButtonOnClick, object: nil)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -67,3 +67,4 @@ const char *kFocusedFieldNameProject;
 const char *kFocusedFieldNameTag;
 
 extern NSString *const kStartButtonStateChange;
+extern NSString *const kEscTouchBarButtonOnClickNotification;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -65,3 +65,5 @@ const char *kFocusedFieldNameProject = "project";
 const char *kFocusedFieldNameTag = "tag";
 
 NSString *const kStartButtonStateChange = @"kStartButtonStateChange";
+
+NSString *const kEscTouchBarButtonOnClickNotification = @"kEscTouchBarButtonOnClickNotification";

--- a/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
+++ b/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
@@ -49,8 +49,14 @@ static NSString *const upArrow = @"\u25B2";
         {
             self.automaticTextCompletionEnabled = NO;
         }
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(escTouchBarButtonOnClickNoti:) name:kEscTouchBarButtonOnClickNotification object:nil];
 	}
 	return self;
+}
+
+-(void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)initBackgroundView
@@ -322,4 +328,8 @@ static NSString *const upArrow = @"\u25B2";
 	[self updateDropdownWithHeight:totalHeight];
 }
 
+- (void) escTouchBarButtonOnClickNoti:(NSNotification *) noti
+{
+    [self resetTable];
+}
 @end


### PR DESCRIPTION
### 📒 Description
It's a better solution for the missing ESC button in the Touch Bar by introducing a fake one.

The first attempt is #3718, is applied in various OSS Touch Bar, but it requires Accessibility Permission in order to send the ESC keystroke.

### How it's better
- Don't require Accessibility permission
- Ease to implementation and the basic feature is remained.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Add Fake ESC button in Touch bar (Except AppStore build)
- [x] Add logic to mimic the behavior of the ESC button: Close AutoCompleteView, Editor, ...

### 👫 Relationships
Closes #3684

### 🔎 Review hints
#### ESC touch bar button is working
1. Run on the TogglDesktop scheme
2. Type some word in Timer AutoComplete
3. Make sure the AutoComplete is presented 
4. Verify that Hit ESC on Touch Bar will close the AutoCompleteView
5. Open the Editor
6. Verify that ESC will close the Editor
7. Open the Editor and open AutoCompleteView in Description, Project, Tag, ...
8. Verify that ESC will close the AutoCompleteView, but not close the Editor

### AppStore version is still working
1. Run on TogglDesktop-AppStore scheme
2. Verify that there is no fake ESC on the Touch Bar and the real ESC is existed
3. Playaround and make sure there is nothing changes

