### PR TITLE
Add the ability to switch the color theme in Preferences

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -271,6 +271,11 @@ void GoogleAnalyticsSettingsEvent::runTask() {
     setActionBool("pomodoro_break-", settings.pomodoro_break);
     makeReq();
 
+    if (settings.pomodoro_break) {
+        setActionInt("pomodoro_break_minutes-", settings.pomodoro_break_minutes);
+        makeReq();
+    }
+
     setActionBool("stop_entry_on_shutdown_sleep-", settings.stop_entry_on_shutdown_sleep);
     makeReq();
 
@@ -280,11 +285,8 @@ void GoogleAnalyticsSettingsEvent::runTask() {
     setActionBool("active_tab-", settings.active_tab);
     makeReq();
 
-    if (settings.pomodoro_break) {
-        setActionInt("pomodoro_break_minutes-",
-                     settings.pomodoro_break_minutes);
-        makeReq();
-    }
+    setActionInt("color_theme-", settings.color_theme);
+    makeReq();
 }
 
 void GoogleAnalyticsSettingsEvent::setActionBool(const std::string &type, bool value) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -2038,6 +2038,11 @@ error Context::SetSettingsActiveTab(const uint8_t active_tab) {
         db()->SetSettingsActiveTab(active_tab));
 }
 
+error Context::SetSettingsColorTheme(const uint8_t color_theme) {
+    return applySettingsSaveResultToUI(
+        db()->SetSettingsColorTheme(color_theme));
+}
+
 error Context::SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes) {
     return applySettingsSaveResultToUI(
         db()->SetSettingsIdleMinutes(idle_minutes));

--- a/src/context.h
+++ b/src/context.h
@@ -169,6 +169,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error SetSettingsActiveTab(const uint8_t active_tab);
 
+    error SetSettingsColorTheme(const uint8_t color_theme);
+
     error SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes);
 
     error SetSettingsFocusOnShortcut(const bool focus_on_shortcut);

--- a/src/database.cc
+++ b/src/database.cc
@@ -430,7 +430,7 @@ error Database::LoadSettings(Settings *settings) {
                   "remind_fri, remind_sat, remind_sun, autotrack, "
                   "open_editor_on_shortcut, has_seen_beta_offering, "
                   "pomodoro, pomodoro_minutes, "
-                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep, show_touch_bar, active_tab "
+                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep, show_touch_bar, active_tab, color_theme "
                   "from settings "
                   "limit 1",
                   into(settings->use_idle_detection),
@@ -463,6 +463,7 @@ error Database::LoadSettings(Settings *settings) {
                   into(settings->stop_entry_on_shutdown_sleep),
                   into(settings->show_touch_bar),
                   into(settings->active_tab),
+                  into(settings->color_theme),
                   limit(1),
                   now;
     } catch(const Poco::Exception& exc) {
@@ -860,6 +861,10 @@ error Database::SetSettingsShowTouchBar(const bool &show_touch_bar) {
 
 error Database::SetSettingsActiveTab(const uint8_t &active_tab) {
     return setSettingsValue("active_tab", active_tab);
+}
+
+error Database::SetSettingsColorTheme(const uint8_t &color_theme) {
+    return setSettingsValue("color_theme", color_theme);
 }
 
 template<typename T>

--- a/src/database.h
+++ b/src/database.h
@@ -130,6 +130,8 @@ class TOGGL_INTERNAL_EXPORT Database {
 
     error SetSettingsActiveTab(const uint8_t &active_tab);
 
+    error SetSettingsColorTheme(const uint8_t &color_theme);
+
     error SetSettingsRemindTimes(
         const std::string &remind_starts,
         const std::string &remind_ends);

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -1313,6 +1313,14 @@ error Migrations::migrateSettings() {
         return err;
     }
 
+    err = db_->Migrate(
+        "settings.color_theme",
+        "ALTER TABLE settings "
+        "ADD COLUMN color_theme INTEGER NOT NULL DEFAULT 0;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/script/generate_cs_api.go
+++ b/src/script/generate_cs_api.go
@@ -27,6 +27,9 @@ func convert(s string, public bool) string {
 	if strings.Contains(s, "int64_t") {
 		return visibility + strings.Replace(s, "int64_t", "Int64", -1)
 	}
+	if strings.Contains(s, "uint8_t") {
+		return visibility + strings.Replace(s, "uint8_t", "byte", -1)
+	}
 	if strings.Contains(s, "void *") {
 		return visibility + strings.Replace(s, "void *", "IntPtr ", -1)
 	}

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -38,6 +38,7 @@ Json::Value Settings::SaveToJSON() const {
     json["stop_entry_on_shutdown_sleep"] = stop_entry_on_shutdown_sleep;
     json["show_touch_bar"] = show_touch_bar;
     json["active_tab"] = active_tab;
+    json["color_theme"] = color_theme;
     return json;
 }
 
@@ -73,7 +74,8 @@ std::string Settings::String() const {
        << " pomodoro_break_minutes=" << pomodoro_break_minutes
        << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep
        << " show_touch_bar=" << show_touch_bar
-       << " active_tab=" << active_tab;
+       << " active_tab=" << active_tab
+       << " color_theme=" << color_theme;
 
     return ss.str();
 }
@@ -108,7 +110,8 @@ bool Settings::IsSame(const Settings &other) const {
             && (pomodoro_break_minutes == other.pomodoro_break_minutes)
             && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep)
             && (show_touch_bar == other.show_touch_bar)
-            && (active_tab == other.active_tab));
+            && (active_tab == other.active_tab)
+            && (color_theme == other.color_theme));
 }
 
 std::string Settings::ModelName() const {

--- a/src/settings.h
+++ b/src/settings.h
@@ -80,6 +80,7 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     bool stop_entry_on_shutdown_sleep;
     bool show_touch_bar;
     Poco::UInt8 active_tab;
+    Poco::UInt8 color_theme;
 
     bool IsSame(const Settings &other) const;
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -181,6 +181,12 @@ bool_t toggl_set_settings_active_tab(
     return toggl::noError == app(context)->SetSettingsActiveTab(active_tab);
 }
 
+bool_t toggl_set_settings_color_theme(
+    void *context,
+    const uint8_t color_theme) {
+    return toggl::noError == app(context)->SetSettingsColorTheme(color_theme);
+}
+
 bool_t toggl_set_settings_idle_minutes(
     void *context,
     const uint64_t idle_minutes) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -192,6 +192,7 @@ extern "C" {
         bool_t StopEntryOnShutdownSleep;
         bool_t ShowTouchBar;
         uint8_t ActiveTab;
+        uint8_t ColorTheme;
     } TogglSettingsView;
 
     typedef struct {
@@ -793,6 +794,10 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_set_settings_active_tab(
         void *context,
         const uint8_t active_tab);
+
+    TOGGL_EXPORT bool_t toggl_set_settings_color_theme(
+        void *context,
+        const uint8_t color_theme);
 
     TOGGL_EXPORT bool_t toggl_set_settings_idle_minutes(
         void *context,

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -472,6 +472,7 @@ TogglSettingsView *settings_view_item_init(
     view->StopEntryOnShutdownSleep = settings.stop_entry_on_shutdown_sleep;
     view->ShowTouchBar = settings.show_touch_bar;
     view->ActiveTab = settings.active_tab;
+    view->ColorTheme = settings.color_theme;
     return view;
 }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -485,6 +485,11 @@ public static partial class Toggl
             return false;
         }
 
+        if (!toggl_set_settings_color_theme(ctx, settings.ColorTheme))
+        {
+            return false;
+        }
+
         return toggl_timeline_toggle_recording(ctx, settings.RecordTimeline);
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -155,8 +155,6 @@ public static partial class Toggl
         public         string EndTimeString;
         public         IntPtr Next;
         public         IntPtr FirstEvent;
-        // Reference to Time entries in this Chunk
-        public         IntPtr Entry;
 
         public override string ToString()
         {
@@ -315,6 +313,8 @@ public static partial class Toggl
         public         bool StopEntryOnShutdownSleep;
         [MarshalAs(UnmanagedType.I1)]
         public         bool ShowTouchBar;
+        public         byte ActiveTab;
+        public         byte ColorTheme;
 
         public override string ToString()
         {
@@ -1029,6 +1029,16 @@ public static partial class Toggl
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_set_time_entry_start_timestamp_with_option(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string guid,
+        Int64 start,
+        [MarshalAs(UnmanagedType.I1)]
+        bool keep_end_time_fixed);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
     private static extern bool toggl_set_time_entry_end(
         IntPtr context,
         [MarshalAs(UnmanagedType.LPWStr)]
@@ -1215,6 +1225,18 @@ public static partial class Toggl
         IntPtr context,
         [MarshalAs(UnmanagedType.I1)]
         bool show_touch_bar);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_set_settings_active_tab(
+        IntPtr context,
+        byte active_tab);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_set_settings_color_theme(
+        IntPtr context,
+        byte color_theme);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]
@@ -1632,6 +1654,10 @@ public static partial class Toggl
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]
     private static extern bool toggl_get_show_touch_bar(
+        IntPtr context);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern byte toggl_get_active_tab(
         IntPtr context);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Theming/Theme.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Theming/Theme.cs
@@ -13,15 +13,31 @@ namespace TogglDesktop.Theming
         private static readonly Subject<ColorScheme> currentColorSchemeSubject = new Subject<ColorScheme>();
         public static IObservable<ColorScheme> CurrentColorScheme => currentColorSchemeSubject.AsObservable();
 
+        public static void SetThemeFromSettings(byte selectedTheme)
+        {
+            switch (selectedTheme)
+            {
+                case 0:
+                    ActivateDetectedColorSchemeOrDefault();
+                    break;
+                case 1:
+                    ActivateColorScheme(ColorScheme.Light);
+                    break;
+                case 2:
+                    ActivateColorScheme(ColorScheme.Dark);
+                    break;
+            }
+        }
+
         /// <returns>Activated color scheme.</returns>
-        public static ColorScheme ActivateDetectedColorSchemeOrDefault(ColorScheme defaultColorScheme = ColorScheme.Light)
+        private static ColorScheme ActivateDetectedColorSchemeOrDefault(ColorScheme defaultColorScheme = ColorScheme.Light)
         {
             var colorScheme = DetectOsColorScheme().GetValueOrDefault(defaultColorScheme);
             ActivateColorScheme(colorScheme);
             return colorScheme;
         }
 
-        public static void ActivateColorScheme(ColorScheme colorScheme)
+        private static void ActivateColorScheme(ColorScheme colorScheme)
         {
             Activate(ThemeType.ColorScheme, colorScheme.ToString());
             currentColorSchemeSubject.OnNext(colorScheme);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
@@ -158,16 +158,5 @@
 
         <toggl:StatusBar x:Name="statusBar" x:FieldModifier="private"
                          VerticalAlignment="Bottom"/>
-
-        <Border Background="{DynamicResource Toggl.CardBackground}"
-                Name="darkModeBorder"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Bottom"
-                Visibility="Collapsed">
-            <CheckBox Click="ToggleDarkMode" Name="darkModeCheckBox" Focusable="False">
-                <TextBlock Foreground="{DynamicResource Toggl.PrimaryTextBrush}">Dark mode</TextBlock>
-            </CheckBox>
-        </Border>
-
     </Grid>
 </mah:MetroWindow>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -224,7 +224,6 @@ namespace TogglDesktop
 
         private void initializeColorScheme()
         {
-            Theme.ActivateDetectedColorSchemeOrDefault();
             Theme.CurrentColorScheme.Subscribe(x => this.updateTitleBarBackground(activeView));
             Theme.CurrentColorScheme.Subscribe(x =>
             {
@@ -472,6 +471,7 @@ namespace TogglDesktop
             if (this.TryBeginInvoke(this.onSettings, open, settings))
                 return;
 
+            Theme.SetThemeFromSettings(settings.ColorTheme);
             this.setGlobalShortcutsFromSettings();
             this.idleDetectionTimer.IsEnabled = settings.UseIdleDetection;
             this.Topmost = settings.OnTop;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -80,9 +80,6 @@ namespace TogglDesktop
             this.finalInitialisation();
             this.trackingWindowSize();
             this.Loaded += onMainWindowLoaded;
-#if DEBUG
-            this.darkModeBorder.Visibility = Visibility.Visible;
-#endif
         }
 
         #region properties
@@ -227,8 +224,7 @@ namespace TogglDesktop
 
         private void initializeColorScheme()
         {
-            var activatedColorScheme = Theme.ActivateDetectedColorSchemeOrDefault();
-            darkModeCheckBox.IsChecked = activatedColorScheme == ColorScheme.Dark;
+            Theme.ActivateDetectedColorSchemeOrDefault();
             Theme.CurrentColorScheme.Subscribe(x => this.updateTitleBarBackground(activeView));
             Theme.CurrentColorScheme.Subscribe(x =>
             {
@@ -971,11 +967,6 @@ namespace TogglDesktop
         public T GetView<T>()
         {
             return (T)this.views.FirstOrDefault(v => v is T);
-        }
-
-        void ToggleDarkMode(object sender, RoutedEventArgs e)
-        {
-            Theme.ActivateColorScheme(darkModeCheckBox.IsChecked.GetValueOrDefault() ? ColorScheme.Dark : ColorScheme.Light);
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -41,8 +41,7 @@
                     <StackPanel Margin="24 32 24 48">
                         <TextBlock Style="{DynamicResource Toggl.TitleText}" Text="Light/dark mode" />
                         <ComboBox x:Name="themeComboBox" Margin="0 6 0 0" Width="360"
-                                  HorizontalAlignment="Left"
-                                  SelectionChanged="ThemeComboBoxOnSelectionChanged">
+                                  HorizontalAlignment="Left">
                             <ComboBoxItem IsSelected="True">Use my Windows mode</ComboBoxItem>
                             <ComboBoxItem>Light</ComboBoxItem>
                             <ComboBoxItem>Dark</ComboBoxItem>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -39,9 +39,11 @@
             <TabItem Header="General">
                 <ScrollViewer>
                     <StackPanel Margin="24 32 24 48">
-                        <TextBlock Style="{DynamicResource Toggl.TitleText}" Text="Light/Dark mode" />
-                        <ComboBox Margin="0 6 0 0" Width="360">
-                            <ComboBoxItem>Use my Windows mode</ComboBoxItem>
+                        <TextBlock Style="{DynamicResource Toggl.TitleText}" Text="Light/dark mode" />
+                        <ComboBox x:Name="themeComboBox" Margin="0 6 0 0" Width="360"
+                                  HorizontalAlignment="Left"
+                                  SelectionChanged="ThemeComboBoxOnSelectionChanged">
+                            <ComboBoxItem IsSelected="True">Use my Windows mode</ComboBoxItem>
                             <ComboBoxItem>Light</ComboBoxItem>
                             <ComboBoxItem>Dark</ComboBoxItem>
                         </ComboBox>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -39,7 +39,13 @@
             <TabItem Header="General">
                 <ScrollViewer>
                     <StackPanel Margin="24 32 24 48">
-                        <TextBlock Style="{DynamicResource Toggl.TitleText}" Text="Set up shortcuts" />
+                        <TextBlock Style="{DynamicResource Toggl.TitleText}" Text="Light/Dark mode" />
+                        <ComboBox Margin="0 6 0 0" Width="360">
+                            <ComboBoxItem>Use my Windows mode</ComboBoxItem>
+                            <ComboBoxItem>Light</ComboBoxItem>
+                            <ComboBoxItem>Dark</ComboBoxItem>
+                        </ComboBox>
+                        <TextBlock Margin="0 32 0 0" Style="{DynamicResource Toggl.TitleText}" Text="Set up shortcuts" />
                         <Grid Margin="0 16 0 0" HorizontalAlignment="Left">
                             <Grid.RowDefinitions>
                                 <RowDefinition />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -108,6 +108,8 @@ namespace TogglDesktop
             this.keepDurationFixedCheckbox.IsChecked = !this.keepEndTimeFixedCheckbox.IsChecked;
 
             this.onStopEntryCheckBox.IsChecked = settings.StopEntryOnShutdownSleep;
+            this.themeComboBox.SelectedIndex = settings.ColorTheme;
+
             Task.Run(UpdateLaunchOnStartupCheckboxAsync);
 
             #endregion
@@ -263,6 +265,7 @@ namespace TogglDesktop
                 PomodoroBreakMinutes = toLong(this.pomodoroBreakTimerDuration.Text),
 
                 StopEntryOnShutdownSleep = isChecked(this.onStopEntryCheckBox),
+                ColorTheme = (byte)this.themeComboBox.SelectedIndex,
 
                 #endregion
 
@@ -391,21 +394,5 @@ namespace TogglDesktop
         }
 
         #endregion
-
-        private void ThemeComboBoxOnSelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            switch (themeComboBox.SelectedIndex)
-            {
-                case 0:
-                    Theming.Theme.ActivateDetectedColorSchemeOrDefault();
-                    break;
-                case 1:
-                    Theming.Theme.ActivateColorScheme(ColorScheme.Light);
-                    break;
-                case 2:
-                    Theming.Theme.ActivateColorScheme(ColorScheme.Dark);
-                    break;
-            }
-        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -3,12 +3,14 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using MahApps.Metro.Controls;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.AutoCompletion.Implementation;
 using TogglDesktop.Diagnostics;
+using TogglDesktop.Theming;
 using TogglDesktop.ViewModels;
 
 #if MS_STORE
@@ -382,12 +384,28 @@ namespace TogglDesktop
                     ProjectLabel = Toggl.GetDefaultProjectName(),
                     ProjectID = projectID,
                     TaskID = taskID,
-                }; 
+                };
             }
 
             this.selectDefaultProject(project);
         }
 
         #endregion
+
+        private void ThemeComboBoxOnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            switch (themeComboBox.SelectedIndex)
+            {
+                case 0:
+                    Theming.Theme.ActivateDetectedColorSchemeOrDefault();
+                    break;
+                case 1:
+                    Theming.Theme.ActivateColorScheme(ColorScheme.Light);
+                    break;
+                case 2:
+                    Theming.Theme.ActivateColorScheme(ColorScheme.Dark);
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
### 📒 Description
This PR adds the ComboBox to Preferences which allows users to switch the color theme independent from the Windows settings. The default is still the Windows theme.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3865 

### 🔎 Review hints
Note: Like most other settings, this setting is local to the app installation. It means the setting persists when the user is logged out/logged in under a different account, and it doesn't persist between app installations of the same user account.

The user is logged in. The user starts the app -> The app is started with the current Windows theme.
The user is logged out. The user starts the app -> The app is started with the current Windows theme.
The user changes the theme in Preferences, presses Save -> The theme gets changed after Save was pressed.
The user changes the theme in Preferences, presses Cancel -> The theme doesn't get changed, opening Preferences again shows old setting.
The user changes the theme in Preferences, presses Save, then restarts the app -> The app is started with the saved theme.