### PR TITLE
Running Time entry on Timeline

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -649,9 +649,7 @@ void Context::updateUI(const UIElements &what) {
                         running_entry->DurationInSeconds(),
                         Format::Classic);
                 running_entry_view.DateDuration =
-                    Formatter::FormatDurationForDateHeader(
-                        user_->related.TotalDurationForDate(
-                            running_entry));
+                    Formatter::FormatDurationForDateHeader(Formatter::AbsDuration(running_entry->Duration()));
                 user_->related.ProjectLabelAndColorCode(
                     running_entry,
                     &running_entry_view);

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/BezierPath+Corner.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/BezierPath+Corner.swift
@@ -43,6 +43,28 @@ struct Corners: OptionSet {
 
         return flippedCorners
     }
+
+    var layerCornerMask: CACornerMask {
+        var mask: CACornerMask = []
+
+        if contains(.topLeft) {
+            mask.insert(.layerMinXMaxYCorner)
+        }
+
+        if contains(.topRight) {
+            mask.insert(.layerMaxXMaxYCorner)
+        }
+
+        if contains(.bottomLeft) {
+            mask.insert(.layerMinXMinYCorner)
+        }
+
+        if contains(.bottomRight) {
+            mask.insert(.layerMinXMaxYCorner)
+        }
+
+        return mask
+    }
 }
 
 extension NSBezierPath {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/BezierPath+Corner.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/BezierPath+Corner.swift
@@ -60,7 +60,7 @@ struct Corners: OptionSet {
         }
 
         if contains(.bottomRight) {
-            mask.insert(.layerMinXMaxYCorner)
+            mask.insert(.layerMaxXMinYCorner)
         }
 
         return mask

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.swift
@@ -176,7 +176,7 @@ extension MainDashboardViewController {
 extension MainDashboardViewController: TimeEntryListViewControllerDelegate {
 
     func isTimerFocusing() -> Bool {
-        return timerController.autoCompleteInput.currentEditor() != nil
+        return timerController.autoCompleteInput?.currentEditor() != nil
     }
 
     func containerViewForTimer() -> NSView! {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -82,7 +82,18 @@ final class TimelineData {
     }
 
     func append(_ entry: TimelineTimeEntry) {
-        timeEntries.append(entry)
+        // Add if need
+        let isContains = timeEntries.contains(where: { (item) -> Bool in
+            if let timeEntry = item as? TimelineTimeEntry, timeEntry.timeEntry.guid == entry.timeEntry.guid {
+                return true
+            }
+            return false
+        })
+        if !isContains {
+            timeEntries.append(entry)
+        }
+
+        // But always reload
         calculateColumnsPositionForTimeline()
     }
     

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -99,6 +99,7 @@ final class TimelineData {
             return false
         })
         if !isContains {
+            print("----------------------------- append to timeline data")
             timeEntries.append(entry)
             timeEntries.sort { (lhs, rhs) -> Bool in
                 return lhs.start < rhs.start

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -38,11 +38,20 @@ final class TimelineData {
 
     // MARK: Init
 
-    init(cmd: TimelineDisplayCommand, zoomLevel: TimelineDatasource.ZoomLevel) {
+    init(cmd: TimelineDisplayCommand, zoomLevel: TimelineDatasource.ZoomLevel, runningTimeEntry: TimeEntryViewItem?) {
         self.zoomLevel = zoomLevel
         self.start = cmd.start
         self.end = cmd.end
-        self.timeEntries = cmd.timeEntries.map { TimelineTimeEntry($0) }.sorted(by: { (lhs, rhs) -> Bool in
+
+        // Add running TimeEntry if need
+        var timeEntries = cmd.timeEntries
+        if let runningTimeEntry = runningTimeEntry {
+            runningTimeEntry.ended = Date()
+            timeEntries.append(runningTimeEntry)
+        }
+
+        // Sort
+        self.timeEntries = timeEntries.map { TimelineTimeEntry($0) }.sorted(by: { (lhs, rhs) -> Bool in
             return lhs.start < rhs.start
         })
         numberOfSections = Section.allCases.count
@@ -91,6 +100,9 @@ final class TimelineData {
         })
         if !isContains {
             timeEntries.append(entry)
+            timeEntries.sort { (lhs, rhs) -> Bool in
+                return lhs.start < rhs.start
+            }
         }
 
         // But always reload

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -81,6 +81,11 @@ final class TimelineData {
         activities.removeAll()
     }
 
+    func append(_ entry: TimelineTimeEntry) {
+        timeEntries.append(entry)
+        calculateColumnsPositionForTimeline()
+    }
+    
     func numberOfItems(in section: Int) -> Int {
         guard let section = Section(rawValue: section) else { return 0 }
         switch section {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -100,4 +100,8 @@ final class TimelineTimeEntry: TimelineBaseTimeEntry {
         guard let date = timeEntry.ended else { return false }
         return Calendar.current.isDateInToday(date)
     }
+
+    func updateEndTimeForRunning() {
+        end = Date().timeIntervalSince1970
+    }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -77,7 +77,7 @@ final class TimelineTimeEntry: TimelineBaseTimeEntry {
 
     var isSmall: Bool {
         // It's small bar if duration less than 1 min
-        return timeEntry.duration_in_seconds <= 60
+        return abs(timeEntry.duration_in_seconds) <= 60
     }
 
     // MARK: Init

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -155,17 +155,8 @@ final class TimelineDashboardViewController: NSViewController {
     }
 
     func render(with cmd: TimelineDisplayCommand) {
-        let timeline = TimelineData(cmd: cmd, zoomLevel: zoomLevel)
-        let date = Date(timeIntervalSince1970: cmd.start)
-        let shouldScroll = datePickerView.currentDate != date
-        datePickerView.currentDate = date
-        datasource.render(timeline)
-
-        handleEmptyState(timeline)
-
-        if shouldScroll {
-            scrollToVisibleItem()
-        }
+        datePickerView.currentDate = Date(timeIntervalSince1970: cmd.start)
+        datasource.render(cmd: cmd, zoomLevel: zoomLevel)
 
         // After the reload finishes, we hightlight a cell again
         updatePositionOfEditorIfNeed()
@@ -311,12 +302,6 @@ extension TimelineDashboardViewController {
         editorPopover.setTimeEntry(timeEntry)
     }
 
-    fileprivate func handleEmptyState(_ timeline: TimelineData) {
-        emptyLbl.isHidden = !timeline.timeEntries.isEmpty
-        emptyActivityLbl.isHidden = !timeline.activities.isEmpty
-        updateEmptyActivityText()
-    }
-
     private func updateEmptyActivityText() {
         emptyActivityLbl.stringValue = recordSwitcher.isOn ? "No activity was recorded yet..." : "Turn on activity\nrecording to see results."
         emptyActivityLblPadding.constant = recordSwitcher.isOn ? -40 : -50
@@ -405,6 +390,12 @@ extension TimelineDashboardViewController: DatePickerViewDelegate {
 // MARK: TimelineDatasourceDelegate
 
 extension TimelineDashboardViewController: TimelineDatasourceDelegate {
+
+    func shouldHandleEmptyState(_ timelineData: TimelineData) {
+        emptyLbl.isHidden = !timelineData.timeEntries.isEmpty
+        emptyActivityLbl.isHidden = !timelineData.activities.isEmpty
+        updateEmptyActivityText()
+    }
 
     func shouldHideAllPopover() {
         closeAllPopovers()

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -436,7 +436,11 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
         // Or present the Popover
         selectedGUID = timeEntry.guid
         editorPopover.setTimeEntry(timeEntry)
-        DesktopLibraryBridge.shared().startEditor(atGUID: timeEntry.guid)
+
+        // We already present the Editor in Timeline, so don't need to present on the Timer anymore
+        if !timeEntry.isRunning() {
+            DesktopLibraryBridge.shared().startEditor(atGUID: timeEntry.guid)
+        }
 
         // Find the cell and present to get the correct position
         // since the toggl_edit causes the Timeline completely reloads -> The cell is reused.

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -361,8 +361,7 @@ extension TimelineDashboardViewController {
     }
 
     @objc private func runningTimeEntryNoti(_ noti: Notification) {
-        guard let timeEntry = noti.object as? TimeEntryViewItem else { return }
-        datasource.update(timeEntry)
+        datasource.update(noti.object)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -246,6 +246,10 @@ extension TimelineDashboardViewController {
                                        selector: #selector(startTimeEntryNoti(_:)),
                                        name: Notification.Name(kStarTimeEntryWithStartTime),
                                        object: nil)
+        NotificationCenter.default.addObserver(self,
+                                       selector: #selector(runningTimeEntryNoti(_:)),
+                                       name: Notification.Name(kDisplayTimerState),
+                                       object: nil)
     }
 
     private func initTrackingArea() {
@@ -354,6 +358,11 @@ extension TimelineDashboardViewController {
     @objc private func startTimeEntryNoti(_ noti: Notification) {
         guard let startTime = noti.object as? Date else { return }
         timelineShouldCreateEmptyEntry(with: startTime.timeIntervalSince1970)
+    }
+
+    @objc private func runningTimeEntryNoti(_ noti: Notification) {
+        guard let timeEntry = noti.object as? TimeEntryViewItem else { return }
+        datasource.update(timeEntry)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -346,7 +346,7 @@ extension TimelineDashboardViewController {
     }
 
     @objc private func runningTimeEntryNoti(_ noti: Notification) {
-        datasource.update(noti.object)
+        datasource.updateRunningTimeEntry(noti.object)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -80,6 +80,7 @@ final class TimelineDatasource: NSObject {
     private var isUserResizing = false
     private var draggingSession = TimelineDraggingSession()
     private var isUserOnAction: Bool { return isUserResizing || draggingSession.isDragging }
+    private var runningTimeEntry: TimelineTimeEntry?
 
     // MARK: Init
 
@@ -106,8 +107,32 @@ final class TimelineDatasource: NSObject {
         self.timeline?.cleanUp()
         self.timeline = nil
         self.timeline = timeline
+        if let runningTimeEntry = runningTimeEntry {
+            timeline.append(runningTimeEntry)
+        }
         flow.currentDate = Date(timeIntervalSince1970: timeline.start)
         collectionView.reloadData()
+    }
+
+    func update(_ timeEntry: Any?) {
+        guard !isUserOnAction else { return }
+
+        // Add
+        if let timeEntry = timeEntry as? TimeEntryViewItem {
+            guard timeEntry.isRunning(),
+                timeEntry.guid != runningTimeEntry?.timeEntry.guid else {
+                    return
+            }
+            let entry = TimelineTimeEntry(timeEntry)
+            timeline?.append(entry)
+            runningTimeEntry = entry
+            collectionView.reloadData()
+            print("✅ ----- runningTimeEntry = \(runningTimeEntry?.timeEntry.guid)")
+        } else {
+            // Or remove
+            runningTimeEntry = nil
+            print("💥 ----- runningTimeEntry = nil")
+        }
     }
 
     func update(_ zoomLevel: ZoomLevel) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/CornerBoxView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/CornerBoxView.swift
@@ -1,0 +1,72 @@
+//
+//  CornerBoxView.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 2/18/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Cocoa
+
+@IBDesignable
+final class CornerBoxView: NSView {
+
+    // MARK: Variables
+
+    @IBInspectable var cornerRadius: CGFloat = 0 {
+        didSet {
+            layer?.cornerRadius = cornerRadius
+        }
+    }
+    @IBInspectable var borderWidth: CGFloat = 0 {
+        didSet {
+            layer?.borderWidth = borderWidth
+        }
+    }
+    @IBInspectable var borderColor: NSColor = NSColor.black {
+        didSet {
+            layer?.borderColor = borderColor.cgColor
+        }
+    }
+    @IBInspectable var backgroundColor: NSColor = NSColor.lightGray {
+        didSet {
+            layer?.backgroundColor = backgroundColor.cgColor
+        }
+    }
+
+    var corners: Corners = [.bottomLeft, .bottomRight, .topLeft, .topRight] {
+        didSet {
+            initCornerMask()
+        }
+    }
+
+    // MARK: Public
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        initCommon()
+        initCornerMask()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        initCommon()
+        initCornerMask()
+    }
+
+    private func initCommon() {
+        wantsLayer = true
+        layer?.masksToBounds = true
+    }
+
+    private func initCornerMask() {
+        if #available(OSX 10.13, *) {
+            layer?.maskedCorners = corners.layerCornerMask
+        } else {
+            let path = NSBezierPath(rect: bounds, roundedCorners: corners, cornerRadius: cornerRadius)
+            let mask = CAShapeLayer()
+            mask.path = path.cgPath
+            layer?.mask = mask
+        }
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
@@ -40,7 +40,7 @@ class TimelineBaseCell: NSCollectionViewItem {
 
     // MARK: OUTLET
 
-    @IBOutlet weak var backgroundBox: NSBox?
+    @IBOutlet weak var backgroundBox: CornerBoxView?
     @IBOutlet weak var foregroundBox: CornerBoxView!
     
     // MARK: Variables
@@ -95,7 +95,7 @@ class TimelineBaseCell: NSCollectionViewItem {
         backgroundColor = foregroundColor.lighten(by: 0.2)
 
         foregroundBox.backgroundColor = foregroundColor
-        backgroundBox?.fillColor = backgroundColor ?? foregroundColor
+        backgroundBox?.backgroundColor = backgroundColor ?? foregroundColor
         backgroundBox?.borderColor = backgroundColor ?? foregroundColor
 
         let cornerRadius = TimelineBaseCell.suitableCornerRadius(isSmallEntry, height: view.frame.height)

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
@@ -41,7 +41,7 @@ class TimelineBaseCell: NSCollectionViewItem {
     // MARK: OUTLET
 
     @IBOutlet weak var backgroundBox: NSBox?
-    @IBOutlet weak var foregroundBox: NSBox!
+    @IBOutlet weak var foregroundBox: CornerBoxView!
     
     // MARK: Variables
 
@@ -94,7 +94,7 @@ class TimelineBaseCell: NSCollectionViewItem {
     func renderColor(with foregroundColor: NSColor, isSmallEntry: Bool) {
         backgroundColor = foregroundColor.lighten(by: 0.2)
 
-        foregroundBox.fillColor = foregroundColor
+        foregroundBox.backgroundColor = foregroundColor
         backgroundBox?.fillColor = backgroundColor ?? foregroundColor
         backgroundBox?.borderColor = backgroundColor ?? foregroundColor
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -39,7 +39,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
 
     var isHighlight: Bool = false {
         didSet {
-            backgroundBox?.borderColor = (isHighlight ? foregroundBox.fillColor : backgroundColor) ?? foregroundBox.fillColor
+            backgroundBox?.borderColor = (isHighlight ? foregroundBox.backgroundColor : backgroundColor) ?? foregroundBox.backgroundColor
         }
     }
 
@@ -58,7 +58,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     @IBOutlet weak var iconStackView: NSStackView!
     @IBOutlet weak var durationLbl: NSTextField!
     @IBOutlet weak var mainStackView: NSStackView!
-    @IBOutlet weak var innerBackgroundBox: NSBox! // Prevent transparent background color
+    @IBOutlet weak var innerBackgroundBox: CornerBoxView! // Prevent transparent background color
     
     // MARK: View
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -58,6 +58,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     @IBOutlet weak var iconStackView: NSStackView!
     @IBOutlet weak var durationLbl: NSTextField!
     @IBOutlet weak var mainStackView: NSStackView!
+    @IBOutlet weak var innerBackgroundBox: NSBox! // Prevent transparent background color
 
     // MARK: View
 
@@ -97,7 +98,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
             timeEntry.hasDetailInfo else { return }
 
         // Hide if it too small
-        backgroundBox?.isHidden = isSmallSize
+        hideBackgroundViews(isHidden: isSmallSize)
 
         // Set initial state
         let topPadding: CGFloat = 5
@@ -172,6 +173,11 @@ extension TimelineTimeEntryCell {
         timeEntryMenu.menuDelegate = self
         view.menu = timeEntryMenu
         view.menu?.delegate = self
+    }
+
+    private func hideBackgroundViews(isHidden: Bool) {
+        backgroundBox?.isHidden = isHidden
+        innerBackgroundBox.isHidden = isHidden
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -166,8 +166,10 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     }
 
     private func handleRunningTimeEntry() {
-        guard let timeEntry = timeEntry else { return }
-
+        let isRunning = timeEntry?.timeEntry.isRunning() ?? false
+        let corner: Corners = isRunning ? [.topLeft, .topRight] : [.bottomLeft, .bottomRight, .topLeft, .topRight]
+        backgroundBox?.corners = corner
+        foregroundBox.corners = corner
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -59,7 +59,6 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     @IBOutlet weak var durationLbl: NSTextField!
     @IBOutlet weak var mainStackView: NSStackView!
     @IBOutlet weak var innerBackgroundBox: NSBox! // Prevent transparent background color
-    @IBOutlet weak var dashView: TimelineDashedCornerView!
     
     // MARK: View
 
@@ -168,7 +167,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
 
     private func handleRunningTimeEntry() {
         guard let timeEntry = timeEntry else { return }
-        dashView.isHidden = !timeEntry.timeEntry.isRunning()
+
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -59,7 +59,8 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     @IBOutlet weak var durationLbl: NSTextField!
     @IBOutlet weak var mainStackView: NSStackView!
     @IBOutlet weak var innerBackgroundBox: NSBox! // Prevent transparent background color
-
+    @IBOutlet weak var dashView: TimelineDashedCornerView!
+    
     // MARK: View
 
     override func viewDidLoad() {
@@ -79,6 +80,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
         self.timeEntry = timeEntry
         renderColor(with: timeEntry.color, isSmallEntry: timeEntry.isSmall)
         populateInfo()
+        handleRunningTimeEntry()
     }
 
     private func populateInfo() {
@@ -162,6 +164,11 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
         } else {
             clientNameLbl.isHidden = true
         }
+    }
+
+    private func handleRunningTimeEntry() {
+        guard let timeEntry = timeEntry else { return }
+        dashView.isHidden = !timeEntry.timeEntry.isRunning()
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -14,14 +14,20 @@
             <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <box boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="10" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="PFT-Hu-lDX">
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="ZlO-hY-zkZ" customClass="CornerBoxView" customModule="TogglDesktop" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
-                    <view key="contentView" id="x0z-XV-qtc">
-                        <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    </view>
-                    <color key="fillColor" name="timeline-background-color"/>
-                </box>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="0.0"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                            <color key="value" name="timeline-background-color"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </customView>
                 <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="line" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xE9-Ie-UP3">
                     <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
                     <view key="contentView" id="r80-dl-MpV">
@@ -151,30 +157,36 @@
                     </view>
                     <color key="fillColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
                 </box>
-                <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="ILd-N3-zAP">
+                <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CHS-wV-aVu" customClass="CornerBoxView" customModule="TogglDesktop" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="20" height="107"/>
-                    <view key="contentView" id="R5g-bh-G9v">
-                        <rect key="frame" x="0.0" y="0.0" width="20" height="107"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    </view>
                     <constraints>
-                        <constraint firstAttribute="width" constant="20" id="kI4-ty-z79"/>
+                        <constraint firstAttribute="width" constant="20" id="QaL-zX-gSd"/>
                     </constraints>
-                    <color key="fillColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
-                </box>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="0.0"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                            <color key="value" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </customView>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="ILd-N3-zAP" secondAttribute="bottom" priority="750" id="1Mm-Za-otm"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="1VM-YB-XHD"/>
+                <constraint firstItem="CHS-wV-aVu" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="1uM-Sp-Zup"/>
                 <constraint firstAttribute="trailing" secondItem="xE9-Ie-UP3" secondAttribute="trailing" priority="750" id="44W-4X-N3n"/>
-                <constraint firstItem="PFT-Hu-lDX" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="HyU-Wh-UDu"/>
+                <constraint firstAttribute="trailing" secondItem="ZlO-hY-zkZ" secondAttribute="trailing" id="4qn-iB-eTU"/>
+                <constraint firstItem="ZlO-hY-zkZ" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="6c8-YK-ZKX"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="Jj8-O9-hu6"/>
-                <constraint firstItem="PFT-Hu-lDX" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="VaI-2H-p9e"/>
-                <constraint firstAttribute="bottom" secondItem="PFT-Hu-lDX" secondAttribute="bottom" id="fW7-Nd-VKX"/>
-                <constraint firstItem="ILd-N3-zAP" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="ibj-8F-oO2"/>
-                <constraint firstAttribute="trailing" secondItem="PFT-Hu-lDX" secondAttribute="trailing" id="kah-E4-eV6"/>
+                <constraint firstAttribute="bottom" secondItem="CHS-wV-aVu" secondAttribute="bottom" priority="750" id="Lko-TK-rov"/>
+                <constraint firstAttribute="bottom" secondItem="ZlO-hY-zkZ" secondAttribute="bottom" id="QMX-O3-uTc"/>
+                <constraint firstItem="CHS-wV-aVu" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="UmF-V8-X38"/>
+                <constraint firstItem="ZlO-hY-zkZ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="VAG-Yl-MTB"/>
                 <constraint firstAttribute="bottom" secondItem="xE9-Ie-UP3" secondAttribute="bottom" priority="750" id="pyj-Y7-31G"/>
-                <constraint firstItem="ILd-N3-zAP" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="zP1-Vu-Sgm"/>
             </constraints>
             <point key="canvasLocation" x="32.5" y="162.5"/>
         </customView>
@@ -185,9 +197,9 @@
                 <outlet property="clientNameLbl" destination="Ypi-B4-1IQ" id="CWd-5X-D9a"/>
                 <outlet property="dotColorBox" destination="IRd-GO-o1l" id="e83-2k-O8A"/>
                 <outlet property="durationLbl" destination="fa0-T9-1iU" id="dzs-lY-QOM"/>
-                <outlet property="foregroundBox" destination="ILd-N3-zAP" id="FYH-LJ-fYB"/>
+                <outlet property="foregroundBox" destination="CHS-wV-aVu" id="nAo-eo-eYl"/>
                 <outlet property="iconStackView" destination="PyM-uW-hFa" id="iwc-5a-pK9"/>
-                <outlet property="innerBackgroundBox" destination="PFT-Hu-lDX" id="xAF-ge-2oe"/>
+                <outlet property="innerBackgroundBox" destination="ZlO-hY-zkZ" id="rfz-JL-MIh"/>
                 <outlet property="mainStackView" destination="Dpe-7G-baj" id="GwM-nb-8fY"/>
                 <outlet property="projectLbl" destination="euI-fo-hqA" id="tZs-ru-phr"/>
                 <outlet property="projectStackView" destination="Azu-a1-gfT" id="MiD-AE-fBP"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -162,23 +162,16 @@
                     </constraints>
                     <color key="fillColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                 </box>
-                <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Sn-zi-QiS" customClass="TimelineDashedCornerView" customModule="TogglDesktop" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
-                </customView>
             </subviews>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="ILd-N3-zAP" secondAttribute="bottom" priority="750" id="1Mm-Za-otm"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="1VM-YB-XHD"/>
                 <constraint firstAttribute="trailing" secondItem="xE9-Ie-UP3" secondAttribute="trailing" priority="750" id="44W-4X-N3n"/>
-                <constraint firstAttribute="bottom" secondItem="1Sn-zi-QiS" secondAttribute="bottom" id="EaS-bq-uin"/>
-                <constraint firstItem="1Sn-zi-QiS" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="GDQ-WZ-yIa"/>
                 <constraint firstItem="PFT-Hu-lDX" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="HyU-Wh-UDu"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="Jj8-O9-hu6"/>
                 <constraint firstItem="PFT-Hu-lDX" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="VaI-2H-p9e"/>
                 <constraint firstAttribute="bottom" secondItem="PFT-Hu-lDX" secondAttribute="bottom" id="fW7-Nd-VKX"/>
-                <constraint firstItem="1Sn-zi-QiS" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="hfT-ee-Px3"/>
                 <constraint firstItem="ILd-N3-zAP" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="ibj-8F-oO2"/>
-                <constraint firstAttribute="trailing" secondItem="1Sn-zi-QiS" secondAttribute="trailing" id="jqP-Lz-sY5"/>
                 <constraint firstAttribute="trailing" secondItem="PFT-Hu-lDX" secondAttribute="trailing" id="kah-E4-eV6"/>
                 <constraint firstAttribute="bottom" secondItem="xE9-Ie-UP3" secondAttribute="bottom" priority="750" id="pyj-Y7-31G"/>
                 <constraint firstItem="ILd-N3-zAP" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="zP1-Vu-Sgm"/>
@@ -190,7 +183,6 @@
                 <outlet property="backgroundBox" destination="xE9-Ie-UP3" id="VlS-Kl-W1W"/>
                 <outlet property="billableImageView" destination="KGC-LT-pQG" id="6hB-b9-5ra"/>
                 <outlet property="clientNameLbl" destination="Ypi-B4-1IQ" id="CWd-5X-D9a"/>
-                <outlet property="dashView" destination="1Sn-zi-QiS" id="4om-eh-Cpr"/>
                 <outlet property="dotColorBox" destination="IRd-GO-o1l" id="e83-2k-O8A"/>
                 <outlet property="durationLbl" destination="fa0-T9-1iU" id="dzs-lY-QOM"/>
                 <outlet property="foregroundBox" destination="ILd-N3-zAP" id="FYH-LJ-fYB"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -187,6 +187,7 @@
                 <outlet property="durationLbl" destination="fa0-T9-1iU" id="dzs-lY-QOM"/>
                 <outlet property="foregroundBox" destination="ILd-N3-zAP" id="FYH-LJ-fYB"/>
                 <outlet property="iconStackView" destination="PyM-uW-hFa" id="iwc-5a-pK9"/>
+                <outlet property="innerBackgroundBox" destination="PFT-Hu-lDX" id="xAF-ge-2oe"/>
                 <outlet property="mainStackView" destination="Dpe-7G-baj" id="GwM-nb-8fY"/>
                 <outlet property="projectLbl" destination="euI-fo-hqA" id="tZs-ru-phr"/>
                 <outlet property="projectStackView" destination="Azu-a1-gfT" id="MiD-AE-fBP"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -28,135 +28,144 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </customView>
-                <box horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="line" cornerRadius="10" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="xE9-Ie-UP3">
+                <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IJ4-qg-XP7" customClass="CornerBoxView" customModule="TogglDesktop" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
-                    <view key="contentView" id="r80-dl-MpV">
-                        <rect key="frame" x="1" y="1" width="195" height="105"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dpe-7G-baj">
-                                <rect key="frame" x="30" y="20" width="165" height="81"/>
-                                <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXs-or-rIk">
-                                        <rect key="frame" x="-2" y="66" width="77" height="15"/>
-                                        <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" title="Copy Review" id="x7F-x0-ynb">
-                                            <font key="font" metaFont="label" size="12"/>
-                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
-                                    <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Azu-a1-gfT">
-                                        <rect key="frame" x="0.0" y="47" width="100" height="15"/>
-                                        <subviews>
-                                            <imageView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="IRd-GO-o1l" customClass="DotImageView" customModule="TogglDesktop" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="4" width="8" height="8"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="8" id="CyW-Lz-h7S"/>
-                                                    <constraint firstAttribute="width" constant="8" id="H94-dd-E7G"/>
-                                                </constraints>
-                                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="time-entry-dot" id="aL9-XR-zzS"/>
-                                            </imageView>
-                                            <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="euI-fo-hqA" customClass="ProjectTextField">
-                                                <rect key="frame" x="13" y="0.0" width="89" height="15"/>
-                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="NEW - TOGGL " placeholderString="+ Add project" id="liW-U4-bg3">
-                                                    <font key="font" metaFont="label" size="12"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
-                                        </subviews>
-                                        <visibilityPriorities>
-                                            <integer value="1000"/>
-                                            <integer value="1000"/>
-                                        </visibilityPriorities>
-                                        <customSpacing>
-                                            <real value="3.4028234663852886e+38"/>
-                                            <real value="3.4028234663852886e+38"/>
-                                        </customSpacing>
-                                    </stackView>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ypi-B4-1IQ">
-                                        <rect key="frame" x="-2" y="28" width="72" height="15"/>
-                                        <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" title="Client name" id="tNO-GK-NSh">
-                                            <font key="font" metaFont="label" size="12"/>
-                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
-                                    <stackView distribution="fill" orientation="horizontal" alignment="bottom" spacing="5" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-uW-hFa">
-                                        <rect key="frame" x="0.0" y="0.0" width="165" height="24"/>
-                                        <subviews>
-                                            <imageView translatesAutoresizingMaskIntoConstraints="NO" id="qtZ-fn-lLE">
-                                                <rect key="frame" x="0.0" y="0.0" width="17" height="17"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="17" id="cLu-gP-d3j"/>
-                                                    <constraint firstAttribute="width" constant="17" id="z8n-Hl-1O0"/>
-                                                </constraints>
-                                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="time-entry-tag" id="yXa-gt-pHS"/>
-                                            </imageView>
-                                            <imageView translatesAutoresizingMaskIntoConstraints="NO" id="KGC-LT-pQG">
-                                                <rect key="frame" x="22" y="0.0" width="17" height="17"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="17" id="KGg-go-8ja"/>
-                                                    <constraint firstAttribute="width" constant="17" id="ojn-fj-sN5"/>
-                                                </constraints>
-                                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="time-entry-billable" id="WjC-yn-K4V"/>
-                                            </imageView>
-                                            <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8dq-AH-3f2">
-                                                <rect key="frame" x="44" y="0.0" width="121" height="16"/>
-                                                <subviews>
-                                                    <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fa0-T9-1iU">
-                                                        <rect key="frame" x="94" y="1" width="24" height="15"/>
-                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" alignment="right" title="12h" id="k25-lb-1QZ">
-                                                            <font key="font" metaFont="label" size="12"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                    </textField>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="16" id="6CP-pL-a92"/>
-                                                    <constraint firstAttribute="trailing" secondItem="fa0-T9-1iU" secondAttribute="trailing" constant="5" id="Iu3-mL-rcj"/>
-                                                    <constraint firstItem="fa0-T9-1iU" firstAttribute="centerY" secondItem="8dq-AH-3f2" secondAttribute="centerY" id="TR5-Qw-8jI"/>
-                                                </constraints>
-                                            </customView>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="orU-Qa-Q0p"/>
-                                        </constraints>
-                                        <visibilityPriorities>
-                                            <integer value="1000"/>
-                                            <integer value="1000"/>
-                                            <integer value="1000"/>
-                                        </visibilityPriorities>
-                                        <customSpacing>
-                                            <real value="3.4028234663852886e+38"/>
-                                            <real value="3.4028234663852886e+38"/>
-                                            <real value="3.4028234663852886e+38"/>
-                                        </customSpacing>
-                                    </stackView>
-                                </subviews>
-                                <visibilityPriorities>
-                                    <integer value="1000"/>
-                                    <integer value="1000"/>
-                                    <integer value="1000"/>
-                                    <integer value="1000"/>
-                                </visibilityPriorities>
-                                <customSpacing>
-                                    <real value="3.4028234663852886e+38"/>
-                                    <real value="3.4028234663852886e+38"/>
-                                    <real value="3.4028234663852886e+38"/>
-                                    <real value="3.4028234663852886e+38"/>
-                                </customSpacing>
-                            </stackView>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="Dpe-7G-baj" firstAttribute="leading" secondItem="r80-dl-MpV" secondAttribute="leading" constant="30" id="ci9-bO-9hN"/>
-                            <constraint firstAttribute="trailing" secondItem="Dpe-7G-baj" secondAttribute="trailing" id="iiK-Hr-LDk"/>
-                            <constraint firstItem="Dpe-7G-baj" firstAttribute="top" secondItem="r80-dl-MpV" secondAttribute="top" constant="4" id="uJq-SO-k3o"/>
-                        </constraints>
-                    </view>
-                    <color key="fillColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
-                </box>
+                    <subviews>
+                        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dpe-7G-baj">
+                            <rect key="frame" x="30" y="22" width="167" height="81"/>
+                            <subviews>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXs-or-rIk">
+                                    <rect key="frame" x="-2" y="66" width="77" height="15"/>
+                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" title="Copy Review" id="x7F-x0-ynb">
+                                        <font key="font" metaFont="label" size="12"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Azu-a1-gfT">
+                                    <rect key="frame" x="0.0" y="47" width="100" height="15"/>
+                                    <subviews>
+                                        <imageView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="IRd-GO-o1l" customClass="DotImageView" customModule="TogglDesktop" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="4" width="8" height="8"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="8" id="CyW-Lz-h7S"/>
+                                                <constraint firstAttribute="width" constant="8" id="H94-dd-E7G"/>
+                                            </constraints>
+                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="time-entry-dot" id="aL9-XR-zzS"/>
+                                        </imageView>
+                                        <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="euI-fo-hqA" customClass="ProjectTextField">
+                                            <rect key="frame" x="13" y="0.0" width="89" height="15"/>
+                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="NEW - TOGGL " placeholderString="+ Add project" id="liW-U4-bg3">
+                                                <font key="font" metaFont="label" size="12"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                    <visibilityPriorities>
+                                        <integer value="1000"/>
+                                        <integer value="1000"/>
+                                    </visibilityPriorities>
+                                    <customSpacing>
+                                        <real value="3.4028234663852886e+38"/>
+                                        <real value="3.4028234663852886e+38"/>
+                                    </customSpacing>
+                                </stackView>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ypi-B4-1IQ">
+                                    <rect key="frame" x="-2" y="28" width="72" height="15"/>
+                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" title="Client name" id="tNO-GK-NSh">
+                                        <font key="font" metaFont="label" size="12"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <stackView distribution="fill" orientation="horizontal" alignment="bottom" spacing="5" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-uW-hFa">
+                                    <rect key="frame" x="0.0" y="0.0" width="147" height="24"/>
+                                    <subviews>
+                                        <imageView translatesAutoresizingMaskIntoConstraints="NO" id="qtZ-fn-lLE">
+                                            <rect key="frame" x="0.0" y="0.0" width="17" height="17"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="17" id="cLu-gP-d3j"/>
+                                                <constraint firstAttribute="width" constant="17" id="z8n-Hl-1O0"/>
+                                            </constraints>
+                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="time-entry-tag" id="yXa-gt-pHS"/>
+                                        </imageView>
+                                        <imageView translatesAutoresizingMaskIntoConstraints="NO" id="KGC-LT-pQG">
+                                            <rect key="frame" x="22" y="0.0" width="17" height="17"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="17" id="KGg-go-8ja"/>
+                                                <constraint firstAttribute="width" constant="17" id="ojn-fj-sN5"/>
+                                            </constraints>
+                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="time-entry-billable" id="WjC-yn-K4V"/>
+                                        </imageView>
+                                        <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8dq-AH-3f2">
+                                            <rect key="frame" x="44" y="0.0" width="103" height="16"/>
+                                            <subviews>
+                                                <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fa0-T9-1iU">
+                                                    <rect key="frame" x="76" y="1" width="24" height="15"/>
+                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" alignment="right" title="12h" id="k25-lb-1QZ">
+                                                        <font key="font" metaFont="label" size="12"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="16" id="6CP-pL-a92"/>
+                                                <constraint firstAttribute="trailing" secondItem="fa0-T9-1iU" secondAttribute="trailing" constant="5" id="Iu3-mL-rcj"/>
+                                                <constraint firstItem="fa0-T9-1iU" firstAttribute="centerY" secondItem="8dq-AH-3f2" secondAttribute="centerY" id="TR5-Qw-8jI"/>
+                                            </constraints>
+                                        </customView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="24" id="orU-Qa-Q0p"/>
+                                    </constraints>
+                                    <visibilityPriorities>
+                                        <integer value="1000"/>
+                                        <integer value="1000"/>
+                                        <integer value="1000"/>
+                                    </visibilityPriorities>
+                                    <customSpacing>
+                                        <real value="3.4028234663852886e+38"/>
+                                        <real value="3.4028234663852886e+38"/>
+                                        <real value="3.4028234663852886e+38"/>
+                                    </customSpacing>
+                                </stackView>
+                            </subviews>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="Dpe-7G-baj" secondAttribute="trailing" id="juF-oq-IqR"/>
+                        <constraint firstItem="Dpe-7G-baj" firstAttribute="leading" secondItem="IJ4-qg-XP7" secondAttribute="leading" constant="30" id="mCx-nk-Ise"/>
+                        <constraint firstItem="Dpe-7G-baj" firstAttribute="top" secondItem="IJ4-qg-XP7" secondAttribute="top" constant="4" id="rZn-oT-5Ns"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                            <color key="value" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                            <color key="value" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </customView>
                 <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CHS-wV-aVu" customClass="CornerBoxView" customModule="TogglDesktop" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="20" height="107"/>
                     <constraints>
@@ -176,23 +185,23 @@
                 </customView>
             </subviews>
             <constraints>
-                <constraint firstItem="xE9-Ie-UP3" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="1VM-YB-XHD"/>
                 <constraint firstItem="CHS-wV-aVu" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="1uM-Sp-Zup"/>
-                <constraint firstAttribute="trailing" secondItem="xE9-Ie-UP3" secondAttribute="trailing" priority="750" id="44W-4X-N3n"/>
                 <constraint firstAttribute="trailing" secondItem="ZlO-hY-zkZ" secondAttribute="trailing" id="4qn-iB-eTU"/>
                 <constraint firstItem="ZlO-hY-zkZ" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="6c8-YK-ZKX"/>
-                <constraint firstItem="xE9-Ie-UP3" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="Jj8-O9-hu6"/>
                 <constraint firstAttribute="bottom" secondItem="CHS-wV-aVu" secondAttribute="bottom" priority="750" id="Lko-TK-rov"/>
                 <constraint firstAttribute="bottom" secondItem="ZlO-hY-zkZ" secondAttribute="bottom" id="QMX-O3-uTc"/>
+                <constraint firstItem="IJ4-qg-XP7" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="QgW-da-GfD"/>
                 <constraint firstItem="CHS-wV-aVu" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="UmF-V8-X38"/>
                 <constraint firstItem="ZlO-hY-zkZ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="VAG-Yl-MTB"/>
-                <constraint firstAttribute="bottom" secondItem="xE9-Ie-UP3" secondAttribute="bottom" priority="750" id="pyj-Y7-31G"/>
+                <constraint firstAttribute="bottom" secondItem="IJ4-qg-XP7" secondAttribute="bottom" priority="750" id="Vu0-nc-Hg8"/>
+                <constraint firstItem="IJ4-qg-XP7" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="ZgH-yY-IDO"/>
+                <constraint firstAttribute="trailing" secondItem="IJ4-qg-XP7" secondAttribute="trailing" priority="750" id="kIo-Bq-IJw"/>
             </constraints>
             <point key="canvasLocation" x="32.5" y="162.5"/>
         </customView>
         <collectionViewItem identifier="TimelineTimeEntryCell" id="7AB-0R-5ZL" customClass="TimelineTimeEntryCell" customModule="TogglDesktop" customModuleProvider="target">
             <connections>
-                <outlet property="backgroundBox" destination="xE9-Ie-UP3" id="VlS-Kl-W1W"/>
+                <outlet property="backgroundBox" destination="IJ4-qg-XP7" id="q8G-r5-CnQ"/>
                 <outlet property="billableImageView" destination="KGC-LT-pQG" id="6hB-b9-5ra"/>
                 <outlet property="clientNameLbl" destination="Ypi-B4-1IQ" id="CWd-5X-D9a"/>
                 <outlet property="dotColorBox" destination="IRd-GO-o1l" id="e83-2k-O8A"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.xib
@@ -162,16 +162,23 @@
                     </constraints>
                     <color key="fillColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                 </box>
+                <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Sn-zi-QiS" customClass="TimelineDashedCornerView" customModule="TogglDesktop" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="197" height="107"/>
+                </customView>
             </subviews>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="ILd-N3-zAP" secondAttribute="bottom" priority="750" id="1Mm-Za-otm"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="1VM-YB-XHD"/>
                 <constraint firstAttribute="trailing" secondItem="xE9-Ie-UP3" secondAttribute="trailing" priority="750" id="44W-4X-N3n"/>
+                <constraint firstAttribute="bottom" secondItem="1Sn-zi-QiS" secondAttribute="bottom" id="EaS-bq-uin"/>
+                <constraint firstItem="1Sn-zi-QiS" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="GDQ-WZ-yIa"/>
                 <constraint firstItem="PFT-Hu-lDX" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="HyU-Wh-UDu"/>
                 <constraint firstItem="xE9-Ie-UP3" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="Jj8-O9-hu6"/>
                 <constraint firstItem="PFT-Hu-lDX" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="VaI-2H-p9e"/>
                 <constraint firstAttribute="bottom" secondItem="PFT-Hu-lDX" secondAttribute="bottom" id="fW7-Nd-VKX"/>
+                <constraint firstItem="1Sn-zi-QiS" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="hfT-ee-Px3"/>
                 <constraint firstItem="ILd-N3-zAP" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" priority="750" id="ibj-8F-oO2"/>
+                <constraint firstAttribute="trailing" secondItem="1Sn-zi-QiS" secondAttribute="trailing" id="jqP-Lz-sY5"/>
                 <constraint firstAttribute="trailing" secondItem="PFT-Hu-lDX" secondAttribute="trailing" id="kah-E4-eV6"/>
                 <constraint firstAttribute="bottom" secondItem="xE9-Ie-UP3" secondAttribute="bottom" priority="750" id="pyj-Y7-31G"/>
                 <constraint firstItem="ILd-N3-zAP" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" priority="750" id="zP1-Vu-Sgm"/>
@@ -183,6 +190,7 @@
                 <outlet property="backgroundBox" destination="xE9-Ie-UP3" id="VlS-Kl-W1W"/>
                 <outlet property="billableImageView" destination="KGC-LT-pQG" id="6hB-b9-5ra"/>
                 <outlet property="clientNameLbl" destination="Ypi-B4-1IQ" id="CWd-5X-D9a"/>
+                <outlet property="dashView" destination="1Sn-zi-QiS" id="4om-eh-Cpr"/>
                 <outlet property="dotColorBox" destination="IRd-GO-o1l" id="e83-2k-O8A"/>
                 <outlet property="durationLbl" destination="fa0-T9-1iU" id="dzs-lY-QOM"/>
                 <outlet property="foregroundBox" destination="ILd-N3-zAP" id="FYH-LJ-fYB"/>

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -287,7 +287,7 @@ extern void *ctx;
 
 	NSLog(@"TimeEntryListViewController displayTimeEntryEditor, thread %@", [NSThread currentThread]);
 
-    self.runningEdit = cmd.timeEntry.isRunning;
+    self.runningEdit = [cmd.timeEntry isRunning];
 
 	// Skip render if need
 	if (!self.isOpening && !self.runningEdit)

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -221,6 +221,8 @@
 		BA43B24F23F438AA0007DD99 /* TimelineLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */; };
 		BA43B25423F525F30007DD99 /* TimelineLineView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA43B25323F525F30007DD99 /* TimelineLineView.xib */; };
 		BA43B25523F525F30007DD99 /* TimelineLineView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA43B25323F525F30007DD99 /* TimelineLineView.xib */; };
+		BA45AAF623FBEED4000C94C0 /* CornerBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA45AAF523FBEED4000C94C0 /* CornerBoxView.swift */; };
+		BA45AAF723FBEED4000C94C0 /* CornerBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA45AAF523FBEED4000C94C0 /* CornerBoxView.swift */; };
 		BA4791F122F0478A00E24F79 /* NSView+Xib.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791E822F0478900E24F79 /* NSView+Xib.swift */; };
 		BA4791F222F0478A00E24F79 /* NSView+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791E922F0478900E24F79 /* NSView+Animation.swift */; };
 		BA4791F322F0478A00E24F79 /* String+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4791EA22F0478900E24F79 /* String+Search.swift */; };
@@ -931,6 +933,7 @@
 		BA412C28224E196D003CA17A /* NoClientCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoClientCellView.xib; sourceTree = "<group>"; };
 		BA43B24D23F438AA0007DD99 /* TimelineLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLineView.swift; sourceTree = "<group>"; };
 		BA43B25323F525F30007DD99 /* TimelineLineView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TimelineLineView.xib; sourceTree = "<group>"; };
+		BA45AAF523FBEED4000C94C0 /* CornerBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerBoxView.swift; sourceTree = "<group>"; };
 		BA4791E822F0478900E24F79 /* NSView+Xib.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Xib.swift"; sourceTree = "<group>"; };
 		BA4791E922F0478900E24F79 /* NSView+Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Animation.swift"; sourceTree = "<group>"; };
 		BA4791EA22F0478900E24F79 /* String+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Search.swift"; sourceTree = "<group>"; };
@@ -1741,6 +1744,7 @@
 				BA5E988823BF496E0089A2C7 /* HoverImageView.swift */,
 				BAF9364B23E8114800EE1076 /* TimelineResizeHoverController.swift */,
 				BAF9364E23E8116900EE1076 /* TimelineResizeHoverController.xib */,
+				BA45AAF523FBEED4000C94C0 /* CornerBoxView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2557,6 +2561,7 @@
 				BA712EC221BF907200A2D8DD /* UndoManager.swift in Sources */,
 				BAA11AC12251F49E007F31D2 /* WorkspaceStorage.swift in Sources */,
 				3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */,
+				BA45AAF623FBEED4000C94C0 /* CornerBoxView.swift in Sources */,
 				BA13D2062269B7C400EB3833 /* CalendarViewController.swift in Sources */,
 				BAFBFCC821CD1D3C004B443F /* SystemService.m in Sources */,
 				BAF50DF821A2A18D0090BA95 /* AppIconFactory.m in Sources */,
@@ -2715,6 +2720,7 @@
 				BAE64D952368334000244D2B /* LiteAutoCompleteDataSource.m in Sources */,
 				BA4A7D5323755A4200A42095 /* GlobalTouchbarButton.swift in Sources */,
 				BAE64D962368334000244D2B /* DescriptionDataSource.swift in Sources */,
+				BA45AAF723FBEED4000C94C0 /* CornerBoxView.swift in Sources */,
 				BAE64D972368334000244D2B /* TagDataSource.swift in Sources */,
 				BAE64D982368334000244D2B /* ColorGraphicsView.swift in Sources */,
 				BAE64D992368334000244D2B /* WorkspaceDataSource.swift in Sources */,


### PR DESCRIPTION
### 📒 Description
This PR introduces new design and logic for the Running TimeEntry in Timeline view

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Logic to render the Running TimeEntry
- [x] Able to drag and drop or resize the running TE
- [x] Timer to update the running TE for re-drawing
- [x] Running TE has a dashed border view

### 👫 Relationships
Closes #3812

### 🔎 Review hints
1. Start any TE. Verify:
- There is a small TE in Timeline view
- It has dashed border
2. Click on the Timer and change the start or duration. Verify
- The Running TimeEntry in Timeline is updated
3. Try to resize the top or drag. Verify
- It will update the start time of the running TE
4. Try to drag a different time entry to make it conflicts with the current TE. Verify:
- Timeline render properly by having two columns
5. Click on the Running TimeEntry in Timeline and update some info in Editor. Verify:
- The info in Timer View is updated properly.
- The running TE pill is also updated.
6. Switch to next/previous date. Verify
- There is no Running Time Entry pill
7. Switch back to today. Verify
- The running TE is presented properly.
8. Waiting a bit. Verify
- The running TE is updated (1 min interval) by the Timer
9. Stop. Verify
- The running Time Entry backs to normal (No dashed border)

### GIF
https://www.dropbox.com/s/2k44d1uocxbh4a4/2020-02-17%2014.29.54.gif?dl=0


