### PR TITLE
Tray icon tooltip UI update

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimeEntryLabelViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimeEntryLabelViewModel.cs
@@ -9,15 +9,25 @@ namespace TogglDesktop.ViewModels
         public TimeEntryLabelViewModel(ProjectLabelViewModel projectLabel)
         {
             ProjectLabel = projectLabel;
-            this.WhenAnyValue(x => x.ProjectLabel.ProjectName)
-                .Select(projectName => string.IsNullOrEmpty(projectName) ? "+ Add details" : "+ Add description")
+            this.WhenAnyValue(x => x.ProjectLabel.ProjectName,
+                    x => x.ShowAddDetailsLabels)
+                .Select(((string projectName, bool showAddDetailsLabels) x) => x.showAddDetailsLabels
+                    ? (string.IsNullOrEmpty(x.projectName)
+                        ? "+ Add details"
+                        : "+ Add description")
+                    : "(no description)")
                 .ToPropertyEx(this, x => x.AddDescriptionLabelText);
-            this.WhenAnyValue(x => x.Description, x => x.ProjectLabel.ProjectName)
-                .Select(((string description, string projectName) tuple) => GetIsAddProjectLabelVisible(tuple.description, tuple.projectName))
+            this.WhenAnyValue(x => x.Description,
+                    x => x.ProjectLabel.ProjectName,
+                    x => x.ShowAddDetailsLabels)
+                .Select(((string description, string projectName, bool showAddDetailsLabels) x) =>
+                    x.showAddDetailsLabels && GetIsAddProjectLabelVisible(x.description, x.projectName))
                 .ToPropertyEx(this, x => x.IsAddProjectLabelVisible);
         }
 
         public ProjectLabelViewModel ProjectLabel { get; }
+
+        [Reactive] public bool ShowAddDetailsLabels { get; set; } = true;
 
         [Reactive]
         public string Description { get; private set; }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml.cs
@@ -152,7 +152,7 @@ namespace TogglDesktop
             this.editProjectPanel.ShowOnlyIf(item.ProjectID != 0);
             this.editModeProjectLabel.ViewModel.SetProject(item);
 
-            this.runningEntryInfoPanel.OnConfirmCompletion(item);
+            this.runningEntryInfoPanel.UpdateBillableAndTags(item.Billable, item.Tags);
         }
 
         private void cancelProjectSelectionButtonClick(object sender, RoutedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryInfoPanel.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryInfoPanel.xaml.cs
@@ -22,11 +22,15 @@ namespace TogglDesktop
 
         public event MouseButtonEventHandler DurationLabelMouseDown;
 
-        public void OnConfirmCompletion(Toggl.TogglAutocompleteView item)
+        public void UpdateBillableAndTags(bool billable, string tags)
         {
-            this.billableIcon.ShowOnlyIf(item.Billable);
-            this.tagsIcon.ShowOnlyIf(!string.IsNullOrEmpty(item.Tags));
-            this.tagsIcon.Tag = item.Tags;
+            this.billableIcon.ShowOnlyIf(billable);
+            this.tagsIcon.ShowOnlyIf(!string.IsNullOrEmpty(tags));
+            this.tagsIcon.Tag = tags;
+            this.tagsIcon.ToolTip =
+                string.IsNullOrEmpty(tags)
+                    ? null
+                    : tags.Replace(Toggl.TagSeparator, " • ");
         }
 
         public bool IsBillable => billableIcon.IsVisible;
@@ -35,17 +39,14 @@ namespace TogglDesktop
         public void ResetUIState(bool running)
         {
             this.ShowOnlyIf(running);
-            this.billableIcon.Visibility = Visibility.Collapsed;
-            this.tagsIcon.Visibility = Visibility.Collapsed;
-            this.tagsIcon.Tag = "";
+            this.UpdateBillableAndTags(false, string.Empty);
             this.durationLabelPanel.ToolTip = null;
             this.durationLabel.Text = "00:00:00";
         }
 
         public void SetTimeEntry(Toggl.TogglTimeEntryView item)
         {
-            this.billableIcon.ShowOnlyIf(item.Billable);
-            this.tagsIcon.ShowOnlyIf(!string.IsNullOrEmpty(item.Tags));
+            this.UpdateBillableAndTags(item.Billable, item.Tags);
             this.durationLabel.Text =
                 item.Ended > item.Started
                 ? item.Duration
@@ -54,10 +55,6 @@ namespace TogglDesktop
                 item.Ended > item.Started
                 ? item.StartTimeString + " - " + item.EndTimeString
                 : "started at " + item.StartTimeString;
-            this.tagsIcon.ToolTip =
-                string.IsNullOrEmpty(item.Tags)
-                ? null
-                : item.Tags.Replace(Toggl.TagSeparator, " • ");
         }
 
         public void SetDurationLabel(string s)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TrayToolTipControl.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TrayToolTipControl.xaml
@@ -5,9 +5,10 @@
              Background="{DynamicResource Toggl.CardBackground}"
              BorderThickness="1"
              BorderBrush="{DynamicResource Toggl.TextBox.Border}"
-             Width="300"
+             MaxWidth="384"
+             MinWidth="144"
              x:Name="me" x:FieldModifier="private">
-    <Grid Margin="16 8 8 8">
+    <Grid Margin="16 8 12 8">
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition />
@@ -22,6 +23,7 @@
                               Grid.ColumnSpan="2"
                               Grid.Row="0"
                               Margin="0 0 8 0"
+                              Width="320"
                               VerticalPadding="1"
                               CompactDescription="True"
                               Visibility="{Binding ElementName=me, Path=IsTracking, Converter={StaticResource BooleanToVisibilityConverter}}"/>
@@ -33,17 +35,18 @@
                                          Visibility="{Binding ElementName=me, Path=IsTracking, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
         <Separator Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                   Margin="-4 8 0 8"
+                   Margin="-4 8 -4 8"
                    Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}"
                    Visibility="{Binding ElementName=me, Path=IsTracking, Converter={StaticResource BooleanToVisibilityConverter}}" />
         <TextBlock Grid.Row="2" Grid.Column="0"
+                   Margin="0 0 8 0"
                    Style="{StaticResource Toggl.BaseText}"
                    Text="Today" />
         <TextBlock Grid.Row="2" Grid.Column="1"
                    Margin="4 0 0 0"
                    Style="{StaticResource Toggl.CaptionSemiBoldText}"
                    VerticalAlignment="Center"
-                   HorizontalAlignment="Center"
+                   HorizontalAlignment="Right"
                    Text="{Binding ElementName=me, Path=TotalToday}" />
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TrayToolTipControl.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TrayToolTipControl.xaml
@@ -1,69 +1,49 @@
 <UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:converters="clr-namespace:TogglDesktop.Converters"
+             xmlns:togglDesktop="clr-namespace:TogglDesktop"
              x:Class="TogglDesktop.TrayToolTipControl"
-             Background="White"
+             Background="{DynamicResource Toggl.CardBackground}"
+             BorderThickness="1"
+             BorderBrush="{DynamicResource Toggl.TextBox.Border}"
+             Width="300"
              x:Name="me" x:FieldModifier="private">
-    <UserControl.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-    </UserControl.Resources>
     <Grid Margin="16 8 8 8">
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition />
             <RowDefinition />
-            <RowDefinition />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="72" />
         </Grid.ColumnDefinitions>
-        <TextBlock Grid.Row="0" Grid.Column="0"
-                   Margin="0 0 8 0"
-                   MaxWidth="280"
-                   FontSize="14"
-                   Foreground="Black"
-                   Text="{Binding ElementName=me, Path=Description}"
-                   TextTrimming="CharacterEllipsis"
-                   VerticalAlignment="Center"
-                   Visibility="{Binding ElementName=me, Path=Description, Converter={StaticResource EmptyStringToCollapsedConverter}}"/>
-        <StackPanel Grid.Row="1" Grid.Column="0"
-                    Margin="0 6 8 0"
-                    MaxWidth="280"
-                    Orientation="Horizontal"
-                    Visibility="{Binding ElementName=me, Path=ProjectAndTask, Converter={StaticResource EmptyStringToCollapsedConverter}}">
-            <TextBlock FontSize="12"
-                       Foreground="{Binding ElementName=me, Path=ProjectColor}"
-                       Text="{Binding ElementName=me, Path=ProjectAndTask}"
-                       TextTrimming="CharacterEllipsis" />
-            <TextBlock FontSize="12"
-                       Foreground="#555555"
-                       Text="{Binding ElementName=me, Path=Client}"
-                       Visibility="{Binding ElementName=me, Path=Client, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
-        </StackPanel>
-        <TextBlock Grid.Row="0" Grid.Column="1" Grid.RowSpan="2"
-                   VerticalAlignment="Center"
-                   HorizontalAlignment="Center"
-                   FontSize="14"
-                   Foreground="Black"
-                   FontWeight="SemiBold"
-                   Text="{Binding ElementName=me, Path=RunningEntryDuration}"
-                   Visibility="{Binding ElementName=me, Path=IsTracking, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-        <Separator Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+
+        <togglDesktop:TimeEntryLabel x:Name="timeEntryLabel" x:FieldModifier="private"
+                              Grid.ColumnSpan="2"
+                              Grid.Row="0"
+                              Margin="0 0 8 0"
+                              VerticalPadding="1"
+                              CompactDescription="True"
+                              Visibility="{Binding ElementName=me, Path=IsTracking, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+        <togglDesktop:TimeEntryInfoPanel x:Name="RunningEntryInfoPanel"
+                                         Grid.Row="0" Grid.Column="1"
+                                         DurationTextBlockStyle="{StaticResource Toggl.BaseText}"
+                                         Background="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=Background}"
+                                         Visibility="{Binding ElementName=me, Path=IsTracking, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+        <Separator Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
                    Margin="-4 8 0 8"
                    Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}"
                    Visibility="{Binding ElementName=me, Path=IsTracking, Converter={StaticResource BooleanToVisibilityConverter}}" />
-        <TextBlock Grid.Row="3" Grid.Column="0"
-                   FontSize="14"
-                   Foreground="Black"
-                   FontWeight="SemiBold"
+        <TextBlock Grid.Row="2" Grid.Column="0"
+                   Style="{StaticResource Toggl.BaseText}"
                    Text="Today" />
-        <TextBlock Grid.Row="3" Grid.Column="1"
+        <TextBlock Grid.Row="2" Grid.Column="1"
+                   Margin="4 0 0 0"
+                   Style="{StaticResource Toggl.CaptionSemiBoldText}"
                    VerticalAlignment="Center"
                    HorizontalAlignment="Center"
-                   FontSize="12"
-                   Foreground="Black"
-                   FontWeight="SemiBold"
                    Text="{Binding ElementName=me, Path=TotalToday}" />
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TrayToolTipControl.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TrayToolTipControl.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
 {
@@ -7,51 +8,18 @@ namespace TogglDesktop
         public TrayToolTipControl()
         {
             InitializeComponent();
+            TimeEntryLabel.ShowAddDetailsLabels = false;
         }
 
-        public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register(
-            "Description", typeof(string), typeof(TrayToolTipControl), new PropertyMetadata(default(string)));
-
-        public string Description
-        {
-            get { return (string) GetValue(DescriptionProperty); }
-            set { SetValue(DescriptionProperty, value); }
-        }
-
-        public static readonly DependencyProperty ProjectColorProperty = DependencyProperty.Register(
-            "ProjectColor", typeof(string), typeof(TrayToolTipControl), new PropertyMetadata(default(string)));
-
-        public string ProjectColor
-        {
-            get { return (string) GetValue(ProjectColorProperty); }
-            set { SetValue(ProjectColorProperty, value); }
-        }
+        public TimeEntryLabelViewModel TimeEntryLabel => timeEntryLabel.ViewModel;
 
         public static readonly DependencyProperty TotalTodayProperty = DependencyProperty.Register(
             "TotalToday", typeof(string), typeof(TrayToolTipControl), new PropertyMetadata(default(string)));
-
-        public static readonly DependencyProperty ProjectAndTaskProperty = DependencyProperty.Register(
-            "ProjectAndTask", typeof(string), typeof(TrayToolTipControl), new PropertyMetadata(default(string)));
-
-        public string ProjectAndTask
-        {
-            get { return (string) GetValue(ProjectAndTaskProperty); }
-            set { SetValue(ProjectAndTaskProperty, value); }
-        }
 
         public string TotalToday
         {
             get { return (string) GetValue(TotalTodayProperty); }
             set { SetValue(TotalTodayProperty, value); }
-        }
-
-        public static readonly DependencyProperty RunningEntryDurationProperty = DependencyProperty.Register(
-            "RunningEntryDuration", typeof(string), typeof(TrayToolTipControl), new PropertyMetadata("0 h 00 min"));
-
-        public string RunningEntryDuration
-        {
-            get { return (string) GetValue(RunningEntryDurationProperty); }
-            set { SetValue(RunningEntryDurationProperty, value); }
         }
 
         public static readonly DependencyProperty IsTrackingProperty = DependencyProperty.Register(
@@ -61,15 +29,6 @@ namespace TogglDesktop
         {
             get { return (bool) GetValue(IsTrackingProperty); }
             set { SetValue(IsTrackingProperty, value); }
-        }
-
-        public static readonly DependencyProperty ClientProperty = DependencyProperty.Register(
-            "Client", typeof(string), typeof(TrayToolTipControl), new PropertyMetadata(default(string)));
-
-        public string Client
-        {
-            get { return (string) GetValue(ClientProperty); }
-            set { SetValue(ClientProperty, value); }
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
@@ -163,7 +163,7 @@ namespace TogglDesktop
             this.editProjectPanel.ShowOnlyIf(item.ProjectID != 0);
             this.editModeProjectLabel.ViewModel.SetProject(item);
 
-            this.runningEntryInfoPanel.OnConfirmCompletion(item);
+            this.runningEntryInfoPanel.UpdateBillableAndTags(item.Billable, item.Tags);
         }
 
         private void cancelProjectSelectionButtonClick(object sender, RoutedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -424,12 +424,17 @@ namespace TogglDesktop
             if (open || userID == 0)
             {
                 this.emailAddressMenuText.Text = "Logged out";
-                // TODO: update tray tooltip with logged out text
+                this.taskbarIcon.TrayToolTip = null;
+                this.taskbarIcon.ToolTipText = "Toggl - Logged out";
+                this.SetMiniTimerVisible(false);
             }
             else
             {
                 this.emailAddressMenuText.Text = Toggl.UserEmail();
+                this.taskbarIcon.TrayToolTip = trayToolTip;
+                this.taskbarIcon.ToolTipText = $"Toggl - Logged in as {Toggl.UserEmail()}";
             }
+
             this.updateTracking(null);
         }
 
@@ -612,10 +617,6 @@ namespace TogglDesktop
         private void updateTaskbarTooltip(object sender, string s)
         {
             this.trayToolTip.RunningEntryInfoPanel.SetDurationLabel(s);
-
-            // ToolTipText is required to be non-empty in order for trayToolTip to show up
-            // this is actually supposed to be shown only on very old systems (pre-Vista)
-            this.taskbarIcon.ToolTipText = $"Total today: {this.trayToolTip.TotalToday}";
         }
 
         #endregion
@@ -829,7 +830,6 @@ namespace TogglDesktop
                 this.trayToolTip.RunningEntryInfoPanel.ResetUIState(false);
                 this.runningMenuText.Text = "Timer is not tracking";
                 this.Title = "Toggl Desktop";
-                this.taskbarIcon.ToolTipText = "Total today: " + this.trayToolTip.TotalToday;
             }
 
             this.updateStatusIcons(true);


### PR DESCRIPTION
### 📒 Description
UI update for the tray icon tooltip

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Implemented new design for the tray icon tooltip inspired by the mini timer design
- [x] Added tags and billable icon to the tray icon tooltip
- [x] Added grayish 1px border to the tray icon tooltip
- [x] When the user is logged out, show simple "Toggl - Logged out" tooltip
- [x] When the user is logged out, make sure the mini timer is not shown

### 👫 Relationships
Closes #3556 

### 🔎 Review hints
- Check out the tray icon tooltip and make sure it looks good and supports both Light and Dark modes.
- Check out the following states: time entry running, time entry stopped, user logged out