### PR TITLE
Ease of project creation by keyboard

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/ProjectDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/ProjectDataSource.swift
@@ -65,6 +65,15 @@ final class ProjectDataSource: AutoCompleteViewDataSource {
                            forIdentifier: Constants.WorkspaceCell)
     }
 
+    override func selectRow(at index: Int) {
+        if tableView.selectedRow == -1 && items.isEmpty {
+            // Open the New Project view
+            textField.didTapOnCreateButton()
+        } else {
+            super.selectRow(at: index)
+        }
+    }
+
     override func filter(with text: String) {
 
         // show all

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -408,6 +408,21 @@ extension ProjectCreationView: NSTextFieldDelegate {
             return true
         }
 
+        // Enter
+        // Easy to create a new project by pressing Enter Twice
+        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+
+            if isValidDataForProjectCreation && (control == projectTextField || control == workspaceAutoComplete || control == clientAutoComplete) {
+
+                // Make sure that the user is selected all text
+                if let selectedRange = control.currentEditor()?.selectedRange,
+                    selectedRange.length == control.stringValue.count {
+                    addBtnOnTap(self)
+                    return true
+                }
+            }
+        }
+
         return false
     }
 }


### PR DESCRIPTION
### 📒 Description
Currently, the user could create a project by focusing on the Create project and Add buttons (By Tab button), but it's cumbersome.

This PR improves how the user could create a new project by pressing Enter.

### 🕶️ Types of changes
**Improvement** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Enter to open the Project Creation view if there are no matched project
- [x] Enter to create new project (if the text is full selection and valid to create)

### 👫 Relationships
Closes #3840

### 🔎 Review hints
1. Open the Editor for any TE
2. Tap to focus on Project Text Field
3. Search some existing projects. Verify
- Able to select navigate the Project suggestion by arrow 
- Able to select by pressing Enter (current behavior)
4. Try different project name and make sure there are no project suggestion and hit **Enter**. Verify:
- The Project Creation is opened.
5. When the project creation is opened and we're focusing on Project Text field, Workspace. Verify:
- Able to create new project by pressing Enter. (Please note the the first Enter will select all text (Normal behavior of UIKit), and the second Enter will create a project)
- If the workspace is absent -> Unable to create the project by enter

### GIF
https://www.dropbox.com/s/sojbc2isf6n0mzr/2020-02-21%2015.23.18.gif?dl=0


