### PR TITLE
Change appcast url from assets.toggl.com to github pages

### DIFF
--- a/src/ui/osx/TogglDesktop/Utils.m
+++ b/src/ui/osx/TogglDesktop/Utils.m
@@ -75,7 +75,7 @@ extern void *ctx;
 + (void)setUpdaterChannel:(NSString *)channel
 {
 #ifdef SPARKLE
-	NSString *url = [NSString stringWithFormat:@"https://assets.toggl.com/installers/darwin_%@_appcast.xml", channel];
+	NSString *url = [NSString stringWithFormat:@"https://toggl-open-source.github.io/toggldesktop/assets/releases/darwin_%@_appcast.xml", channel];
 
 	NSAssert([SUUpdater sharedUpdater], @"No updater found");
 	NSLog(@"Setting updater feed URL to %@", url);


### PR DESCRIPTION
### 📒 Description
Change appcast url from assets.toggl.com to github pages

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 👫 Relationships
Closes #1611

### 🔎 Review hints
Build a release version of the app with an older version number and make sure it can update itself. Verify the update works on all 3 channels: stable, beta, dev.