### PR TITLE
Calendar design update

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -642,6 +642,7 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="ui\Resources\DesignUpdate\Buttons.xaml" />
+    <Page Include="ui\Resources\DesignUpdate\Calendar.xaml" />
     <Page Include="ui\Resources\DesignUpdate\ComboBox.xaml" />
     <Page Include="ui\Resources\DesignUpdate\ContextMenu.xaml" />
     <Page Include="ui\Resources\DesignUpdate\Controls.xaml" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/DatePickerKeyboardHandlingBehavior.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Behaviors/DatePickerKeyboardHandlingBehavior.cs
@@ -22,6 +22,14 @@ namespace TogglDesktop.Behaviors
                     AssociatedObject.IsDropDownOpen = true;
                 }
             }
+            else if (args.Key == Key.Escape)
+            {
+                if (AssociatedObject.IsDropDownOpen == true)
+                {
+                    args.Handled = true;
+                    AssociatedObject.IsDropDownOpen = false;
+                }
+            }
 
             if (!AssociatedObject.SelectedDate.HasValue)
             {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
@@ -1,0 +1,31 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="Toggl.Calendar" TargetType="{x:Type Calendar}">
+        <Setter Property="Background" Value="{DynamicResource Toggl.CardBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource Toggl.LightGrayBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CalendarButtonStyle" Value="{DynamicResource MahApps.Styles.CalendarButton}" />
+        <Setter Property="CalendarDayButtonStyle" Value="{DynamicResource MahApps.Styles.CalendarDayButton}" />
+        <Setter Property="CalendarItemStyle" Value="{DynamicResource MahApps.Styles.CalendarItem}" />
+        <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Calendar}">
+                    <Grid x:Name="PART_Root"
+                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                          Background="Transparent">
+                        <CalendarItem x:Name="PART_CalendarItem"
+                                      Background="{TemplateBinding Background}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      Style="{TemplateBinding CalendarItemStyle}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
@@ -1,12 +1,228 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="Toggl.CalendarItem" TargetType="{x:Type CalendarItem}">
+        <Setter Property="Margin" Value="0 3" />
+        <Setter Property="Padding" Value="16" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CalendarItem}">
+                    <ControlTemplate.Resources>
+                        <!--  Used for day names  -->
+                        <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
+                            <TextBlock Margin="0 6 0 6"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       FontWeight="Bold"
+                                       Foreground="{DynamicResource MahApps.Brushes.Black}"
+                                       Opacity="0.8"
+                                       Text="{Binding}" />
+                        </DataTemplate>
+                    </ControlTemplate.Resources>
+                    <Grid x:Name="PART_Root">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid Margin="{TemplateBinding Padding}">
+                                <Grid.Resources>
+                                    <ControlTemplate x:Key="Toggl.Button.Next" TargetType="{x:Type Button}">
+                                        <Grid x:Name="background" Background="Transparent">
+                                            <Path x:Name="BtnArrow"
+                                                  Width="11"
+                                                  Height="11"
+                                                  Margin="10"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Data="F0 M 50.72,52.83 L 56,47.39 56.48,48.03 50.72,53.8 44.79,48.03 45.27,47.39 50.72,52.83 z"
+                                                  Fill="{DynamicResource Toggl.DarkGrayBrush}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                  Stretch="Uniform" />
+                                        </Grid>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="background" Property="Background" Value="{DynamicResource Toggl.Button.Outlined.HoverBackground}" />
+                                            </Trigger>
+                                            <Trigger Property="IsPressed" Value="True">
+                                                <Setter TargetName="background" Property="Background" Value="{DynamicResource Toggl.Button.Outlined.PressedBackground}" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                    <ControlTemplate x:Key="MahApps.Templates.Button.Header" TargetType="{x:Type Button}">
+                                        <Grid Cursor="Hand">
+                                            <ContentPresenter x:Name="buttonContent"
+                                                              Margin="1 4 1 9"
+                                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                              Content="{TemplateBinding Content}"
+                                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                              Opacity="0.7" />
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup x:Name="CommonStates">
+                                                    <VisualState x:Name="Normal" />
+                                                    <VisualState x:Name="MouseOver">
+                                                        <Storyboard>
+                                                            <DoubleAnimation Storyboard.TargetName="buttonContent"
+                                                                             Storyboard.TargetProperty="Opacity"
+                                                                             To="1"
+                                                                             Duration="0" />
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                    <VisualState x:Name="Disabled">
+                                                        <Storyboard>
+                                                            <DoubleAnimation Storyboard.TargetName="buttonContent"
+                                                                             Storyboard.TargetProperty="Opacity"
+                                                                             To=".5"
+                                                                             Duration="0" />
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                        </Grid>
+                                    </ControlTemplate>
+
+                                    <Style x:Key="PreviousCalendarButtonStyle" TargetType="{x:Type Button}">
+                                        <Setter Property="Template" Value="{StaticResource Toggl.Button.Next}" />
+                                        <Setter Property="LayoutTransform">
+                                            <Setter.Value>
+                                                <TransformGroup>
+                                                    <RotateTransform Angle="180" />
+                                                </TransformGroup>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Style>
+                                    <Style x:Key="NextCalendarButtonStyle" TargetType="{x:Type Button}">
+                                        <Setter Property="Template" Value="{StaticResource Toggl.Button.Next}" />
+                                    </Style>
+                                    <Style x:Key="HeaderCalendarButtonStyle" TargetType="{x:Type Button}">
+                                        <Setter Property="Template" Value="{StaticResource MahApps.Templates.Button.Header}" />
+                                    </Style>
+                                </Grid.Resources>
+
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <Grid Grid.Row="0"
+                                      HorizontalAlignment="Stretch"
+                                      Background="{DynamicResource MahApps.Brushes.Accent}">
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Focusable="False"
+                                            FontWeight="Bold"
+                                            Style="{StaticResource HeaderCalendarButtonStyle}" />
+                                    <Button x:Name="PART_PreviousButton"
+                                            Grid.Row="0"
+                                            Width="32"
+                                            Height="32"
+                                            HorizontalAlignment="Left"
+                                            Focusable="False"
+                                            Style="{StaticResource PreviousCalendarButtonStyle}" />
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0"
+                                            Width="32"
+                                            Height="32"
+                                            HorizontalAlignment="Right"
+                                            Focusable="False"
+                                            Style="{StaticResource NextCalendarButtonStyle}" />
+                                </Grid>
+                                <Grid x:Name="PART_MonthView"
+                                      Grid.Row="1"
+                                      Margin="6 -1 6 6"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
+                                      Visibility="Visible">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                </Grid>
+                                <Grid x:Name="PART_YearView"
+                                      Grid.Row="1"
+                                      Margin="6 -3 7 6"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
+                                      Visibility="Hidden">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                </Grid>
+                            </Grid>
+                        </Border>
+                        <Rectangle x:Name="PART_DisabledVisual"
+                                   Fill="{DynamicResource MahApps.Brushes.Controls.Disabled}"
+                                   Opacity="0"
+                                   Stretch="Fill"
+                                   Stroke="{DynamicResource MahApps.Brushes.Controls.Disabled}"
+                                   StrokeThickness="1"
+                                   Visibility="Collapsed" />
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="PART_DisabledVisual"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="1"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="PART_DisabledVisual" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}" Value="Year">
+                            <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
+                            <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}" Value="Decade">
+                            <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
+                            <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="Toggl.Calendar" TargetType="{x:Type Calendar}">
         <Setter Property="Background" Value="{DynamicResource Toggl.CardBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.LightGrayBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CalendarButtonStyle" Value="{DynamicResource MahApps.Styles.CalendarButton}" />
         <Setter Property="CalendarDayButtonStyle" Value="{DynamicResource MahApps.Styles.CalendarDayButton}" />
-        <Setter Property="CalendarItemStyle" Value="{DynamicResource MahApps.Styles.CalendarItem}" />
+        <Setter Property="CalendarItemStyle" Value="{DynamicResource Toggl.CalendarItem}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -27,5 +243,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
@@ -10,12 +10,10 @@
                     <ControlTemplate.Resources>
                         <!--  Used for day names  -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
-                            <TextBlock Margin="0 6 0 6"
+                            <TextBlock Margin="0 7 0 9"
+                                       Style="{DynamicResource Toggl.CaptionGrayishText}"
                                        HorizontalAlignment="Center"
                                        VerticalAlignment="Center"
-                                       FontWeight="Bold"
-                                       Foreground="{DynamicResource MahApps.Brushes.Black}"
-                                       Opacity="0.8"
                                        Text="{Binding}" />
                         </DataTemplate>
                     </ControlTemplate.Resources>
@@ -26,7 +24,7 @@
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                             <Grid Margin="{TemplateBinding Padding}">
                                 <Grid.Resources>
-                                    <ControlTemplate x:Key="Toggl.Button.Next" TargetType="{x:Type Button}">
+                                    <ControlTemplate x:Key="Toggl.Templates.Button.Next" TargetType="{x:Type Button}">
                                         <Grid x:Name="background" Background="Transparent">
                                             <Path x:Name="BtnArrow"
                                                   Width="11"
@@ -48,41 +46,24 @@
                                             </Trigger>
                                         </ControlTemplate.Triggers>
                                     </ControlTemplate>
-                                    <ControlTemplate x:Key="MahApps.Templates.Button.Header" TargetType="{x:Type Button}">
-                                        <Grid Cursor="Hand">
-                                            <ContentPresenter x:Name="buttonContent"
-                                                              Margin="1 4 1 9"
-                                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                              Content="{TemplateBinding Content}"
-                                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                              Opacity="0.7" />
-                                            <VisualStateManager.VisualStateGroups>
-                                                <VisualStateGroup x:Name="CommonStates">
-                                                    <VisualState x:Name="Normal" />
-                                                    <VisualState x:Name="MouseOver">
-                                                        <Storyboard>
-                                                            <DoubleAnimation Storyboard.TargetName="buttonContent"
-                                                                             Storyboard.TargetProperty="Opacity"
-                                                                             To="1"
-                                                                             Duration="0" />
-                                                        </Storyboard>
-                                                    </VisualState>
-                                                    <VisualState x:Name="Disabled">
-                                                        <Storyboard>
-                                                            <DoubleAnimation Storyboard.TargetName="buttonContent"
-                                                                             Storyboard.TargetProperty="Opacity"
-                                                                             To=".5"
-                                                                             Duration="0" />
-                                                        </Storyboard>
-                                                    </VisualState>
-                                                </VisualStateGroup>
-                                            </VisualStateManager.VisualStateGroups>
+                                    <ControlTemplate x:Key="Toggl.Templates.Button.Header" TargetType="{x:Type Button}">
+                                        <Grid x:Name="background" Background="Transparent">
+                                            <TextBlock Style="{DynamicResource Toggl.SubtitleText}"
+                                                       Text="{TemplateBinding Content}"
+                                                       HorizontalAlignment="Left" />
                                         </Grid>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="background" Property="Background" Value="{DynamicResource Toggl.Button.Outlined.HoverBackground}" />
+                                            </Trigger>
+                                            <Trigger Property="IsPressed" Value="True">
+                                                <Setter TargetName="background" Property="Background" Value="{DynamicResource Toggl.Button.Outlined.PressedBackground}" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
                                     </ControlTemplate>
 
                                     <Style x:Key="PreviousCalendarButtonStyle" TargetType="{x:Type Button}">
-                                        <Setter Property="Template" Value="{StaticResource Toggl.Button.Next}" />
+                                        <Setter Property="Template" Value="{StaticResource Toggl.Templates.Button.Next}" />
                                         <Setter Property="LayoutTransform">
                                             <Setter.Value>
                                                 <TransformGroup>
@@ -92,10 +73,10 @@
                                         </Setter>
                                     </Style>
                                     <Style x:Key="NextCalendarButtonStyle" TargetType="{x:Type Button}">
-                                        <Setter Property="Template" Value="{StaticResource Toggl.Button.Next}" />
+                                        <Setter Property="Template" Value="{StaticResource Toggl.Templates.Button.Next}" />
                                     </Style>
                                     <Style x:Key="HeaderCalendarButtonStyle" TargetType="{x:Type Button}">
-                                        <Setter Property="Template" Value="{StaticResource MahApps.Templates.Button.Header}" />
+                                        <Setter Property="Template" Value="{StaticResource Toggl.Templates.Button.Header}" />
                                     </Style>
                                 </Grid.Resources>
 
@@ -108,27 +89,26 @@
                                 </Grid.RowDefinitions>
 
                                 <Grid Grid.Row="0"
-                                      HorizontalAlignment="Stretch"
-                                      Background="{DynamicResource MahApps.Brushes.Accent}">
+                                      HorizontalAlignment="Stretch">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
                                     <Button x:Name="PART_HeaderButton"
-                                            Grid.Row="0"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
+                                            Grid.Column="0"
                                             Focusable="False"
-                                            FontWeight="Bold"
                                             Style="{StaticResource HeaderCalendarButtonStyle}" />
                                     <Button x:Name="PART_PreviousButton"
-                                            Grid.Row="0"
+                                            Grid.Column="1"
                                             Width="32"
                                             Height="32"
-                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             Style="{StaticResource PreviousCalendarButtonStyle}" />
                                     <Button x:Name="PART_NextButton"
-                                            Grid.Row="0"
+                                            Grid.Column="2"
                                             Width="32"
                                             Height="32"
-                                            HorizontalAlignment="Right"
                                             Focusable="False"
                                             Style="{StaticResource NextCalendarButtonStyle}" />
                                 </Grid>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
@@ -160,6 +160,123 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
+    <Style x:Key="Toggl.CalendarButton" TargetType="{x:Type CalendarButton}">
+        <Setter Property="Background" Value="{DynamicResource Toggl.ComboBox.HighlightedBackground}" />
+        <Setter Property="FontFamily" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontFamily, Mode=OneWay}" />
+        <Setter Property="FontSize" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontSize, Mode=OneWay}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="MinHeight" Value="42" />
+        <Setter Property="MinWidth" Value="40" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CalendarButton}">
+                    <Grid>
+                        <Rectangle x:Name="SelectedBackground"
+                                   Fill="{TemplateBinding Background}"
+                                   Opacity="0" />
+                        <Rectangle x:Name="Background"
+                                   Fill="{TemplateBinding Background}"
+                                   Opacity="0" />
+                        <ContentPresenter x:Name="NormalText"
+                                          Margin="1 0 1 1"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          TextElement.Foreground="{TemplateBinding Foreground}" />
+                        <Rectangle x:Name="CalendarButtonFocusVisual"
+                                   IsHitTestVisible="false"
+                                   Stroke="{DynamicResource Toggl.SecondaryTextBrush}"
+                                   Visibility="Collapsed" />
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition GeneratedDuration="0:0:0.1" />
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="MouseOver">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Background"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To=".5"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Background"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To=".5"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="SelectionStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition GeneratedDuration="0" />
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Unselected" />
+                                <VisualState x:Name="Selected">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="SelectedBackground"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To=".75"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ActiveStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition GeneratedDuration="0" />
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Active" />
+                                <VisualState x:Name="Inactive" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="CalendarButtonFocusStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition GeneratedDuration="0" />
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="CalendarButtonFocused">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CalendarButtonFocusVisual"
+                                                                       Storyboard.TargetProperty="Visibility"
+                                                                       Duration="0">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Visible</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="CalendarButtonUnfocused">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CalendarButtonFocusVisual"
+                                                                       Storyboard.TargetProperty="Visibility"
+                                                                       Duration="0">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsInactive" Value="True">
+                            <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="{DynamicResource Toggl.DisabledTextBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter TargetName="CalendarButtonFocusVisual" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
     <Style x:Key="Toggl.CalendarItem" TargetType="{x:Type CalendarItem}">
         <Setter Property="Margin" Value="0 3" />
         <Setter Property="Padding" Value="16" />
@@ -207,7 +324,7 @@
                                         </ControlTemplate.Triggers>
                                     </ControlTemplate>
                                     <ControlTemplate x:Key="Toggl.Templates.Button.Header" TargetType="{x:Type Button}">
-                                        <Border x:Name="background" Margin="4 0" Background="Transparent">
+                                        <Border x:Name="background" Margin="4 0" Padding="4 0" Background="Transparent">
                                             <TextBlock Style="{DynamicResource Toggl.SubtitleText}"
                                                        Text="{TemplateBinding Content}"
                                                        HorizontalAlignment="Stretch" />
@@ -361,7 +478,7 @@
         <Setter Property="Background" Value="{DynamicResource Toggl.CardBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.LightGrayBrush}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CalendarButtonStyle" Value="{DynamicResource MahApps.Styles.CalendarButton}" />
+        <Setter Property="CalendarButtonStyle" Value="{DynamicResource Toggl.CalendarButton}" />
         <Setter Property="CalendarDayButtonStyle" Value="{DynamicResource Toggl.CalendarDayButton}" />
         <Setter Property="CalendarItemStyle" Value="{DynamicResource Toggl.CalendarItem}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
@@ -476,7 +476,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="Toggl.Calendar" TargetType="{x:Type Calendar}">
+    <Style x:Key="Toggl.Calendar.Base" TargetType="{x:Type Calendar}">
         <Setter Property="Background" Value="{DynamicResource Toggl.CardBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.LightGrayBrush}" />
         <Setter Property="BorderThickness" Value="1" />
@@ -486,6 +486,9 @@
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
+    </Style>
+
+    <Style x:Key="Toggl.Calendar" TargetType="{x:Type Calendar}" BasedOn="{StaticResource Toggl.Calendar.Base}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Calendar}">
@@ -503,4 +506,29 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style x:Key="Toggl.Calendar.WithShadow" TargetType="{x:Type Calendar}" BasedOn="{StaticResource Toggl.Calendar.Base}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Calendar}">
+                    <Grid x:Name="PART_Root"
+                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                          Background="Transparent">
+                        <Border Margin="8 0 8 8">
+                            <Border.Effect>
+                                <DropShadowEffect ShadowDepth="1" BlurRadius="4" Direction="270" Opacity="0.2" Color="Black" />
+                            </Border.Effect>
+                            <CalendarItem x:Name="PART_CalendarItem"
+                                          Background="{TemplateBinding Background}"
+                                          BorderBrush="{TemplateBinding BorderBrush}"
+                                          BorderThickness="{TemplateBinding BorderThickness}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{TemplateBinding CalendarItemStyle}" />
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
@@ -127,6 +127,7 @@
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="SelectedBackground" Property="Opacity" Value="1" />
                             <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="White" />
+                            <Setter TargetName="NormalText" Property="TextElement.FontWeight" Value="SemiBold" />
                         </Trigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
@@ -137,6 +138,7 @@
                             <Setter TargetName="DayButtonFocusVisual" Property="Stroke" Value="{DynamicResource Toggl.SecondaryTextBrush}" />
                             <Setter TargetName="DayButtonFocusVisual" Property="Visibility" Value="Visible" />
                             <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="White" />
+                            <Setter TargetName="NormalText" Property="TextElement.FontWeight" Value="SemiBold" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Calendar.xaml
@@ -1,5 +1,165 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="Toggl.CalendarButtonFocusVisualStyle">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border BorderThickness="1"
+                            BorderBrush="{DynamicResource Toggl.SecondaryTextBrush}">
+                        <Rectangle SnapsToDevicePixels="True"
+                                   StrokeThickness="1"
+                                   UseLayoutRounding="True">
+                            <Rectangle.Stroke>
+                                <SolidColorBrush Color="{DynamicResource Toggl.WhiteColor}" />
+                            </Rectangle.Stroke>
+                        </Rectangle>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="Toggl.CalendarDayButton" TargetType="{x:Type CalendarDayButton}">
+        <Setter Property="FontFamily" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontFamily, Mode=OneWay}" />
+        <Setter Property="FontSize" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontSize, Mode=OneWay}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="MinWidth" Value="32" />
+        <Setter Property="Margin" Value="1" />
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource Toggl.CalendarButtonFocusVisualStyle}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CalendarDayButton}">
+                    <Grid>
+                        <Rectangle x:Name="TodayBackground"
+                                   Stroke="{DynamicResource Toggl.AccentBrush}"
+                                   StrokeThickness="1"
+                                   Opacity="0" />
+                        <Rectangle x:Name="SelectedBackground"
+                                   Fill="{DynamicResource Toggl.AccentBrush}"
+                                   Opacity="0" />
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}" />
+                        <Rectangle x:Name="HighlightBackground"
+                                   Fill="{DynamicResource Toggl.PrimaryTextBrush}"
+                                   Opacity="0" />
+                        <Path x:Name="Blackout"
+                              Margin="3"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch"
+                              Data="M8.1772461,11.029181 L10.433105,11.029181 L11.700684,12.801641 L12.973633,11.029181 L15.191895,11.029181 L12.844727,13.999395 L15.21875,17.060919 L12.962891,17.060919 L11.673828,15.256231 L10.352539,17.060919 L8.1396484,17.060919 L10.519043,14.042364 z"
+                              Fill="{DynamicResource MahApps.Brushes.Accent3}"
+                              Opacity="0"
+                              RenderTransformOrigin="0.5,0.5"
+                              Stretch="Fill" />
+                        <ContentPresenter x:Name="NormalText"
+                                          Margin="5 1 5 1"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          TextElement.Foreground="{TemplateBinding Foreground}" />
+                        <Rectangle x:Name="DayButtonFocusVisual"
+                                   IsHitTestVisible="false"
+                                   Stroke="{DynamicResource Toggl.SecondaryTextBrush}"
+                                   Visibility="Collapsed" />
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition GeneratedDuration="0:0:0.1" />
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="MouseOver">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0.05"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0.15"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0"
+                                                         Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="NormalText"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To=".35"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ActiveStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition GeneratedDuration="0" />
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Active" />
+                                <VisualState x:Name="Inactive" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="BlackoutDayStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition GeneratedDuration="0" />
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="NormalDay" />
+                                <VisualState x:Name="BlackoutDay">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Blackout"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="1"
+                                                         Duration="0" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsInactive" Value="True">
+                            <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="{DynamicResource Toggl.DisabledTextBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="SelectedBackground" Property="Opacity" Value="1" />
+                            <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="White" />
+                        </Trigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="DayButtonFocusVisual" Property="Stroke" Value="{DynamicResource Toggl.SecondaryTextBrush}" />
+                            <Setter TargetName="DayButtonFocusVisual" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="White" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="TodayBackground" Property="Opacity" Value="1" />
+                        </MultiDataTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsToday" Value="True" />
+                                <Condition Property="IsBlackedOut" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Blackout" Property="Fill" Value="{DynamicResource Toggl.AccentBrush}" />
+                            <Setter TargetName="TodayBackground" Property="Opacity" Value="0.5" />
+                        </MultiTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
     <Style x:Key="Toggl.CalendarItem" TargetType="{x:Type CalendarItem}">
         <Setter Property="Margin" Value="0 3" />
         <Setter Property="Padding" Value="16" />
@@ -47,11 +207,11 @@
                                         </ControlTemplate.Triggers>
                                     </ControlTemplate>
                                     <ControlTemplate x:Key="Toggl.Templates.Button.Header" TargetType="{x:Type Button}">
-                                        <Grid x:Name="background" Background="Transparent">
+                                        <Border x:Name="background" Margin="4 0" Background="Transparent">
                                             <TextBlock Style="{DynamicResource Toggl.SubtitleText}"
                                                        Text="{TemplateBinding Content}"
-                                                       HorizontalAlignment="Left" />
-                                        </Grid>
+                                                       HorizontalAlignment="Stretch" />
+                                        </Border>
                                         <ControlTemplate.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
                                                 <Setter TargetName="background" Property="Background" Value="{DynamicResource Toggl.Button.Outlined.HoverBackground}" />
@@ -98,7 +258,8 @@
                                     <Button x:Name="PART_HeaderButton"
                                             Grid.Column="0"
                                             Focusable="False"
-                                            Style="{StaticResource HeaderCalendarButtonStyle}" />
+                                            Style="{StaticResource HeaderCalendarButtonStyle}"
+                                            HorizontalAlignment="Left"/>
                                     <Button x:Name="PART_PreviousButton"
                                             Grid.Column="1"
                                             Width="32"
@@ -114,7 +275,7 @@
                                 </Grid>
                                 <Grid x:Name="PART_MonthView"
                                       Grid.Row="1"
-                                      Margin="6 -1 6 6"
+                                      Margin="0 4 0 0"
                                       HorizontalAlignment="Stretch"
                                       VerticalAlignment="Stretch"
                                       Visibility="Visible">
@@ -139,7 +300,7 @@
                                 </Grid>
                                 <Grid x:Name="PART_YearView"
                                       Grid.Row="1"
-                                      Margin="6 -3 7 6"
+                                      Margin="0 4 0 0"
                                       HorizontalAlignment="Stretch"
                                       VerticalAlignment="Stretch"
                                       Visibility="Hidden">
@@ -201,7 +362,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.LightGrayBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CalendarButtonStyle" Value="{DynamicResource MahApps.Styles.CalendarButton}" />
-        <Setter Property="CalendarDayButtonStyle" Value="{DynamicResource MahApps.Styles.CalendarDayButton}" />
+        <Setter Property="CalendarDayButtonStyle" Value="{DynamicResource Toggl.CalendarDayButton}" />
         <Setter Property="CalendarItemStyle" Value="{DynamicResource Toggl.CalendarItem}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
@@ -45,13 +45,12 @@
         <Setter Property="Background" Value="{DynamicResource Toggl.SelectionElements.Background}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.TextBox.Border}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CalendarStyle" Value="{StaticResource Toggl.Calendar}" />
+        <Setter Property="CalendarStyle" Value="{StaticResource Toggl.Calendar.WithShadow}" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource Toggl.AccentBrush}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource Toggl.TextBox.MouseOverBorder}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
         <Setter Property="Padding" Value="5 3" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="24" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="IsTodayHighlighted" Value="True" />
@@ -147,7 +146,8 @@
                                    AllowsTransparency="True"
                                    Placement="Bottom"
                                    PlacementTarget="{Binding ElementName=PART_Root}"
-                                   StaysOpen="False" />
+                                   StaysOpen="False"
+                                   HorizontalOffset="-8"/>
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
@@ -5,6 +5,7 @@
                     xmlns:behaviours="http://metro.mahapps.com/winfx/xaml/shared">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
+        <ResourceDictionary Source="Calendar.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style TargetType="Button" x:Key="Toggl.DateIconButton">
@@ -44,7 +45,7 @@
         <Setter Property="Background" Value="{DynamicResource Toggl.SelectionElements.Background}" />
         <Setter Property="BorderBrush" Value="{DynamicResource Toggl.TextBox.Border}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CalendarStyle" Value="{DynamicResource MahApps.Styles.Calendar.Base}" />
+        <Setter Property="CalendarStyle" Value="{StaticResource Toggl.Calendar}" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource Toggl.AccentBrush}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource Toggl.TextBox.MouseOverBorder}" />
         <Setter Property="Foreground" Value="{DynamicResource Toggl.PrimaryTextBrush}" />
@@ -95,7 +96,7 @@
                                                Focusable="{TemplateBinding Focusable}"
                                                FontSize="{TemplateBinding FontSize}"
                                                Foreground="{TemplateBinding Foreground}"
-                                               SelectionBrush="{DynamicResource HighlightBrush}">
+                                               SelectionBrush="{DynamicResource MahApps.Brushes.Highlight}">
                                 <i:Interaction.Behaviors>
                                     <behaviours:DatePickerTextBoxBehavior />
                                 </i:Interaction.Behaviors>
@@ -104,7 +105,7 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Style="{DynamicResource FloatingMessageContainerStyle}">
+                                            Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{behaviours:MathMultiplyConverter}">
                                         <Binding ElementName="PART_FloatingMessage"
@@ -149,8 +150,8 @@
                                    StaysOpen="False" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
-                                Background="{DynamicResource ControlsDisabledBrush}"
-                                BorderBrush="{DynamicResource ControlsDisabledBrush}"
+                                Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
+                                BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 IsHitTestVisible="False"
                                 Opacity="0"


### PR DESCRIPTION
### 📒 Description
Implementation of the calendar UI based on the new design

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Calendar UI according to the new design
- [x] Display today's day with green border (or dark gray border if today is selected)
- [x] Update year and decade view to be consistent with the new design
- [x] Make sure Esc is properly handled -> closes only calendar and not the edit view

### 👫 Relationships
Closes #3700

### 🔎 Review hints
To show the calendar open EditView -> date field -> click date icon.

Verify that the calendar matches the design from Zeplin, with the following exceptions:
- Today's day has green border (or dark gray border if today is selected)
- Preview/Next button order is switch to correspond to the default Windows calendar