### PR TITLE
Track the usage of expand/collapse days functionality

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -6057,4 +6057,36 @@ void Context::TrackInAppMessage(const Poco::Int64 type) {
     }
 }
 
+void Context::TrackCollapseDay() {
+    if ("production" == environment_) {
+        analytics_.Track(db_->AnalyticsClientID(),
+                         "time_entry_list",
+                         "collapse_day");
+    }
+}
+
+void Context::TrackExpandDay() {
+    if ("production" == environment_) {
+        analytics_.Track(db_->AnalyticsClientID(),
+                         "time_entry_list",
+                         "expand_day");
+    }
+}
+
+void Context::TrackCollapseAllDays() {
+    if ("production" == environment_) {
+        analytics_.Track(db_->AnalyticsClientID(),
+                         "time_entry_list",
+                         "collapse_all_days");
+    }
+}
+
+void Context::TrackExpandAllDays() {
+    if ("production" == environment_) {
+        analytics_.Track(db_->AnalyticsClientID(),
+                         "time_entry_list",
+                         "expand_all_days");
+    }
+}
+
 }  // namespace toggl

--- a/src/context.h
+++ b/src/context.h
@@ -210,7 +210,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     bool GetShowTouchBar();
 
     uint8_t GetActiveTab();
-    
+
     void SetWindowMaximized(
         const bool value);
 
@@ -525,6 +525,14 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
                        const Poco::Int64 height);
 
     void TrackInAppMessage(const Poco::Int64 type);
+
+    void TrackCollapseDay();
+
+    void TrackExpandDay();
+
+    void TrackCollapseAllDays();
+
+    void TrackExpandAllDays();
 
  protected:
     void uiUpdaterActivity();

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1496,6 +1496,34 @@ void toggl_iam_click(void *context,
 }
 
 char_t *toggl_format_duration_time(void *context,
-                          const uint64_t timestamp) {
+                                   const uint64_t timestamp) {
     return copy_string(toggl::Formatter::FormatDurationForDateHeader(timestamp));
+}
+
+void track_collapse_day(void *context) {
+    if (!context) {
+        return;
+    }
+    app(context)->TrackCollapseDay();
+}
+
+void track_expand_day(void *context) {
+    if (!context) {
+        return;
+    }
+    app(context)->TrackExpandDay();
+}
+
+void track_collapse_all_days(void *context) {
+    if (!context) {
+        return;
+    }
+    app(context)->TrackCollapseAllDays();
+}
+
+void track_expand_all_days(void *context) {
+    if (!context) {
+        return;
+    }
+    app(context)->TrackExpandAllDays();
 }

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -676,7 +676,7 @@ extern "C" {
         const char_t *guid,
         const int64_t start);
 
-TOGGL_EXPORT bool_t toggl_set_time_entry_start_timestamp_with_option(
+    TOGGL_EXPORT bool_t toggl_set_time_entry_start_timestamp_with_option(
         void *context,
         const char_t *guid,
         const int64_t start,
@@ -1140,6 +1140,18 @@ TOGGL_EXPORT bool_t toggl_set_time_entry_start_timestamp_with_option(
     TOGGL_EXPORT char_t *toggl_format_duration_time(
         void *context,
         const uint64_t timestamp);
+
+    TOGGL_EXPORT void track_collapse_day(
+        void *context);
+
+    TOGGL_EXPORT void track_expand_day(
+        void *context);
+
+    TOGGL_EXPORT void track_collapse_all_days(
+        void *context);
+
+    TOGGL_EXPORT void track_expand_all_days(
+        void *context);
 
 #undef TOGGL_EXPORT
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -734,6 +734,27 @@ public static partial class Toggl
     {
         toggl_iam_click(ctx, 3);
     }
+
+    public static void TrackCollapseDay()
+    {
+        track_collapse_day(ctx);
+    }
+
+    public static void TrackExpandDay()
+    {
+        track_expand_day(ctx);
+    }
+
+    public static void TrackCollapseAllDays()
+    {
+        track_collapse_all_days(ctx);
+    }
+
+    public static void TrackExpandAllDays()
+    {
+        track_expand_all_days(ctx);
+    }
+
     #endregion
 
     #region callback events

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -1693,6 +1693,28 @@ public static partial class Toggl
         IntPtr context,
         UInt64 type);
 
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern string toggl_format_duration_time(
+        IntPtr context,
+        UInt64 timestamp);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void track_collapse_day(
+        IntPtr context);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void track_expand_day(
+        IntPtr context);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void track_collapse_all_days(
+        IntPtr context);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void track_expand_all_days(
+        IntPtr context);
+
+
 
 
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
@@ -355,14 +355,6 @@ namespace TogglDesktop
             }
         }
 
-        private bool TryExpandFocusedDay()
-        {
-            if (FocusedCellIndex >= 0) return false; // cell is selected
-            if (FocusedDayIndex < 0) return false; // nothing is selected
-            _days[FocusedDayIndex].Expand();
-            return true;
-        }
-
         private void onHighlightEdit(object sender, ExecutedRoutedEventArgs e)
         {
             if (TryExpandFocusedDay())
@@ -471,24 +463,34 @@ namespace TogglDesktop
             return true;
         }
 
+        private bool TryExpandFocusedDay()
+        {
+            if (FocusedCellIndex >= 0) return false; // cell is selected
+            if (FocusedDayIndex < 0) return false; // nothing is selected
+            _days[FocusedDayIndex].Expand();
+            Toggl.TrackExpandDay();
+            return true;
+        }
+
         private bool TryCollapseFocusedDay()
         {
             if (FocusedDayIndex < 0)
                 return false;
             _days[FocusedDayIndex].Collapse();
+            Toggl.TrackCollapseDay();
             return true;
         }
 
         public void CollapseAllDays()
         {
             _days.ForEach(day => day.Collapse());
-            Toggl.ViewTimeEntryList();
+            Toggl.TrackCollapseAllDays();
         }
 
         public void ExpandAllDays()
         {
             _days.ForEach(day => day.Expand());
-            Toggl.ViewTimeEntryList();
+            Toggl.TrackExpandAllDays();
         }
 
         private void onLoadMoreButtonClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### 📒 Description
Add Google Analytics tracking of the expand/collapse days functionality

### 🕶️ Types of changes
 - **New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3467

### 🔎 Review hints
Tracking should occur only in Release mode.

The following actions should cause analytics events:
Expand/Collapse single day by mouse click
Expand/Collapse single day by Right/Left arrow key press.
Expand/Collapse all days by right-clicking the time entry list -> context menu -> Expand/Collapse all days.
Expand/Collapse all days by Ctrl+Right/Left arrow keypress when the time entry list contains focus.