### PR TITLE
Register application shortcuts on Edit view popup window 

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -34,6 +34,8 @@ namespace TogglDesktop
             this.mainGrid.Width = 0;
 
             Toggl.OnTimeEntryEditor += this.onTimeEntryEditor;
+
+            KeyboardShortcuts.RegisterShortcuts(this);
         }
 
         private void onTimeEntryEditor(bool open, Toggl.TogglTimeEntryView te, string focusedFieldName)


### PR DESCRIPTION
### 📒 Description
Enables edit view to respond to the application shortcuts in the same way as the main window and the mini timer window do.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3871

### 🔎 Review hints
Make sure the application shortcuts work on the Edit view (Start, Continue, Stop, Quit app, etc.).