### PR TITLE
Fix Esc key not closing the Edit view

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
@@ -53,15 +53,6 @@ namespace TogglDesktop
 
             this.fillTimeEntryList(list);
             this.Entries.ViewModel.OnTimeEntryList(showLoadMoreButton, list.Count == 0);
-
-            if (open)
-            {
-                if (this.Entries.IsAnyCellSelected)
-                {
-                    this.Entries.Focus(false);
-                    this.Entries.DeselectCells();
-                }
-            }
         }
 
         private void onTimeEntryEditor(bool open, Toggl.TogglTimeEntryView te, string focusedFieldName)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
@@ -11,24 +11,20 @@
              mc:Ignorable="d" 
              d:DesignWidth="400"
              Title="Toggl Desktop"
-             Style="{StaticResource Toggl.MainWindow}">
+             Style="{StaticResource Toggl.MainWindow}"
+             KeyDown="OnMainWindowKeyDown">
 
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../Resources/DesignUpdate/MahApps.Overrides.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <RoutedUICommand x:Key="EscapeCommand" />
         </ResourceDictionary>
     </Window.Resources>
 
     <i:Interaction.Behaviors>
         <behaviors:HideWindowOnClosingBehavior />
     </i:Interaction.Behaviors>
-
-    <Window.CommandBindings>
-        <CommandBinding Command="{StaticResource EscapeCommand}" Executed="onEscapeCommand"/>
-    </Window.CommandBindings>
 
     <Window.InputBindings>
         <KeyBinding Key="N" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.New}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
@@ -39,7 +39,6 @@
         <KeyBinding Key="V" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.NewFromPaste}" />
         <KeyBinding Key="Q" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Quit}" />
         <KeyBinding Key="OemComma" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Preferences}" />
-        <KeyBinding Key="Escape" Command="{StaticResource EscapeCommand}" />
     </Window.InputBindings>
 
     <mah:MetroWindow.RightWindowCommands>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ using TogglDesktop.Theming;
 using TogglDesktop.Tutorial;
 using TogglDesktop.ViewModels;
 using Control = System.Windows.Controls.Control;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MenuItem = System.Windows.Controls.MenuItem;
 using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 
@@ -959,6 +960,14 @@ namespace TogglDesktop
         public T GetView<T>()
         {
             return (T)this.views.FirstOrDefault(v => v is T);
+        }
+
+        private void OnMainWindowKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                this.closeEditPopup();
+            }
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -576,6 +576,10 @@ namespace TogglDesktop
         {
             this.updateEditPopupLocation();
             this.updateEntriesListWidth();
+            if (editPopup.IsVisible == false && ReferenceEquals(this.activeView, this.timerEntryListView))
+            {
+                this.timerEntryListView.Entries.DeselectCells();
+            }
         }
 
         private void onTaskbarLeftMouseUp(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### 📒 Description
Fix Esc key not closing the Edit view.
The issue was caused by #3875 and happened because the main window's key bindings contained Esc binding and this binding was assigned to Edit view as well which couldn't execute it as the command belonged to the main window.
The fix is to subscribe to the main window's Esc via event instead of key binding.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Subscribe to Esc via event instead of KeyBinding
- [x] Deselect cells as soon as Edit view is closed

### 👫 Relationships
Closes #3881 

### 🔎 Review hints
See #3881 for steps to reproduce.

