### PR TITLE
Improve TogglDesktop Networking

### DIFF
--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -310,7 +310,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         Poco::Net::HTTPSClientSession session(uri.getHost(), uri.getPort(),
                                               context);
 
-        session.setKeepAlive(false);
+        session.setKeepAlive(true);
         session.setTimeout(
             Poco::Timespan(req.timeout_seconds * Poco::Timespan::SECONDS));
 
@@ -329,7 +329,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         Poco::Net::HTTPRequest poco_req(req.method,
                                         encoded_url,
                                         Poco::Net::HTTPMessage::HTTP_1_1);
-        poco_req.setKeepAlive(false);
+        poco_req.setKeepAlive(true);
 
         // FIXME: should get content type as parameter instead
         if (req.payload.size()) {

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -344,6 +344,9 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
             cred.authenticate(poco_req);
         }
 
+        // Request gzip unless downloading files
+        poco_req.set("Accept-Encoding", "gzip");
+
         if (!req.form) {
             std::istringstream requestStream(req.payload);
 
@@ -368,9 +371,6 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
             std::ostream& send = session.sendRequest(poco_req);
             req.form->write(send);
         }
-
-        // Request gzip unless downloading files
-        poco_req.set("Accept-Encoding", "gzip");
 
         // Remove Auth info
         poco_req.erase("Authorization");


### PR DESCRIPTION
### 📒 Description
This PR improve some part of the Library Networking, such as:
- Content-Encoding and Connection Alive

### 🕶️ Types of changes
 **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Add Accept-Encoding: gzip to all requests
- [x] Keep the connection alive

### 👫 Relationships
Closes #3780

### 🔎 Review hints
#### Verify that the Responses are compressed under GZIP
1. Open Proxyman or Charles
2. Run TogglDesktop via Xcode
3. Play around and verify that:
- All out-going requests have `Accept-Encoding: gzip`
- Some responses are compressed (see screenshot)
<img width="2032" alt="Screen_Shot_2020-02-11_at_16_02_22" src="https://user-images.githubusercontent.com/5878421/74225130-af951f80-4cec-11ea-98b6-a38ed76b6ae8.png">
4. All logic are working well

#### No failed requests
1. Open log `/Users/<user_name>/Library/Application Support/Kopsik/development/toggl_desktop.log`
2. Play around the app
3. Verify that there all response status code is 200.

#### Able to update build
1. Set build number as 7.5.10 for TogglProduction scheme
2. Archive the build via TogglProduction scheme (don't need do a notarization)
3. Open and check whether or not the app is able to download and update to the latest stable build.

