### PR TITLE
Create Empty TE without stopping the current running TE

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2751,7 +2751,8 @@ TimeEntry *Context::Start(
     const std::string tags,
     const bool prevent_on_app,
     const time_t started,
-    const time_t ended) {
+    const time_t ended,
+    const bool stop_current_running) {
 
     // Do not even allow to add new time entries,
     // else they will linger around in the app
@@ -2792,7 +2793,8 @@ TimeEntry *Context::Start(
                           project_guid,
                           tags,
                           started,
-                          ended);
+                          ended,
+                          stop_current_running);
     }
 
     error err = save(true);
@@ -4487,7 +4489,8 @@ void Context::displayPomodoro() {
                                              "",  // project_guid
                                              "pomodoro-break",
                                              0,
-                                             0);  // tags
+                                             0,
+                                             true);  // tags
 
         // Set workspace id to same as the previous entry
         pomodoro_break_entry_->SetWID(wid);

--- a/src/context.h
+++ b/src/context.h
@@ -331,7 +331,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const std::string tags,
         const bool prevent_on_app,
         const time_t started,
-        const time_t ended);
+        const time_t ended,
+        const bool stop_current_running);
 
     TimeEntry *ContinueLatest(const bool prevent_on_app);
 

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -653,7 +653,7 @@ TEST(User, TestStartTimeEntryWithDuration) {
 
     size_t count = user.related.TimeEntries.size();
 
-    user.Start("Old work", "1 hour", 0, 0, "", "", 0, 0);
+    user.Start("Old work", "1 hour", 0, 0, "", "", 0, 0, true);
 
     ASSERT_EQ(count + 1, user.related.TimeEntries.size());
 
@@ -669,7 +669,7 @@ TEST(User, TestStartTimeEntryWithoutDuration) {
     ASSERT_EQ(noError,
               user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
 
-    user.Start("Old work", "", 0, 0, "", "", 0, 0);
+    user.Start("Old work", "", 0, 0, "", "", 0, 0, true);
 
     TimeEntry *te = user.RunningTimeEntry();
     ASSERT_TRUE(te);
@@ -684,7 +684,7 @@ TEST(User, TestDeletionSteps) {
               user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
 
     // first, mark time entry as deleted
-    user.Start("My new time entry", "", 0, 0, "", "", 0, 0);
+    user.Start("My new time entry", "", 0, 0, "", "", 0, 0, true);
     TimeEntry *te = user.RunningTimeEntry();
     ASSERT_TRUE(te);
     std::vector<ModelChange> changes;

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -641,7 +641,8 @@ char_t *toggl_start(
         tag_list,
         prevent_on_app,
         started,
-        ended);
+        ended,
+        true);
     if (te) {
         return copy_string(te->GUID());
     }

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -649,6 +649,26 @@ char_t *toggl_start(
     return nullptr;
 }
 
+char_t *toggl_create_empty_time_entry(
+                                      void *context,
+                                      const uint64_t started,
+                                      const uint64_t ended) {
+    toggl::TimeEntry *te = app(context)->Start("",
+                                               "",
+                                               0,
+                                               0,
+                                               "",
+                                               "",
+                                               false,
+                                               started,
+                                               ended,
+                                               false);
+    if (te) {
+        return copy_string(te->GUID());
+    }
+    return nullptr;
+}
+
 bool_t toggl_continue(
     void *context,
     const char_t *guid) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -919,6 +919,12 @@ TOGGL_EXPORT bool_t toggl_set_time_entry_start_timestamp_with_option(
         const uint64_t started,
         const uint64_t ended);
 
+    // Create an Empty Time Entry without stopping the running TE
+    TOGGL_EXPORT char_t *toggl_create_empty_time_entry(
+        void *context,
+        const uint64_t started,
+        const uint64_t ended);
+
     // returns GUID of the new project. you must free() the result
     TOGGL_EXPORT char_t *toggl_add_project(
         void *context,

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -84,7 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)timelineGetCurrentDate;
 
-- (NSString *_Nullable)starNewTimeEntryAtStarted:(NSTimeInterval)started ended:(NSTimeInterval)ended;
+- (NSString *_Nullable)startNewTimeEntryAtStarted:(NSTimeInterval)started ended:(NSTimeInterval)ended;
+
+- (NSString *_Nullable)createEmptyTimeEntryAtStarted:(NSTimeInterval)started ended:(NSTimeInterval)ended;
 
 - (void)startEditorAtGUID:(NSString *)GUID;
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -264,7 +264,7 @@ void *ctx;
 	toggl_view_timeline_current_day(ctx);
 }
 
-- (NSString *)starNewTimeEntryAtStarted:(NSTimeInterval)started ended:(NSTimeInterval)ended
+- (NSString *)startNewTimeEntryAtStarted:(NSTimeInterval)started ended:(NSTimeInterval)ended
 {
 	char *guid = toggl_start(ctx,
 							 "",
@@ -281,6 +281,15 @@ void *ctx;
 
 	free(guid);
 	return GUID;
+}
+
+- (NSString *)createEmptyTimeEntryAtStarted:(NSTimeInterval)started ended:(NSTimeInterval)ended
+{
+    char *guid = toggl_create_empty_time_entry(ctx, started, ended);
+    NSString *GUID = [NSString stringWithUTF8String:guid];
+
+    free(guid);
+    return GUID;
 }
 
 - (void)startEditorAtGUID:(NSString *)GUID

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -203,7 +203,7 @@ final class TimelineData {
         // Start a running TE if the TE is today
         if timeEntry.isToday() {
             let startTime = timeEntry.end + 1
-            guard let guid = DesktopLibraryBridge.shared().starNewTimeEntry(atStarted: 0, ended: 0) else { return }
+            guard let guid = DesktopLibraryBridge.shared().startNewTimeEntry(atStarted: 0, ended: 0) else { return }
 
             // Only set start time if it's not the future
             // Otherwise, the library code gets buggy

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -453,7 +453,7 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
 
     func startNewTimeEntry(at started: TimeInterval, ended: TimeInterval) {
         guard !editorPopover.isShown else { return }
-        guard let guid = DesktopLibraryBridge.shared().starNewTimeEntry(atStarted: started, ended: ended) else { return }
+        guard let guid = DesktopLibraryBridge.shared().createEmptyTimeEntry(atStarted: started, ended: ended) else { return }
         self.showEditorForTimeEntry(with: guid)
     }
 

--- a/src/user.cc
+++ b/src/user.cc
@@ -163,9 +163,12 @@ TimeEntry *User::Start(
     const std::string project_guid,
     const std::string tags,
     const time_t started,
-    const time_t ended) {
+    const time_t ended,
+    const bool stop_current_running) {
 
-    Stop();
+    if (stop_current_running) {
+        Stop();
+    }
 
     time_t now = time(nullptr);
 

--- a/src/user.h
+++ b/src/user.h
@@ -65,7 +65,8 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         const std::string project_guid,
         const std::string tags,
         const time_t started,
-        const time_t ended);
+        const time_t ended,
+        const bool stop_current_running);
 
     TimeEntry *Continue(
         const std::string &GUID,


### PR DESCRIPTION
### 📒 Description
This PR would introduce a method to create a TE without stopping the running TE. It's essential to avoid stopping when clicking on the Timeline

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Introduce a method in lib to create a TE
- [x] Add optional param on -start to prevent stopping the running TE if need

### 👫 Relationships
Closes  #3827

### 🔎 Review hints
1. Try to start or continue a TE in List
Verify that:
- The current running TE is stopped
- A new TE is starting (normal behavior)
2. Start an TE
3. Click on the Empty space of Timeline View
Verify that:
- The running TE is not stopped 
- A new Empty TE is created and able to edit

