### PR TITLE
FixTimeline Editor doesn't update TE data properly

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -88,6 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startEditorAtGUID:(NSString *)GUID;
 
+- (void)closeEditor;
+
 - (void)setEditorWindowSize:(CGSize)size;
 
 - (CGSize)getEditorWindowSize;

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -40,8 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 							 projectID:(uint64_t)projectID
 						   projectGUID:(NSString *)projectGUID;
 
-- (void)togglEditor;
-
 - (void)updateTimeEntryWithDescription:(NSString *)descriptionName guid:(NSString *)guid;
 
 - (void)updateTimeEntryWithTags:(NSArray<NSString *> *)tags guid:(NSString *)guid;

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -288,6 +288,11 @@ void *ctx;
 	toggl_edit(ctx, [GUID UTF8String], false, kFocusedFieldNameDescription);
 }
 
+- (void)closeEditor
+{
+    toggl_close_editor(ctx);
+}
+
 - (void)setEditorWindowSize:(CGSize)size
 {
 	toggl_set_window_edit_size_width(ctx, size.width);

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -85,11 +85,6 @@ void *ctx;
 								 [projectGUID UTF8String]);
 }
 
-- (void)togglEditor
-{
-	toggl_view_time_entry_list(ctx);
-}
-
 - (void)updateTimeEntryWithDescription:(NSString *)descriptionName guid:(NSString *)guid
 {
 	toggl_set_time_entry_description(ctx,

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -290,7 +290,7 @@ void *ctx;
 
 - (void)closeEditor
 {
-    toggl_close_editor(ctx);
+    toggl_view_time_entry_list(ctx);
 }
 
 - (void)setEditorWindowSize:(CGSize)size

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -75,7 +75,6 @@ final class TimelineDashboardViewController: NSViewController {
     private lazy var editorPopover: EditorPopover = {
         let popover = EditorPopover()
         popover.animates = false
-        popover.behavior = .transient
         popover.prepareViewController()
         popover.delegate = self
         return popover
@@ -545,6 +544,7 @@ extension TimelineDashboardViewController: NSPopoverDelegate {
             return
         }
         selectedGUID = nil
+        DesktopLibraryBridge.shared().closeEditor()
     }
 }
 

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -206,7 +206,6 @@ extern void *ctx;
 - (void)displayTimeEntryList:(DisplayCommand *)cmd
 {
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	NSLog(@"❌ TimeEntryListViewController displayTimeEntryList, Total Count %lu, show_load_more %@", (unsigned long)cmd.timeEntries.count, cmd.show_load_more ? @"YES" : @"NO");
 
 	NSArray<TimeEntryViewItem *> *newTimeEntries = [cmd.timeEntries copy];
 
@@ -285,7 +284,7 @@ extern void *ctx;
 {
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 
-	NSLog(@"TimeEntryListViewController displayTimeEntryEditor, thread %@", [NSThread currentThread]);
+	NSLog(@"✅ TimeEntryListViewController displayTimeEntryEditor, thread %@", [NSThread currentThread]);
 
     self.runningEdit = [cmd.timeEntry isRunning];
 


### PR DESCRIPTION
### 📒 Description
There are some case that the Timeline Editor doesn't update the TE properly.
**GIF**
![2020-02-25 21 01 38](https://user-images.githubusercontent.com/5878421/75253958-1ef13000-5812-11ea-8722-da969dca86d2.gif)
**How to reproduce:**
1. Open Toggl and switch to Timeline Tab
2. Click on any TE to open the Editor
3. Click again on this TE to close 
4. Click again on this TE to open the Editor
5. Try to select any TE, which has different Project
6. Observe: The Timeline Pill is updated correctly, but the Editor is not

### Problem
We don't have any method to call the Library to close the Editor in order to reset some values. Therefore, when the Timeline Editor is closed, the Library doesn't know it state. Then, at the second time, when we update the TE, the Library doesn't send the updated TE to the Editor -> Missing data

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Add close method in library and reset some values
- [x] Call Close when the Editor in Timeline is closed.
- [x] Remove some unusual log

### 👫 Relationships
Similar with user bug. Closes  #3829

### 🔎 Review hints
1. Open Timeline
2. Try to open/close the Editor
3. Select some TE and verify that:
- The Editor is updated correctly.

