### PR TITLE
Re-select the last workspace in Project Creation view (mac)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -6052,4 +6052,8 @@ void Context::TrackInAppMessage(const Poco::Int64 type) {
     }
 }
 
+Poco::UInt64 Context::GetDefaultWorkspaceID() {
+    return user_->DefaultWID();
+}
+
 }  // namespace toggl

--- a/src/context.h
+++ b/src/context.h
@@ -523,6 +523,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     void TrackInAppMessage(const Poco::Int64 type);
 
+    Poco::UInt64 GetDefaultWorkspaceID();
+
  protected:
     void uiUpdaterActivity();
     void checkReminders();

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1499,3 +1499,8 @@ char_t *toggl_format_duration_time(void *context,
                           const uint64_t timestamp) {
     return copy_string(toggl::Formatter::FormatDurationForDateHeader(timestamp));
 }
+
+uint64_t toggl_get_default_workspace_id(
+    void *context) {
+    return app(context)->GetDefaultWorkspaceID();
+}

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1141,6 +1141,9 @@ TOGGL_EXPORT bool_t toggl_set_time_entry_start_timestamp_with_option(
         void *context,
         const uint64_t timestamp);
 
+TOGGL_EXPORT uint64_t toggl_get_default_workspace_id(
+        void *context);
+
 #undef TOGGL_EXPORT
 
 #ifdef __cplusplus

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -92,6 +92,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGSize)getEditorWindowSize;
 
+- (UInt64) defaultWorkspaceID;
+
 #pragma mark - Editor
 
 - (void)loadMoreTimeEntry;

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -369,4 +369,9 @@ void *ctx;
     }
     return nil;
 }
+
+- (UInt64) defaultWorkspaceID
+{
+    return toggl_get_default_workspace_id(ctx);
+}
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -54,6 +54,7 @@ final class ProjectCreationView: NSView {
             resetViews()
         }
     }
+    private var lastWorkspaceID: UInt64?
     private(set) var selectedWorkspace: Workspace? {
         didSet {
             clientDatasource.selectedWorkspace = selectedWorkspace
@@ -129,6 +130,7 @@ final class ProjectCreationView: NSView {
         projectTextField.stringValue = title
         window?.makeFirstResponder(projectTextField)
         updateLayoutState()
+        selectLastWorkspaceItem()
     }
 
     @IBAction func cancelBtnOnTap(_ sender: Any) {
@@ -160,6 +162,7 @@ final class ProjectCreationView: NSView {
         let clientGUID = clientData.1
         let projectName = projectTextField.stringValue
         let colorHex = selectedColor.colorHex
+        lastWorkspaceID = workspaceID
 
         let projectGUID = DesktopLibraryBridge.shared().createProject(withTimeEntryGUID: timeEntryGUID,
                                                                     workspaceID: workspaceID,
@@ -327,6 +330,16 @@ extension ProjectCreationView {
         colorPickerView.setColorWheelHidden(!isPremiumWorkspace)
         if displayMode != .normal {
             displayMode = isPremiumWorkspace ? .fullColorPicker : .compactColorPicker
+        }
+    }
+
+    private func selectLastWorkspaceItem() {
+        guard let lastWorkspaceID = lastWorkspaceID else { return }
+        guard let workspaces = workspaceDatasource.items as? [Workspace] else { return }
+        let index = workspaces.firstIndex(where: { $0.ID == lastWorkspaceID })
+
+        if let index = index {
+            workspaceDatasource.selectRow(at: index)
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -54,7 +54,7 @@ final class ProjectCreationView: NSView {
             resetViews()
         }
     }
-    private var lastWorkspaceID: UInt64?
+    private lazy var lastWorkspaceID: UInt64? = DesktopLibraryBridge.shared().defaultWorkspaceID()
     private(set) var selectedWorkspace: Workspace? {
         didSet {
             clientDatasource.selectedWorkspace = selectedWorkspace
@@ -336,7 +336,7 @@ extension ProjectCreationView {
     private func selectLastWorkspaceItem() {
         guard let lastWorkspaceID = lastWorkspaceID else { return }
         guard let workspaces = workspaceDatasource.items as? [Workspace] else { return }
-        let index = workspaces.firstIndex(where: { $0.ID == lastWorkspaceID })
+        let index = workspaces.firstIndex(where: { $0.WID == lastWorkspaceID })
 
         if let index = index {
             workspaceDatasource.selectRow(at: index)


### PR DESCRIPTION
### 📒 Description
Same the title 🤚 
As there is no knowledge about the default workspace, so the solution could be that we re-select the last workspace selection.

### 🕶️ Types of changes
 **Improvement** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Save the last Workspace ID and re-select if need

### 👫 Relationships
Closes #3841

### 🔎 Review hints
1. Open Project Creation view. Verify
- The default workspace is correct (Compare with the web) 
2. Select any workspace
3. Click add to create a new project
4. Open Editor again in different TE
5. Open Project Creation View. Verify:
- The Workspace is matched with the last workspace 

