### PR TITLE
Update to MahApps.Metro 2.0

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -871,7 +871,7 @@
       <Version>1.0.8</Version>
     </PackageReference>
     <PackageReference Include="MahApps.Metro">
-      <Version>1.6.5</Version>
+      <Version>2.0.0-alpha0660</Version>
     </PackageReference>
     <PackageReference Include="NHotkey.Wpf">
       <Version>1.2.1</Version>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/ActivateParentWindowOnMouseClick.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/ActivateParentWindowOnMouseClick.cs
@@ -1,6 +1,6 @@
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace TogglDesktop.Behaviors
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/CloseWindowOnEscBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/CloseWindowOnEscBehavior.cs
@@ -1,6 +1,6 @@
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace TogglDesktop.Behaviors
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/DatePickerKeyboardHandlingBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/DatePickerKeyboardHandlingBehavior.cs
@@ -1,6 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace TogglDesktop.Behaviors
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/FocusParentWindowOnClosingBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/FocusParentWindowOnClosingBehavior.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 using System.Windows;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace TogglDesktop.Behaviors
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/HideWindowOnClosingBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/HideWindowOnClosingBehavior.cs
@@ -1,8 +1,8 @@
 using System;
 using System.ComponentModel;
 using System.Windows;
-using System.Windows.Interactivity;
 using System.Windows.Threading;
+using Microsoft.Xaml.Behaviors;
 
 namespace TogglDesktop.Behaviors
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/NumericInputTextBoxBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/NumericInputTextBoxBehavior.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace TogglDesktop.Behaviors
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/RepositionPopupWithParentWindowBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/RepositionPopupWithParentWindowBehavior.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls.Primitives;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 using RoutedEventArgs = System.Windows.RoutedEventArgs;
 
 namespace TogglDesktop.Behaviors

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
@@ -220,7 +220,7 @@
                 <Setter Property="Background" Value="{DynamicResource Toggl.Button.Titlebar.MouseOver}" />
             </Trigger>
             <Trigger Property="IsPressed" Value="True">
-                <Setter Property="Background" Value="{DynamicResource Toggl.Button.Primary.PressedBackground}" />
+                <Setter Property="Background" Value="{DynamicResource Toggl.Button.Titlebar.Pressed}" />
                 <Setter Property="Foreground" Value="White" />
             </Trigger>
         </Style.Triggers>
@@ -341,5 +341,4 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ComboBox.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ComboBox.xaml
@@ -35,7 +35,7 @@
                                 FontSize="{TemplateBinding Controls:TextBoxHelper.ButtonFontSize}"
                                 Foreground="{TemplateBinding Foreground}"
                                 IsTabStop="False"
-                                Style="{DynamicResource ChromelessButtonStyle}"
+                                Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                 Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
                         <Grid x:Name="BtnArrowBackground"
                               Grid.Column="2"
@@ -69,7 +69,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MetroComboBox}">
+    <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MahApps.Styles.ComboBox}">
         <Setter Property="Padding" Value="5 3" />
         <Setter Property="Height" Value="32" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
@@ -179,7 +179,7 @@
                                      IsReadOnly="{TemplateBinding IsReadOnly}"
                                      MaxLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ComboBoxHelper.MaxLength), Mode=OneWay}"
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                     Style="{StaticResource EditableTextBoxStyle}"
+                                     Style="{StaticResource MahApps.Styles.TextBox.Editable}"
                                      Visibility="Collapsed" />
 
                             <TextBlock x:Name="PART_WatermarkMessage"
@@ -190,7 +190,7 @@
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Foreground="{TemplateBinding Foreground}"
-                                       Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
+                                       Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
@@ -198,7 +198,7 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Style="{DynamicResource FloatingMessageContainerStyle}">
+                                            Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
                                         <Binding ElementName="PART_FloatingMessage"
@@ -214,7 +214,7 @@
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Foreground="{TemplateBinding Foreground}"
-                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}"
+                                           Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
@@ -257,8 +257,8 @@
 
                         <Border x:Name="DisabledVisualElement"
                                 Grid.ColumnSpan="3"
-                                Background="{DynamicResource ControlsDisabledBrush}"
-                                BorderBrush="{DynamicResource ControlsDisabledBrush}"
+                                Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
+                                BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 IsHitTestVisible="False"
@@ -363,10 +363,10 @@
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedItem, Mode=OneWay, Converter={x:Static Converters:IsNullConverter.Instance}}" Value="False" />
                             </MultiDataTrigger.Conditions>
                             <MultiDataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
+                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ShowFloatingMessage}" />
                             </MultiDataTrigger.EnterActions>
                             <MultiDataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
+                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.HideFloatingMessage}" />
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
@@ -397,7 +397,13 @@
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
                         </Trigger>
-
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+                        </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Visibility" Value="Visible" />
                         </Trigger>
@@ -405,9 +411,23 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingStackPanel.IsVirtualizing" Value="True">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel IsItemsHost="True"
+                                                    IsVirtualizing="True"
+                                                    IsVirtualizingWhenGrouping="True"
+                                                    VirtualizationMode="Recycling" />
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
-    <Style BasedOn="{StaticResource MetroComboBoxItem}" TargetType="ComboBoxItem">
+    <Style BasedOn="{StaticResource MahApps.Styles.ComboBoxItem}" TargetType="ComboBoxItem">
         <Setter Property="Padding" Value="12,2,6,2" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ContextMenu.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ContextMenu.xaml
@@ -1,6 +1,5 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ContextMenu.xaml" />
         <ResourceDictionary Source="Typography.xaml" />
@@ -31,7 +30,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="ContextMenu" BasedOn="{StaticResource MetroContextMenu}">
+    <Style TargetType="ContextMenu" BasedOn="{StaticResource MahApps.Styles.ContextMenu}">
         <Setter Property="Background" Value="{DynamicResource Toggl.CardBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.TextBox.MouseOverBorder}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
@@ -39,7 +38,7 @@
         <Setter Property="Padding" Value="2 4 2 4" />
     </Style>
 
-    <Style TargetType="MenuItem" BasedOn="{StaticResource MetroMenuItem}">
+    <Style TargetType="MenuItem" BasedOn="{StaticResource MahApps.Styles.MenuItem}">
         <Setter Property="Background" Value="{DynamicResource Toggl.CardBackground}" />
         <Setter Property="Width" Value="280" />
         <Style.Triggers>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Controls.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Controls.xaml
@@ -4,9 +4,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Blue.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/light.blue.xaml" />
         <ResourceDictionary Source="ToolTip.xaml" />
         <ResourceDictionary Source="ErrorTemplate.xaml" />
         <ResourceDictionary Source="TextBox.xaml" />
@@ -25,5 +23,5 @@
         <ResourceDictionary Source="DatePicker.xaml" />
         <ResourceDictionary Source="Icons.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    <Style BasedOn="{StaticResource MahApps.Metro.Styles.WindowButtonCommands.Win10}" TargetType="mah:WindowButtonCommands" />
+    <Style BasedOn="{StaticResource MahApps.Styles.WindowButtonCommands.Win10}" TargetType="mah:WindowButtonCommands" />
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-                    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+                    xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
                     xmlns:behaviours="http://metro.mahapps.com/winfx/xaml/shared">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
@@ -44,7 +44,7 @@
         <Setter Property="Background" Value="{DynamicResource Toggl.SelectionElements.Background}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.TextBox.Border}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CalendarStyle" Value="{DynamicResource MahApps.Metro.Styles.BaseMetroCalendar}" />
+        <Setter Property="CalendarStyle" Value="{DynamicResource MahApps.Styles.Calendar.Base}" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource Toggl.AccentBrush}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource Toggl.TextBox.MouseOverBorder}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
@@ -119,7 +119,7 @@
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Foreground="{TemplateBinding Foreground}"
-                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}"
+                                           Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
                                            Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
                                            TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
@@ -183,17 +183,17 @@
                                 <Condition Binding="{Binding Path=(mah:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <MultiDataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
+                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ShowFloatingMessage}" />
                             </MultiDataTrigger.EnterActions>
                             <MultiDataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
+                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.HideFloatingMessage}" />
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Foreground" Value="{DynamicResource Toggl.DisabledTextBrush}" />
@@ -202,9 +202,9 @@
         </Style.Triggers>
     </Style>
 
-    <Style x:Key="MetroDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
+    <Style x:Key="MahApps.Styles.DatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
         <Setter Property="Background" Value="{DynamicResource Toggl.SelectionElements.Background}" />
-        <Setter Property="ContextMenu" Value="{DynamicResource TextBoxMetroContextMenu}" />
+        <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FontFamily" Value="{DynamicResource BaseFont}" />
@@ -290,7 +290,7 @@
                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                    Foreground="{TemplateBinding Foreground}"
-                                   Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
+                                   Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
                                    Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
                                    TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
                                    TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ErrorTemplate.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ErrorTemplate.xaml
@@ -70,7 +70,7 @@
         </Border>
     </Grid>
 
-    <ControlTemplate x:Key="ValidationErrorTemplate">
+    <ControlTemplate x:Key="MahApps.Templates.ValidationError">
         <AdornedElementPlaceholder x:Name="placeholder">
             <Grid SnapsToDevicePixels="True">
                 <Rectangle x:Name="PopupTargetElement"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ListBox.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ListBox.xaml
@@ -40,7 +40,7 @@
                                 FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
                                 Foreground="{TemplateBinding Foreground}"
                                 IsTabStop="False"
-                                Style="{DynamicResource ChromelessButtonStyle}"
+                                Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                 Visibility="{TemplateBinding mah:TextBoxHelper.ClearTextButton, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         <Grid x:Name="BtnArrowBackground"
                               Grid.Column="2"
@@ -74,7 +74,7 @@
         </Setter>
     </Style>
 
-    <Style BasedOn="{StaticResource MetroListBoxItem}" TargetType="ListBoxItem">
+    <Style BasedOn="{StaticResource MahApps.Styles.ListBoxItem}" TargetType="ListBoxItem">
         <Setter Property="Padding" Value="0" />
         <Setter Property="MinHeight" Value="0" />
         <Setter Property="Background" Value="Transparent" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/MahApps.Overrides.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/MahApps.Overrides.xaml
@@ -1,38 +1,53 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
-    <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource Toggl.AccentColor}" po:Freeze="True"/>
-    <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{DynamicResource Toggl.BlackColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource Toggl.Grayish1Color}" po:Freeze="True" />
-    <SolidColorBrush x:Key="TextBrush" Color="{DynamicResource Toggl.BlackColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="IdealForegroundColorBrush" Color="{DynamicResource Toggl.BlackColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="WindowTitleColorBrush" Color="{DynamicResource Toggl.WhiteColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="NonActiveWindowTitleColorBrush" Color="{DynamicResource Toggl.WhiteColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="ControlsDisabledBrush" Color="{DynamicResource Toggl.BlackColor}" Opacity="0.05" po:Freeze="True" />
-    <SolidColorBrush x:Key="SemiTransparentWhiteBrush" Color="{DynamicResource Toggl.Grayish2Color}" Opacity="0.5" po:Freeze="True" />
-    <system:Double x:Key="WindowTitleFontSize">12</system:Double>
+    <SolidColorBrush x:Key="MahApps.Brushes.Accent" Color="{DynamicResource Toggl.AccentColor}" po:Freeze="True"/>
+    <SolidColorBrush x:Key="MahApps.Brushes.AccentSelectedColor" Color="{DynamicResource Toggl.BlackColor}" po:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.TextBox.Border" Color="{DynamicResource Toggl.Grayish1Color}" po:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.Text" Color="{DynamicResource Toggl.BlackColor}" po:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.IdealForeground" Color="{DynamicResource Toggl.BlackColor}" po:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.WindowTitle" Color="{DynamicResource Toggl.WhiteColor}" po:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.WindowTitle.NonActive" Color="{DynamicResource Toggl.WhiteColor}" po:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.Controls.Disabled" Color="{DynamicResource Toggl.BlackColor}" Opacity="0.05" po:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.SemiTransparentWhite" Color="{DynamicResource Toggl.Grayish2Color}" Opacity="0.5" po:Freeze="True" />
 
     <!-- ToggleSwitch -->
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOverBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOver.Win10"
                      Color="{DynamicResource Toggl.GrayColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffMouseOverBorderBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.OffMouseOverBorder.Win10"
                      Color="{DynamicResource Toggl.GrayColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.OnSwitchMouseOver.Win10"
                      Color="{DynamicResource Toggl.AccentColorPlusOne}" po:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.ThumbIndicatorChecked.Win10"
                      Color="{DynamicResource Toggl.SelectionElements.BackgroundColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.PressedBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.Pressed.Win10"
                      Color="{DynamicResource Toggl.Grayish1Color}" po:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorPressedBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.ThumbIndicatorPressed.Win10"
                      Color="{DynamicResource Toggl.SelectionElements.BackgroundColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffDisabledBorderBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.OffDisabledBorder.Win10"
                      Color="{DynamicResource Toggl.LightGrayColor}" po:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchDisabledBrush.Win10"
+    <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitchButton.OnSwitchDisabled.Win10"
                      Color="{DynamicResource Toggl.LightGrayColor}" po:Freeze="True" />
 
     <!-- ContextMenu -->
-    <SolidColorBrush x:Key="MenuItemSelectionFill" Color="{DynamicResource Toggl.LightGrayColor}" po:Freeze="True"/>
-    <SolidColorBrush x:Key="MenuItemSelectionStroke" Color="{DynamicResource Toggl.LightGrayColor}" po:Freeze="True"/>
-    <SolidColorBrush x:Key="DisabledMenuItemForeground" Color="{DynamicResource Toggl.Grayish1Color}" po:Freeze="True"/>
+    <SolidColorBrush x:Key="MahApps.Brushes.MenuItem.SelectionFill" Color="{DynamicResource Toggl.LightGrayColor}" po:Freeze="True"/>
+    <SolidColorBrush x:Key="MahApps.Brushes.MenuItem.SelectionStroke" Color="{DynamicResource Toggl.LightGrayColor}" po:Freeze="True"/>
+    <SolidColorBrush x:Key="MahApps.Brushes.MenuItem.DisabledForeground" Color="{DynamicResource Toggl.Grayish1Color}" po:Freeze="True"/>
+
+    <Style x:Key="MahApps.Styles.Button.MetroWindow.Light"
+           BasedOn="{StaticResource MahApps.Styles.Button.MetroWindow.Light}"
+           TargetType="{x:Type Button}">
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource Toggl.Button.Titlebar.MouseOver}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource Toggl.Button.Titlebar.Pressed}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource Toggl.DisabledTextBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/PasswordBox.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/PasswordBox.xaml
@@ -5,7 +5,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/controls.passwordbox.xaml" />
         <ResourceDictionary Source="Typography.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    <Style TargetType="PasswordBox" BasedOn="{StaticResource MetroPasswordBox}">
+    <Style TargetType="PasswordBox" BasedOn="{StaticResource MahApps.Styles.PasswordBox}">
         <Setter Property="FontFamily" Value="{StaticResource BaseFont}" />
         <Setter Property="FontSize" Value="{StaticResource NormalFontSize}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
@@ -16,6 +16,7 @@
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource Toggl.TextBox.MouseOverBorder}" />
         <Setter Property="Padding" Value="5 3" />
         <Setter Property="Height" Value="32" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="PasswordChar" Value="*" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/TabControl.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/TabControl.xaml
@@ -6,7 +6,7 @@
         <ResourceDictionary Source="Typography.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style BasedOn="{StaticResource MetroTabControl}" TargetType="{x:Type TabControl}">
+    <Style BasedOn="{StaticResource MahApps.Styles.TabControl}" TargetType="{x:Type TabControl}">
         <Setter Property="mah:TabControlHelper.Underlined" Value="TabPanel" />
         <Setter Property="mah:TabControlHelper.UnderlineBrush" Value="Transparent" />
         <Setter Property="mah:TabControlHelper.UnderlineMouseOverBrush" Value="{DynamicResource Toggl.SecondaryTextBrush}" />
@@ -102,8 +102,8 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style BasedOn="{StaticResource MetroTabItem}" TargetType="{x:Type TabItem}">
-        <Setter Property="mah:ControlsHelper.HeaderFontSize" Value="14" />
+    <Style BasedOn="{StaticResource MahApps.Styles.TabItem}" TargetType="{x:Type TabItem}">
+        <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="14" />
         <Setter Property="FontFamily" Value="{StaticResource BaseFont}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.SecondaryTextBrush}" />
         <Setter Property="Padding" Value="0 2" />
@@ -138,11 +138,11 @@
                                                        ContentStringFormat="{TemplateBinding HeaderStringFormat}"
                                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                                       FontFamily="{TemplateBinding FontFamily}"
-                                                       FontSize="{TemplateBinding mah:ControlsHelper.HeaderFontSize}"
-                                                       FontStretch="{TemplateBinding mah:ControlsHelper.HeaderFontStretch}"
+                                                       FontFamily="{TemplateBinding mah:HeaderedControlHelper.HeaderFontFamily}"
+                                                       FontSize="{TemplateBinding mah:HeaderedControlHelper.HeaderFontSize}"
+                                                       FontStretch="{TemplateBinding mah:HeaderedControlHelper.HeaderFontStretch}"
                                                        FontStyle="{TemplateBinding FontStyle}"
-                                                       FontWeight="{TemplateBinding mah:ControlsHelper.HeaderFontWeight}"
+                                                       FontWeight="{TemplateBinding mah:HeaderedControlHelper.HeaderFontWeight}"
                                                        Foreground="{TemplateBinding Foreground}"
                                                        RecognizesAccessKey="True"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/TextBox.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/TextBox.xaml
@@ -8,14 +8,14 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TextBlock.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="MahApps.Metro.Styles.MetroWatermarkTextBlock"
-           BasedOn="{StaticResource MetroTextBlock}"
+    <Style x:Key="MahApps.Styles.TextBlock.Watermark"
+           BasedOn="{StaticResource MahApps.Styles.TextBlock}"
            TargetType="{x:Type TextBlock}">
         <Setter Property="IsHitTestVisible" Value="False" />
         <Setter Property="Opacity" Value="0.33" />
     </Style>
 
-    <Style TargetType="TextBox" BasedOn="{StaticResource MetroTextBox}">
+    <Style TargetType="TextBox" BasedOn="{StaticResource MahApps.Styles.TextBox}">
         <Setter Property="FontFamily" Value="{DynamicResource BaseFont}" />
         <Setter Property="FontSize" Value="{DynamicResource NormalFontSize}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ToggleSwitch.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ToggleSwitch.xaml
@@ -6,7 +6,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="Toggl.ToggleSwitchButton"
-           BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton.Win10}"
+           BasedOn="{StaticResource MahApps.Styles.ToggleSwitchButton.Win10}"
            TargetType="{x:Type Controls:ToggleSwitchButton}">
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.SelectionElements.Border}" />
@@ -16,7 +16,7 @@
         <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource Toggl.DisabledTextBrush}" />
     </Style>
 
-    <Style BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}"
+    <Style BasedOn="{StaticResource MahApps.Styles.ToggleSwitch.Win10}"
            TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="OffSwitchBrush" Value="{DynamicResource Toggl.SelectionElements.Background}" />
         <Setter Property="OnSwitchBrush" Value="{DynamicResource Toggl.AccentBrush}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ToolTip.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ToolTip.xaml
@@ -3,7 +3,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/controls.tooltip.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    <Style TargetType="ToolTip" BasedOn="{StaticResource MetroToolTip}">
+    <Style TargetType="ToolTip" BasedOn="{StaticResource MahApps.Styles.ToolTip}">
         <Setter Property="Background" Value="{DynamicResource Toggl.CardBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.PopupBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Dark.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Dark.xaml
@@ -101,6 +101,7 @@
     <SolidColorBrush x:Key="Toggl.ErrorMessageBackground" Color="{StaticResource Toggl.ErrorMessageBackgroundColor}" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.ErrorMessageBackground2" Color="{StaticResource Toggl.ErrorMessageBackgroundColor}" Opacity="0.8" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.Button.Titlebar.MouseOver" Color="{StaticResource Toggl.Grayish2Color}" Opacity="0.5" po:Freeze="True" />
+    <SolidColorBrush x:Key="Toggl.Button.Titlebar.Pressed" Color="{StaticResource Toggl.Grayish2Color}" Opacity="0.8" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.LoginView.Border" Color="#353535" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.Logo.Letters" Color="#FFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.TimeEntryListBackground" Color="{StaticResource Toggl.OffWhiteColor}" Opacity="0.8" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Light.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/Themes/ColorScheme/Light.xaml
@@ -100,6 +100,7 @@
     <SolidColorBrush x:Key="Toggl.ErrorMessageBackground" Color="{StaticResource Toggl.ErrorMessageBackgroundColor}" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.ErrorMessageBackground2" Color="{StaticResource Toggl.ErrorMessageBackgroundColor}" Opacity="0.8" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.Button.Titlebar.MouseOver" Color="{StaticResource Toggl.Grayish2Color}" Opacity="0.5" po:Freeze="True" />
+    <SolidColorBrush x:Key="Toggl.Button.Titlebar.Pressed" Color="{StaticResource Toggl.Grayish2Color}" Opacity="0.8" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.LoginView.Border" Color="#E5E5E5" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.Logo.Letters" Color="#424242" po:Freeze="True" />
     <SolidColorBrush x:Key="Toggl.TimeEntryListBackground" Color="{StaticResource Toggl.OffWhiteColor}" Opacity="0.8" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -7,6 +7,7 @@ using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
+using ValidationHelper = ReactiveUI.Validation.Helpers.ValidationHelper;
 
 namespace TogglDesktop.ViewModels
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -6,7 +6,7 @@
              xmlns:toggl="clr-namespace:TogglDesktop"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" MinWidth="300">
     <Grid Background="{DynamicResource Toggl.CardBackground}">
         <Grid Name="contentGrid" x:FieldModifier="private" Margin="28 20">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml
@@ -34,7 +34,7 @@
                 VerticalAlignment="Center" HorizontalAlignment="Center">
             <DockPanel>
                 <Viewbox Width="63" Height="19" DockPanel.Dock="Top" Margin="0 40 0 0">
-                    <ContentControl Content="{StaticResource Toggl.LogoSvg}" />
+                    <ContentControl Content="{StaticResource Toggl.LogoSvg}" Focusable="False" />
                 </Viewbox>
                 <StackPanel DockPanel.Dock="Bottom"
                             Orientation="Vertical"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Navigation;
 using System.Windows.Threading;
-using MahApps.Metro.Behaviours;
+using MahApps.Metro.Behaviors;
 using ReactiveUI;
 using TogglDesktop.ViewModels;
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
         mc:Ignorable="d" 
         Height="460" Width="300"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml
@@ -5,7 +5,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:toggl="clr-namespace:TogglDesktop"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
         mc:Ignorable="d"
         d:DesignWidth="400" d:DesignHeight="520"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/FeedbackWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/FeedbackWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d" 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
@@ -6,7 +6,7 @@
              xmlns:tb="http://www.hardcodet.net/taskbar"
              xmlns:toggl="clr-namespace:TogglDesktop"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              mc:Ignorable="d" 
              d:DesignWidth="400"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MessageBox.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MessageBox.xaml
@@ -4,7 +4,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+    xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
     mc:Ignorable="d" 
     MinHeight="160"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:toggl="clr-namespace:TogglDesktop"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"


### PR DESCRIPTION
### 📒 Description
Update the MahApps.Metro dependency to version 2.0.
Benefits:
- Bugfixes and updates compared to previous version 1.6.5.
- Will be easier to migrate to .NET Core 3 in the future
- #3770 does not occur if the Maximize button is not shown (and it should not be shown according to the design).

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Update to MahApps.Metro 2.0
  - [x] Update old resource names to new names
  - [x] Replace old `System.Windows.Interactivity` to newer open-source `Microsoft.Xaml.Behaviors.Wpf`
  - [x] Fix the style of titlebar buttons (hover/pressed states in particular)
  - [x] Copy the combobox virtualization fix from the MahApps.Metro (as our ComboBox template had the copy of MahApps.Metro's template with modifications)

### 👫 Relationships
Closes #3770
Point 2 of #3459

### 🔎 Review hints
- Verify #3770 does not occur when maximizing the window (double-click the titlebar)
- Click around the app to see if anything looks visually off or crashes in the runtime (I've tested it myself for a couple of hours)