### PR TITLE
Current Moment Timeline

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -30,6 +30,11 @@ final class TimelineData {
     let start: TimeInterval
     let end: TimeInterval
     private(set) var zoomLevel: TimelineDatasource.ZoomLevel
+    var isToday: Bool {
+        // Get the middle of the day
+        let middle = start + (end - start) / 2
+        return Calendar.current.isDateInToday(Date(timeIntervalSince1970: middle))
+    }
 
     // MARK: Init
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -73,7 +73,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                             </constraints>
                             <buttonCell key="cell" type="bevel" title="Permission required!" bezelStyle="regularSquare" image="NSCaution" imagePosition="left" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="Uj3-3t-CiG">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="menu" size="10"/>
+                                <font key="font" metaFont="system" size="10"/>
                             </buttonCell>
                             <connections>
                                 <action selector="permissionBtnOnClicked:" target="-2" id="z5L-tH-fof"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -123,11 +123,6 @@ final class TimelineDatasource: NSObject {
     func scrollToVisibleItem() {
         guard let timeline = timeline, !isUserOnAction else { return }
 
-        // Skip if both are empty
-        if timeline.timeEntries.isEmpty && timeline.activities.isEmpty {
-            return
-        }
-
         // Get the section should be presented
         // Force render with correct frame then scrolling to desire item
         collectionView.setNeedsDisplay(collectionView.frame)
@@ -136,11 +131,16 @@ final class TimelineDatasource: NSObject {
         // Scroll to current time if it's today
         if let currentMomentAttribute = flow.currentMomentAttribute,
             timeline.isToday {
-            // Middle position
-            var currentTimeFrame = currentMomentAttribute.frame
-            currentTimeFrame.origin.y += collectionView.bounds.size.height / 3 * 2
-            collectionView.scrollToVisible(currentTimeFrame)
+            var visiblePoint = currentMomentAttribute.frame.origin
+            visiblePoint.y -= 100 // Off to better visibility
+            collectionView.scroll(visiblePoint)
         } else {
+
+            // Skip if both are empty
+            if timeline.timeEntries.isEmpty && timeline.activities.isEmpty {
+                return
+            }
+
             // Scroll to top Entry or events
             var visibleSection: TimelineData.Section?
             if !timeline.timeEntries.isEmpty {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -129,18 +129,26 @@ final class TimelineDatasource: NSObject {
         }
 
         // Get the section should be presented
-        var section: TimelineData.Section?
-        if !timeline.timeEntries.isEmpty {
-            section = .timeEntry
-        } else if !timeline.activities.isEmpty {
-            section = .activity
-        }
+        // Force render with correct frame then scrolling to desire item
+        collectionView.setNeedsDisplay(collectionView.frame)
+        collectionView.displayIfNeeded()
 
-        // Scroll to visible item
-        if let section = section {
-            // Force render with correct frame then scrolling to desire item
-            collectionView.setNeedsDisplay(collectionView.frame)
-            collectionView.displayIfNeeded()
+        // Scroll to current time if it's today
+        if let currentMomentAttribute = flow.currentMomentAttribute,
+            timeline.isToday {
+            // Middle position
+            var currentTimeFrame = currentMomentAttribute.frame
+            currentTimeFrame.origin.y += collectionView.bounds.size.height / 3 * 2
+            collectionView.scrollToVisible(currentTimeFrame)
+        } else {
+            // Scroll to top Entry or events
+            var visibleSection: TimelineData.Section?
+            if !timeline.timeEntries.isEmpty {
+                visibleSection = .timeEntry
+            } else if !timeline.activities.isEmpty {
+                visibleSection = .activity
+            }
+            guard let section = visibleSection else { return }
             collectionView.scrollToItems(at: Set<IndexPath>(arrayLiteral: IndexPath(item: 0, section: section.rawValue)),
                                          scrollPosition: [.centeredHorizontally, .centeredVertically])
         }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -132,7 +132,7 @@ final class TimelineDatasource: NSObject {
         if let currentMomentAttribute = flow.currentMomentAttribute,
             timeline.isToday {
             var visiblePoint = currentMomentAttribute.frame.origin
-            visiblePoint.y -= 100 // Off to better visibility
+            visiblePoint.y -= (collectionView.enclosingScrollView?.bounds.height ?? 0) / 2 // Middle of the screen
             collectionView.scroll(visiblePoint)
         } else {
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
@@ -21,7 +21,9 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
 
     struct Constants {
         static let MinimumHeight: CGFloat = 2.0
-        static let CurrentTimeMomentID = "CurrentTimeMomentID"
+        static let TimelineLineView = "TimelineLineView"
+        static let TimelineLineViewX: CGFloat = 44
+        static let TimelineLineViewHeight: CGFloat = 8
 
         struct TimeLabel {
             static let Size = CGSize(width: 54.0, height: 32)
@@ -94,7 +96,7 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
         minimumInteritemSpacing = 0
         sectionInset = NSEdgeInsetsZero
         scrollDirection = .vertical
-        register(TimelineLineView.self, forDecorationViewOfKind: Constants.CurrentTimeMomentID)
+        register(NSNib(nibNamed: Constants.TimelineLineView, bundle: nil), forDecorationViewOfKind: Constants.TimelineLineView)
     }
 
     override func prepare() {
@@ -163,7 +165,7 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
     }
 
     override func layoutAttributesForDecorationView(ofKind elementKind: NSCollectionView.DecorationElementKind, at indexPath: IndexPath) -> NSCollectionViewLayoutAttributes? {
-        if elementKind == Constants.CurrentTimeMomentID {
+        if elementKind == Constants.TimelineLineView {
             return currentMomentAttribute
         }
         return nil
@@ -295,9 +297,9 @@ extension TimelineFlowLayout {
     }
 
     private func calculateCurrentMomentAttribute() {
-        let att = NSCollectionViewLayoutAttributes(forDecorationViewOfKind: Constants.CurrentTimeMomentID, with: IndexPath(item: 0, section: 0))
-        let y = convertToYPosition(from: Date().timeIntervalSince1970)
-        att.frame = CGRect(x: 0, y: y, width: collectionView?.frame.width ?? 0, height: 1)
+        let att = NSCollectionViewLayoutAttributes(forDecorationViewOfKind: Constants.TimelineLineView, with: IndexPath(item: 0, section: 0))
+        let y = convertToYPosition(from: Date().timeIntervalSince1970) - Constants.TimelineLineViewHeight / 2.0
+        att.frame = CGRect(x: Constants.TimelineLineViewX, y: y, width: collectionView?.frame.width ?? 0, height: Constants.TimelineLineViewHeight)
         att.zIndex = 1
         self.currentMomentAttribute = att
     }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
@@ -24,7 +24,7 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
         static let TimelineLineView = "TimelineLineView"
         static let TimelineLineViewX: CGFloat = 44
         static let TimelineLineViewHeight: CGFloat = 8
-        static let TimelineLineInterval: TimeInterval = 10 // 1 min
+        static let TimelineLineInterval: TimeInterval = 60 // 1 min
 
         struct TimeLabel {
             static let Size = CGSize(width: 54.0, height: 32)

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
@@ -55,7 +55,7 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
     private var activityAttributes: [NSCollectionViewLayoutAttributes] = []
     private var dividerAttributes: [NSCollectionViewLayoutAttributes] = []
     private var backgroundAttributes: [NSCollectionViewLayoutAttributes] = []
-    private var currentMomentAttribute: NSCollectionViewLayoutAttributes?
+    private(set) var currentMomentAttribute: NSCollectionViewLayoutAttributes?
     private var verticalPaddingTimeLabel: CGFloat {
         switch zoomLevel {
         case .x1:

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
@@ -92,7 +92,7 @@ class TimelineBaseCell: NSCollectionViewItem {
     // MARK: Public
 
     func renderColor(with foregroundColor: NSColor, isSmallEntry: Bool) {
-        backgroundColor = foregroundColor.lighten(by: 0.1)
+        backgroundColor = foregroundColor.lighten(by: 0.2)
 
         foregroundBox.fillColor = foregroundColor
         backgroundBox?.fillColor = backgroundColor ?? foregroundColor

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.swift
@@ -1,0 +1,43 @@
+//
+//  TimelineLineView.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 2/12/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Foundation
+
+final class TimelineLineView: NSView {
+
+    override var isFlipped: Bool {
+        return true
+    }
+
+    private lazy var color: NSColor = {
+        if #available(OSX 10.13, *) {
+            return NSColor(named: NSColor.Name("timeline-divider-color"))!
+        } else {
+            return ConvertHexColor.hexCode(toNSColor: "#e8e8e8")
+        }
+    }()
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        // Drawing code here.
+        let path = NSBezierPath()
+        path.move(to: NSPoint(x: NSMinX(bounds), y: NSMinY(bounds)))
+        path.line(to: NSPoint(x: NSMaxX(bounds), y: NSMaxY(bounds)))
+        path.lineWidth = 1
+
+        // Dashed line
+        let dashes: [CGFloat] = [4.0, 8.0]
+        path.setLineDash(dashes, count: dashes.count, phase: 0.0)
+        path.lineCapStyle = .butt
+
+        // Draw
+        color.setStroke()
+        path.stroke()
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.swift
@@ -8,36 +8,4 @@
 
 import Foundation
 
-final class TimelineLineView: NSView {
-
-    override var isFlipped: Bool {
-        return true
-    }
-
-    private lazy var color: NSColor = {
-        if #available(OSX 10.13, *) {
-            return NSColor(named: NSColor.Name("timeline-divider-color"))!
-        } else {
-            return ConvertHexColor.hexCode(toNSColor: "#e8e8e8")
-        }
-    }()
-
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-
-        // Drawing code here.
-        let path = NSBezierPath()
-        path.move(to: NSPoint(x: NSMinX(bounds), y: NSMinY(bounds)))
-        path.line(to: NSPoint(x: NSMaxX(bounds), y: NSMaxY(bounds)))
-        path.lineWidth = 1
-
-        // Dashed line
-        let dashes: [CGFloat] = [4.0, 8.0]
-        path.setLineDash(dashes, count: dashes.count, phase: 0.0)
-        path.lineCapStyle = .butt
-
-        // Draw
-        color.setStroke()
-        path.stroke()
-    }
-}
+final class TimelineLineView: NSView {}

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.xib
@@ -24,7 +24,7 @@
                         <constraint firstAttribute="width" constant="8" id="5Td-Jt-CqG"/>
                         <constraint firstAttribute="height" constant="8" id="A0C-nh-G2c"/>
                     </constraints>
-                    <color key="fillColor" name="login-button-background"/>
+                    <color key="fillColor" name="timeline-label-color"/>
                 </box>
                 <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-fr-ulf">
                     <rect key="frame" x="0.0" y="4" width="195" height="1"/>
@@ -35,7 +35,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="tJU-S3-7WP"/>
                     </constraints>
-                    <color key="fillColor" name="login-button-background"/>
+                    <color key="fillColor" name="timeline-label-color"/>
                 </box>
             </subviews>
             <constraints>
@@ -49,8 +49,8 @@
         </customView>
     </objects>
     <resources>
-        <namedColor name="login-button-background">
-            <color red="1" green="0.17599999904632568" blue="0.33300000429153442" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="timeline-label-color">
+            <color red="0.67450980392156867" green="0.67450980392156867" blue="0.67450980392156867" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.xib
@@ -10,7 +10,7 @@
         <customObject id="-2" userLabel="File's Owner"/>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView id="c22-O7-iKe" customClass="TimelineLineView" customModule="TogglDesktop" customModuleProvider="target">
+        <customView identifier="TimelineLineView" id="c22-O7-iKe" customClass="TimelineLineView" customModule="TogglDesktop" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="195" height="8"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineLineView.xib
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="c22-O7-iKe" customClass="TimelineLineView" customModule="TogglDesktop" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="195" height="8"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <box boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="aTh-qO-ouO">
+                    <rect key="frame" x="0.0" y="0.0" width="8" height="8"/>
+                    <view key="contentView" id="dWC-nd-UXg">
+                        <rect key="frame" x="0.0" y="0.0" width="8" height="8"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </view>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="8" id="5Td-Jt-CqG"/>
+                        <constraint firstAttribute="height" constant="8" id="A0C-nh-G2c"/>
+                    </constraints>
+                    <color key="fillColor" name="login-button-background"/>
+                </box>
+                <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-fr-ulf">
+                    <rect key="frame" x="0.0" y="4" width="195" height="1"/>
+                    <view key="contentView" id="7Wo-IN-6qH">
+                        <rect key="frame" x="0.0" y="0.0" width="195" height="1"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </view>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="tJU-S3-7WP"/>
+                    </constraints>
+                    <color key="fillColor" name="login-button-background"/>
+                </box>
+            </subviews>
+            <constraints>
+                <constraint firstItem="aTh-qO-ouO" firstAttribute="centerY" secondItem="c22-O7-iKe" secondAttribute="centerY" id="B6n-ks-iBc"/>
+                <constraint firstAttribute="trailing" secondItem="hVc-fr-ulf" secondAttribute="trailing" id="Cua-9J-FBq"/>
+                <constraint firstItem="hVc-fr-ulf" firstAttribute="centerY" secondItem="c22-O7-iKe" secondAttribute="centerY" id="GEF-m8-vbP"/>
+                <constraint firstItem="aTh-qO-ouO" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="qGR-KL-hrw"/>
+                <constraint firstItem="hVc-fr-ulf" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="tp3-Ia-dL6"/>
+            </constraints>
+            <point key="canvasLocation" x="-250.5" y="89"/>
+        </customView>
+    </objects>
+    <resources>
+        <namedColor name="login-button-background">
+            <color red="1" green="0.17599999904632568" blue="0.33300000429153442" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -3,6 +3,7 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,6 +14,14 @@
             <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
+                <box boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="10" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="PFT-Hu-lDX">
+                    <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
+                    <view key="contentView" id="x0z-XV-qtc">
+                        <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </view>
+                    <color key="fillColor" name="timeline-background-color"/>
+                </box>
                 <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="line" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xE9-Ie-UP3">
                     <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
                     <view key="contentView" id="r80-dl-MpV">
@@ -158,8 +167,12 @@
                 <constraint firstAttribute="bottom" secondItem="ILd-N3-zAP" secondAttribute="bottom" priority="750" id="1Mm-Za-otm"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="1VM-YB-XHD"/>
                 <constraint firstAttribute="trailing" secondItem="xE9-Ie-UP3" secondAttribute="trailing" priority="750" id="44W-4X-N3n"/>
+                <constraint firstItem="PFT-Hu-lDX" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="HyU-Wh-UDu"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="Jj8-O9-hu6"/>
+                <constraint firstItem="PFT-Hu-lDX" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="VaI-2H-p9e"/>
+                <constraint firstAttribute="bottom" secondItem="PFT-Hu-lDX" secondAttribute="bottom" id="fW7-Nd-VKX"/>
                 <constraint firstItem="ILd-N3-zAP" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="ibj-8F-oO2"/>
+                <constraint firstAttribute="trailing" secondItem="PFT-Hu-lDX" secondAttribute="trailing" id="kah-E4-eV6"/>
                 <constraint firstAttribute="bottom" secondItem="xE9-Ie-UP3" secondAttribute="bottom" priority="750" id="pyj-Y7-31G"/>
                 <constraint firstItem="ILd-N3-zAP" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="zP1-Vu-Sgm"/>
             </constraints>
@@ -187,5 +200,8 @@
         <image name="time-entry-billable" width="17" height="17"/>
         <image name="time-entry-dot" width="8" height="8"/>
         <image name="time-entry-tag" width="17" height="17"/>
+        <namedColor name="timeline-background-color">
+            <color red="0.98039215686274506" green="0.98431372549019602" blue="0.9882352941176471" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		BA412C29224E196D003CA17A /* NoClientCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA412C28224E196D003CA17A /* NoClientCellView.xib */; };
 		BA43B24E23F438AA0007DD99 /* TimelineLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */; };
 		BA43B24F23F438AA0007DD99 /* TimelineLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */; };
+		BA43B25423F525F30007DD99 /* TimelineLineView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA43B25323F525F30007DD99 /* TimelineLineView.xib */; };
+		BA43B25523F525F30007DD99 /* TimelineLineView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA43B25323F525F30007DD99 /* TimelineLineView.xib */; };
 		BA4791F122F0478A00E24F79 /* NSView+Xib.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791E822F0478900E24F79 /* NSView+Xib.swift */; };
 		BA4791F222F0478A00E24F79 /* NSView+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791E922F0478900E24F79 /* NSView+Animation.swift */; };
 		BA4791F322F0478A00E24F79 /* String+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791EA22F0478900E24F79 /* String+Search.swift */; };
@@ -928,6 +930,7 @@
 		BA412C26224E195C003CA17A /* NoClientCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoClientCellView.swift; sourceTree = "<group>"; };
 		BA412C28224E196D003CA17A /* NoClientCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoClientCellView.xib; sourceTree = "<group>"; };
 		BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLineView.swift; sourceTree = "<group>"; };
+		BA43B25323F525F30007DD99 /* TimelineLineView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TimelineLineView.xib; sourceTree = "<group>"; };
 		BA4791E822F0478900E24F79 /* NSView+Xib.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Xib.swift"; sourceTree = "<group>"; };
 		BA4791E922F0478900E24F79 /* NSView+Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Animation.swift"; sourceTree = "<group>"; };
 		BA4791EA22F0478900E24F79 /* String+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Search.swift"; sourceTree = "<group>"; };
@@ -1724,6 +1727,7 @@
 				BA75FF2A22BCC20D00D3F08C /* TimelineActivityCell.xib */,
 				BAD0E0BC22C49BAC009F5A83 /* TimelineDividerView.swift */,
 				BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */,
+				BA43B25323F525F30007DD99 /* TimelineLineView.xib */,
 				BAA0F5A223A38CB300F04654 /* TimelineBackgroundCell.swift */,
 				BAB5FFD623F15A65003781D3 /* TimelineBackgroundCell.xib */,
 				BAA0105122CB72E4007C1541 /* TimelineDashedCornerView.swift */,
@@ -2071,6 +2075,7 @@
 				BAB0029F2273125C005ECC93 /* DayLabel.xib in Resources */,
 				BA9C2DFE224C823C002AD2A1 /* ColorPickerView.xib in Resources */,
 				747B74881A0AD28200BB3791 /* ConsoleViewController.xib in Resources */,
+				BA43B25423F525F30007DD99 /* TimelineLineView.xib in Resources */,
 				743E584D1A775BB300F17CB0 /* Localizable.strings in Resources */,
 				BAE007DE21FAF00D00404379 /* Media.xcassets in Resources */,
 				C5DA1FC517F1B38B001C4565 /* LoginViewController.xib in Resources */,
@@ -2121,6 +2126,7 @@
 				BAE64E052368334000244D2B /* SystemMessageView.xib in Resources */,
 				BAE64E062368334000244D2B /* TimeEntryEmptyView.xib in Resources */,
 				BA37ACD723D8900C0013EE26 /* TimelineEmptyTimeEntryCell.xib in Resources */,
+				BA43B25523F525F30007DD99 /* TimelineLineView.xib in Resources */,
 				BAE64E072368334000244D2B /* DateCellViewItem.xib in Resources */,
 				BAE64E082368334000244D2B /* ColorViewItem.xib in Resources */,
 				BAE64E092368334000244D2B /* OverlayViewController.xib in Resources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -217,6 +217,8 @@
 		BA412C25224E147A003CA17A /* ClientAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA412C24224E147A003CA17A /* ClientAutoCompleteTextField.swift */; };
 		BA412C27224E195C003CA17A /* NoClientCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA412C26224E195C003CA17A /* NoClientCellView.swift */; };
 		BA412C29224E196D003CA17A /* NoClientCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA412C28224E196D003CA17A /* NoClientCellView.xib */; };
+		BA43B24E23F438AA0007DD99 /* TimelineLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */; };
+		BA43B24F23F438AA0007DD99 /* TimelineLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */; };
 		BA4791F122F0478A00E24F79 /* NSView+Xib.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791E822F0478900E24F79 /* NSView+Xib.swift */; };
 		BA4791F222F0478A00E24F79 /* NSView+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791E922F0478900E24F79 /* NSView+Animation.swift */; };
 		BA4791F322F0478A00E24F79 /* String+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791EA22F0478900E24F79 /* String+Search.swift */; };
@@ -925,6 +927,7 @@
 		BA412C24224E147A003CA17A /* ClientAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientAutoCompleteTextField.swift; sourceTree = "<group>"; };
 		BA412C26224E195C003CA17A /* NoClientCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoClientCellView.swift; sourceTree = "<group>"; };
 		BA412C28224E196D003CA17A /* NoClientCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoClientCellView.xib; sourceTree = "<group>"; };
+		BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLineView.swift; sourceTree = "<group>"; };
 		BA4791E822F0478900E24F79 /* NSView+Xib.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Xib.swift"; sourceTree = "<group>"; };
 		BA4791E922F0478900E24F79 /* NSView+Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Animation.swift"; sourceTree = "<group>"; };
 		BA4791EA22F0478900E24F79 /* String+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Search.swift"; sourceTree = "<group>"; };
@@ -1720,6 +1723,7 @@
 				BA75FF2922BCC20D00D3F08C /* TimelineActivityCell.swift */,
 				BA75FF2A22BCC20D00D3F08C /* TimelineActivityCell.xib */,
 				BAD0E0BC22C49BAC009F5A83 /* TimelineDividerView.swift */,
+				BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */,
 				BAA0F5A223A38CB300F04654 /* TimelineBackgroundCell.swift */,
 				BAB5FFD623F15A65003781D3 /* TimelineBackgroundCell.xib */,
 				BAA0105122CB72E4007C1541 /* TimelineDashedCornerView.swift */,
@@ -2584,6 +2588,7 @@
 				BA014050225710FD000E5B91 /* TagAutoCompleteTextField.swift in Sources */,
 				BA5E988923BF496E0089A2C7 /* HoverImageView.swift in Sources */,
 				BAE8E845224CA9AC006D534E /* ProjectAutoCompleteTextField.swift in Sources */,
+				BA43B24E23F438AA0007DD99 /* TimelineLineView.swift in Sources */,
 				BA6572A7224DFA6F00BA4C60 /* HSBGen.swift in Sources */,
 				BA5B0E4E2330E1C6008D1DED /* GoogleAuthenticationServer.swift in Sources */,
 				BA8B4C752251FAD500592BC7 /* WorkspaceCellView.swift in Sources */,
@@ -2658,6 +2663,7 @@
 				BAE64D742368334000244D2B /* ClientCellView.swift in Sources */,
 				BAE64D752368334000244D2B /* AutocompleteDataSource.m in Sources */,
 				BAE64D762368334000244D2B /* BezierPath+Corner.swift in Sources */,
+				BA43B24F23F438AA0007DD99 /* TimelineLineView.swift in Sources */,
 				BA47DEB923969EAC005216AD /* InAppMessage.swift in Sources */,
 				BAE64D772368334000244D2B /* ProjectContentCellView.swift in Sources */,
 				BAE64D782368334000244D2B /* NSHoverButton.m in Sources */,


### PR DESCRIPTION
### 📒 Description
This PR introduces a new design to present the current time in Timeline View

⚠️ please don't merge this PR until https://github.com/toggl-open-source/toggldesktop/pull/3796 is merged.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add Timeline Line as a decoration view
- [x] Add Timer (1 min) to invalidate the Current Line Attribute and re-draw (don't need to re-draw entire layouts)
- [x] Add the background to prevent the transparent color in Timeline Background
- [x] Auto scroll to Current Time if it's today.

### 👫 Relationships
Closes #3805

### 🔎 Review hints
1. Start the app. Verify that:
- Scroll to Current Moment Line since it's a today
2. Try to Switch to next and previous days: Verify:
- If it's a today, it should scroll to Current Line
- If it's not today, it will scroll to the Top of Entry or events
3. Try dragging or resizing, verify:
- If the Line is below the Timeline Entry
4. Wait a bit, verify:
- After 1 mins, the Current Line is update with new position.

### Screenshots
<img width="502" alt="Screen Shot 2020-02-13 at 15 50 36" src="https://user-images.githubusercontent.com/5878421/74419044-e77e9d00-4e7b-11ea-99d6-905e96cc9e56.png">

<img width="502" alt="Screen Shot 2020-02-13 at 15 50 31" src="https://user-images.githubusercontent.com/5878421/74419028-e0f02580-4e7b-11ea-98f9-a2fcb5897a37.png">


