### PR TITLE
Add caching for GitHub Actions Windows builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,7 +196,25 @@ jobs:
         TAG_NAME=$(./dist/get-tag-name.sh)
         echo "Setting version to ${TAG_NAME/v/}"
         bash dist/windows/scripts/set_version.sh "${TAG_NAME/v/}"
+    - name: Cache POCO bin
+      id: cache-poco-bin
+      uses: actions/cache@v1
+      with:
+        path: third_party/poco/bin
+        key: ${{ runner.os }}-poco-bin-1.9.0
+    - name: Cache POCO lib
+      id: cache-poco-lib
+      uses: actions/cache@v1
+      with:
+        path: third_party/poco/lib
+        key: ${{ runner.os }}-poco-lib-1.9.0
+    - name: Build on Windows x86 without POCO
+      if: steps.cache-poco-bin.outputs.cache-hit == 'true'
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=Release /p:Platform="x86" /t:Clean,Build /restore /m src\ui\windows\TogglDesktop\TogglDesktop.NoPoco.sln
     - name: Build on Windows x86
+      if: steps.cache-poco-bin.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=Release /p:Platform="x86" /t:Clean,Build /restore /m src\ui\windows\TogglDesktop\TogglDesktop.sln

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,9 +187,6 @@ jobs:
         base64 -d Certificate.b64 > Certificate.pfx
         cp Certificate.pfx dist/windows
       shell: bash
-    - name: Install dependencies
-      run: |
-        choco install nsis -y
     - name: Set version
       shell: bash
       run: |
@@ -223,6 +220,10 @@ jobs:
       run: |
         ./dist/windows/scripts/sign.sh
       shell: bash
+    - name: Install NSIS
+      if: github.event_name == 'release'
+      run: |
+        choco install nsis -y
     - name: Create x86 installer
       if: github.event_name == 'release'
       run: |
@@ -252,9 +253,6 @@ jobs:
         base64 -d Certificate.b64 > Certificate.pfx
         cp Certificate.pfx dist/windows
       shell: bash
-    - name: Install dependencies
-      run: |
-        choco install nsis -y
     - name: Set version
       shell: bash
       run: |
@@ -288,6 +286,10 @@ jobs:
       run: |
         ./dist/windows/scripts/sign.sh
       shell: bash
+    - name: Install NSIS
+      if: github.event_name == 'release'
+      run: |
+        choco install nsis -y
     - name: Make x64 installer
       if: github.event_name == 'release'
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,7 +261,25 @@ jobs:
         TAG_NAME=$(./dist/get-tag-name.sh)
         echo "Setting version to ${TAG_NAME/v/}"
         bash dist/windows/scripts/set_version.sh "${TAG_NAME/v/}"
+    - name: Cache POCO bin64
+      id: cache-poco-bin64
+      uses: actions/cache@v1
+      with:
+        path: third_party/poco/bin64
+        key: ${{ runner.os }}-poco-bin64-1.9.0
+    - name: Cache POCO lib64
+      id: cache-poco-lib64
+      uses: actions/cache@v1
+      with:
+        path: third_party/poco/lib64
+        key: ${{ runner.os }}-poco-lib64-1.9.0
+    - name: Build on Windows x64 without POCO
+      if: steps.cache-poco-bin64.outputs.cache-hit == 'true'
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=Release /p:Platform="x64" /t:Clean,Build /restore /m src\ui\windows\TogglDesktop\TogglDesktop.NoPoco.sln
     - name: Build on Windows x64
+      if: steps.cache-poco-bin64.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=Release /p:Platform="x64" /t:Clean,Build /restore /m src\ui\windows\TogglDesktop\TogglDesktop.sln


### PR DESCRIPTION
### 📒 Description
Adds caching for GitHub Actions Windows builds

### 🕶️ Types of changes
- **Improvement** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add caching for POCO bin and lib folders
- [x] Build `TogglDesktop.NoPoco.sln` if there is a cache hit, build `TogglDesktop.sln` otherwise.
- [x] Install NSIS only when actually building the installer

### 👫 Relationships

### 🔎 Review hints
Verify the builds are successful and the running time decreased.
