### PR TITLE
Clean up pushChanges and make it generic for all models

### DIFF
--- a/src/base_model.cc
+++ b/src/base_model.cc
@@ -12,6 +12,7 @@
 #include <Poco/Timestamp.h>
 #include <Poco/DateTime.h>
 #include <Poco/LocalDateTime.h>
+#include <Poco/Net/HTTPRequest.h>
 
 namespace toggl {
 
@@ -72,7 +73,17 @@ HTTPSRequest BaseModel::PrepareRequest() {
 
     auto json = SaveToJSON();
     req.relative_url = ModelURL();
-    req.payload = writer.write(json);
+
+    if (NeedsDELETE()) {
+        req.payload = "";
+        req.method = Poco::Net::HTTPRequest::HTTP_DELETE;
+    } else if (ID()) {
+        req.payload = writer.write(json);
+        req.method = Poco::Net::HTTPRequest::HTTP_PUT;
+    } else {
+        req.payload = writer.write(json);
+        req.method = Poco::Net::HTTPRequest::HTTP_POST;
+    }
 
     return req;
 }

--- a/src/base_model.cc
+++ b/src/base_model.cc
@@ -62,6 +62,17 @@ void BaseModel::SetValidationError(const std::string &value) {
     }
 }
 
+HTTPSRequest BaseModel::PrepareRequest() {
+    HTTPSRequest req;
+    Json::StyledWriter writer;
+
+    auto json = SaveToJSON();
+    req.relative_url = ModelURL();
+    req.payload = writer.write(json);
+
+    return req;
+}
+
 void BaseModel::SetDeletedAt(const Poco::Int64 value) {
     if (deleted_at_ != value) {
         deleted_at_ = value;

--- a/src/base_model.cc
+++ b/src/base_model.cc
@@ -64,6 +64,10 @@ void BaseModel::SetValidationError(const std::string &value) {
 
 HTTPSRequest BaseModel::PrepareRequest() {
     HTTPSRequest req;
+    // if pushing is not needed, return an empty request
+    if (!NeedsPush())
+        return req;
+
     Json::StyledWriter writer;
 
     auto json = SaveToJSON();

--- a/src/base_model.cc
+++ b/src/base_model.cc
@@ -181,7 +181,7 @@ error BaseModel::ApplyBatchUpdateResult(
             return noError;
         }
 
-        if (ResolveError(err)) {
+        if (ResolveError(err) == noError) {
             return noError;
         }
 

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -138,6 +138,15 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual std::string ModelURL() const = 0;
 
     virtual void LoadFromJSON(Json::Value value) {}
+    error LoadFromJSONString(const std::string &json) {
+        Json::Value root;
+        Json::Reader reader;
+        if (!reader.parse(json, root)) {
+            return error("error parsing project POST response");
+        }
+        LoadFromJSON(root);
+        return noError;
+    }
     virtual Json::Value SaveToJSON() const {
         return 0;
     }

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -159,8 +159,8 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual bool ResourceCannotBeCreated(const toggl::error &err) const {
         return false;
     }
-    virtual bool ResolveError(const toggl::error &err) {
-        return false;
+    virtual error ResolveError(const toggl::error &err) {
+        return err;
     }
 
     error LoadFromDataString(const std::string &);

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -14,6 +14,7 @@
 #include "types.h"
 #include "util/logger.h"
 #include "util/memory.h"
+#include "https_client.h"
 
 #include <Poco/Types.h>
 
@@ -140,6 +141,8 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual Json::Value SaveToJSON() const {
         return 0;
     }
+
+    virtual HTTPSRequest PrepareRequest();
 
     virtual bool DuplicateResource(const toggl::error &err) const {
         return false;

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -138,15 +138,7 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual std::string ModelURL() const = 0;
 
     virtual void LoadFromJSON(Json::Value value) {}
-    error LoadFromJSONString(const std::string &json) {
-        Json::Value root;
-        Json::Reader reader;
-        if (!reader.parse(json, root)) {
-            return error("error parsing project POST response");
-        }
-        LoadFromJSON(root);
-        return noError;
-    }
+    error LoadFromJSONString(const std::string &json, bool with_id);
     virtual Json::Value SaveToJSON() const {
         return 0;
     }

--- a/src/client.cc
+++ b/src/client.cc
@@ -63,17 +63,17 @@ Json::Value Client::SaveToJSON() const {
     return n;
 }
 
-bool Client::ResolveError(const toggl::error &err) {
+error Client::ResolveError(const toggl::error &err) {
     if (nameHasAlreadyBeenTaken(err)) {
         SetName(Name() + " 1");
-        return true;
+        return noError;
     }
     if (err.find(kClientNameAlreadyExists) != std::string::npos) {
         // remove duplicate from db
         MarkAsDeletedOnServer();
-        return true;
+        return noError;
     }
-    return false;
+    return err;
 }
 
 bool Client::nameHasAlreadyBeenTaken(const error &err) {

--- a/src/client.h
+++ b/src/client.h
@@ -39,7 +39,7 @@ class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
     std::string ModelURL() const override;
     void LoadFromJSON(Json::Value value) override;
     Json::Value SaveToJSON() const override;
-    bool ResolveError(const toggl::error &err) override;
+    error ResolveError(const toggl::error &err) override;
     bool ResourceCannotBeCreated(const toggl::error &err) const override;
 
  private:

--- a/src/context.cc
+++ b/src/context.cc
@@ -4956,14 +4956,7 @@ error Context::pushChanges(
                     continue;
                 }
 
-                Json::Value root;
-                Json::Reader reader;
-                if (!reader.parse(resp.body, root)) {
-                    err = error("error parsing client POST response");
-                    continue;
-                }
-
-                client->LoadFromJSON(root);
+                err = client->LoadFromJSONString(resp.body);
             }
 
             return err;
@@ -4997,14 +4990,7 @@ error Context::pushChanges(
                     continue;
                 }
 
-                Json::Value root;
-                Json::Reader reader;
-                if (!reader.parse(resp.body, root)) {
-                    err = error("error parsing project POST response");
-                    continue;
-                }
-
-                project->LoadFromJSON(root);
+                err = project->LoadFromJSONString(resp.body);
             }
 
             return err;

--- a/src/context.cc
+++ b/src/context.cc
@@ -4950,7 +4950,7 @@ error Context::pushChanges(
 
                 if (resp.err != noError) {
                     // if we're able to solve the error
-                    if (client->ResolveError(resp.body)) {
+                    if (client->ResolveError(resp.body) == noError) {
                         displayError(save(false));
                     }
                     continue;
@@ -4984,7 +4984,7 @@ error Context::pushChanges(
 
                 if (resp.err != noError) {
                     // if we're able to solve the error
-                    if (project->ResolveError(resp.body)) {
+                    if (project->ResolveError(resp.body) == noError) {
                         displayError(save(false));
                     }
                     continue;
@@ -5018,7 +5018,7 @@ error Context::pushChanges(
 
                 if (resp.err != noError) {
                     // if we're able to solve the error
-                    if (te->ResolveError(resp.body)) {
+                    if (te->ResolveError(resp.body) == noError) {
                         displayError(save(false));
                     }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -5075,15 +5075,8 @@ error Context::pushClients(
     std::string client_json("");
     error err = noError;
     for (auto &client : clients) {
-        Json::Value clientJson = client->SaveToJSON();
-
-        Json::StyledWriter writer;
-        client_json = writer.write(clientJson);
-
-        HTTPSRequest req;
+        HTTPSRequest req = client->PrepareRequest();
         req.host = urls::API();
-        req.relative_url = client->ModelURL();
-        req.payload = client_json;
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
@@ -5128,15 +5121,8 @@ error Context::pushProjects(
             }
         }
 
-        Json::Value projectJson = project->SaveToJSON();
-
-        Json::StyledWriter writer;
-        project_json = writer.write(projectJson);
-
-        HTTPSRequest req;
+        HTTPSRequest req = project->PrepareRequest();
         req.host = urls::API();
-        req.relative_url = project->ModelURL();
-        req.payload = project_json;
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 
@@ -5199,17 +5185,8 @@ error Context::pushEntries(
             continue;
         }
 
-        Json::Value entryJson = te->SaveToJSON();
-
-        Json::StyledWriter writer;
-        entry_json = writer.write(entryJson);
-
-        // std::cout << entry_json;
-
-        HTTPSRequest req;
+        HTTPSRequest req = te->PrepareRequest();
         req.host = urls::API();
-        req.relative_url = te->ModelURL();
-        req.payload = entry_json;
         req.basic_auth_username = api_token;
         req.basic_auth_password = "api_token";
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -4973,7 +4973,7 @@ error Context::pushChanges(
                     continue;
                 }
 
-                err = model->LoadFromJSONString(resp.body, false);
+                err = model->LoadFromJSONString(resp.body, model->NeedsPOST());
             }
 
             return err;

--- a/src/context.cc
+++ b/src/context.cc
@@ -4956,7 +4956,7 @@ error Context::pushChanges(
                     continue;
                 }
 
-                err = client->LoadFromJSONString(resp.body);
+                err = client->LoadFromJSONString(resp.body, false);
             }
 
             return err;
@@ -4990,7 +4990,7 @@ error Context::pushChanges(
                     continue;
                 }
 
-                err = project->LoadFromJSONString(resp.body);
+                err = project->LoadFromJSONString(resp.body, false);
             }
 
             return err;
@@ -5051,29 +5051,7 @@ error Context::pushChanges(
                     continue;
                 }
 
-                Json::Value root;
-                Json::Reader reader;
-                if (!reader.parse(resp.body, root)) {
-                    return error("error parsing time entry POST response");
-                }
-
-                auto id = root["id"].asUInt64();
-                if (!id) {
-                    logger.error("Backend is sending invalid data: ignoring update without an ID");
-                    continue;
-                }
-
-                if (!te->ID()) {
-                    if (!(related.User->SetTimeEntryID(id, te))) {
-                        continue;
-                    }
-                }
-
-                if (te->ID() != id) {
-                    return error("Backend has changed the ID of the entry");
-                }
-
-                te->LoadFromJSON(root);
+                te->LoadFromJSONString(resp.body, true);
             }
 
             if (error_found) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -5021,27 +5021,16 @@ error Context::pushChanges(
                     if (te->ResolveError(resp.body) == noError) {
                         displayError(save(false));
                     }
-
-                    // Not found on server. Probably deleted already.
-                    if (te->isNotFound(resp.body)) {
-                        te->MarkAsDeletedOnServer();
-                        continue;
-                    }
                     error_found = true;
                     error_message = resp.err;
                     if (resp.status_code == 429) {
                         error_message = error(kRateLimit);
                     }
-
-                    // Mark the time entry as unsynced now
-                    te->SetUnsynced();
-
                     offline = IsNetworkingError(resp.err);
 
                     if (offline) {
                         trigger_sync_ = false;
                     }
-
                     continue;
                 }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -4946,7 +4946,7 @@ error Context::pushChanges(
                 req.basic_auth_username = api_token;
                 req.basic_auth_password = "api_token";
 
-                HTTPSResponse resp = toggl_client.Post(req);
+                HTTPSResponse resp = toggl_client.Request(req);
 
                 if (resp.err != noError) {
                     // if we're able to solve the error
@@ -4980,7 +4980,7 @@ error Context::pushChanges(
                 req.basic_auth_username = api_token;
                 req.basic_auth_password = "api_token";
 
-                HTTPSResponse resp = toggl_client.Post(req);
+                HTTPSResponse resp = toggl_client.Request(req);
 
                 if (resp.err != noError) {
                     // if we're able to solve the error
@@ -5014,16 +5014,7 @@ error Context::pushChanges(
                 req.basic_auth_username = api_token;
                 req.basic_auth_password = "api_token";
 
-                HTTPSResponse resp;
-
-                if (te->NeedsDELETE()) {
-                    req.payload = "";
-                    resp = toggl_client.Delete(req);
-                } else if (te->ID()) {
-                    resp = toggl_client.Put(req);
-                } else {
-                    resp = toggl_client.Post(req);
-                }
+                HTTPSResponse resp = toggl_client.Request(req);
 
                 if (resp.err != noError) {
                     // if we're able to solve the error

--- a/src/context.h
+++ b/src/context.h
@@ -630,9 +630,6 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pushChanges(
         TogglClient *https_client,
         bool *had_something_to_push);
-    error updateEntryProjects(
-        std::vector<locked<Project>> &projects,
-        std::vector<locked<TimeEntry>> &time_entries);
     error signup(
         TogglClient *https_client,
         const std::string &email,

--- a/src/context.h
+++ b/src/context.h
@@ -637,8 +637,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         std::vector<locked<Client> > &clients,
         const std::string &api_token,
         const TogglClient &toggl_client);
-    error pushEntries(const std::map<std::string, locked<BaseModel> > &models,
-        std::vector<locked<TimeEntry> > &time_entries,
+    error pushEntries(std::vector<locked<TimeEntry> > &time_entries,
         const std::string &api_token,
         const TogglClient &toggl_client);
     error updateEntryProjects(
@@ -677,12 +676,6 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pushObmAction();
 
     error pullObmExperiments();
-
-    template<typename T>
-    void collectPushableModels(
-        ProtectedContainer<T> &list,
-        std::vector<locked<T>> *result,
-        std::map<std::string, locked<BaseModel>> *models = nullptr);
 
     Poco::Mutex db_m_;
     Database *db_;

--- a/src/context.h
+++ b/src/context.h
@@ -630,16 +630,6 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pushChanges(
         TogglClient *https_client,
         bool *had_something_to_push);
-    error pushClients(std::vector<locked<Client> > &clients,
-        const std::string &api_token,
-        const TogglClient &toggl_client);
-    error pushProjects(std::vector<locked<Project> > &projects,
-        std::vector<locked<Client> > &clients,
-        const std::string &api_token,
-        const TogglClient &toggl_client);
-    error pushEntries(std::vector<locked<TimeEntry> > &time_entries,
-        const std::string &api_token,
-        const TogglClient &toggl_client);
     error updateEntryProjects(
         std::vector<locked<Project>> &projects,
         std::vector<locked<TimeEntry>> &time_entries);

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -199,35 +199,35 @@ error HTTPSClient::statusCodeToError(const Poco::Int64 status_code) const {
 HTTPSResponse HTTPSClient::Post(
     HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_POST;
-    return request(req);
+    return Request(req);
 }
 
 HTTPSResponse HTTPSClient::Get(
     HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_GET;
-    return request(req);
+    return Request(req);
 }
 
 HTTPSResponse HTTPSClient::GetFile(
     HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_GET;
     req.timeout_seconds = kHTTPClientTimeoutSeconds * 10;
-    return request(req);
+    return Request(req);
 }
 
 HTTPSResponse HTTPSClient::Delete(
     HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_DELETE;
-    return request(req);
+    return Request(req);
 }
 
 HTTPSResponse HTTPSClient::Put(
     HTTPSRequest req) const {
     req.method = Poco::Net::HTTPRequest::HTTP_PUT;
-    return request(req);
+    return Request(req);
 }
 
-HTTPSResponse HTTPSClient::request(
+HTTPSResponse HTTPSClient::Request(
     HTTPSRequest req) const {
     HTTPSResponse resp = makeHttpRequest(req);
 
@@ -476,7 +476,7 @@ Logger TogglClient::logger() const {
     return { "TogglClient" };
 }
 
-HTTPSResponse TogglClient::request(
+HTTPSResponse TogglClient::Request(
     HTTPSRequest req) const {
 
     error err = TogglStatus.Status();
@@ -491,7 +491,7 @@ HTTPSResponse TogglClient::request(
         monitor_->DisplaySyncState(kSyncStateWork);
     }
 
-    HTTPSResponse resp = HTTPSClient::request(req);
+    HTTPSResponse resp = HTTPSClient::Request(req);
 
     if (monitor_) {
         monitor_->DisplaySyncState(kSyncStateIdle);

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -95,25 +95,22 @@ class TOGGL_INTERNAL_EXPORT HTTPSClientConfig {
 
 class TOGGL_INTERNAL_EXPORT HTTPSRequest {
  public:
-    HTTPSRequest()
-        : method("")
-    , host("")
-    , relative_url("")
-    , payload("")
-    , basic_auth_username("")
-    , basic_auth_password("")
-    , form(nullptr)
-    , timeout_seconds(kHTTPClientTimeoutSeconds) {}
-    virtual ~HTTPSRequest() {}
+    HTTPSRequest() {}
+    ~HTTPSRequest() {}
 
-    std::string method;
-    std::string host;
-    std::string relative_url;
-    std::string payload;
-    std::string basic_auth_username;
-    std::string basic_auth_password;
-    Poco::Net::HTMLForm *form;
-    Poco::Int64 timeout_seconds;
+    bool IsNull() const {
+        return method.empty() && host.empty() && relative_url.empty() && payload.empty() && basic_auth_password.empty() && basic_auth_password.empty()
+            && !form && timeout_seconds == kHTTPClientTimeoutSeconds;
+    }
+
+    std::string method {};
+    std::string host {};
+    std::string relative_url {};
+    std::string payload {};
+    std::string basic_auth_username {};
+    std::string basic_auth_password {};
+    Poco::Net::HTMLForm *form {};
+    Poco::Int64 timeout_seconds { kHTTPClientTimeoutSeconds };
 };
 
 class TOGGL_INTERNAL_EXPORT HTTPSResponse {

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -146,11 +146,12 @@ class TOGGL_INTERNAL_EXPORT HTTPSClient {
     HTTPSResponse Put(
         HTTPSRequest req) const;
 
+    virtual HTTPSResponse Request(
+        HTTPSRequest req) const;
+
     static HTTPSClientConfig Config;
 
  protected:
-    virtual HTTPSResponse request(
-        HTTPSRequest req) const;
 
     virtual Logger logger() const;
 
@@ -178,11 +179,12 @@ class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPSClient {
     explicit TogglClient(SyncStateMonitor *monitor = nullptr)
         : monitor_(monitor) {}
 
+    virtual HTTPSResponse Request(
+        HTTPSRequest req) const override;
+
     static ServerStatus TogglStatus;
 
  protected:
-    virtual HTTPSResponse request(
-        HTTPSRequest req) const override;
 
     virtual Logger logger() const override;
 

--- a/src/project.cc
+++ b/src/project.cc
@@ -184,25 +184,25 @@ bool Project::onlyAdminsCanChangeProjectVisibility(
         "Only admins can change project visibility"));
 }
 
-bool Project::ResolveError(const toggl::error &err) {
+error Project::ResolveError(const toggl::error &err) {
     if (userCannotAccessWorkspace(err)) {
         SetWID(0);
-        return true;
+        return noError;
     }
     if (clientIsInAnotherWorkspace(err)) {
         SetCID(0);
-        return true;
+        return noError;
     }
     if (!IsPrivate() && onlyAdminsCanChangeProjectVisibility(err)) {
         SetPrivate(true);
-        return true;
+        return noError;
     }
     if (err.find(kProjectNameAlready) != std::string::npos) {
         // remove duplicate from db
         MarkAsDeletedOnServer();
-        return true;
+        return noError;
     }
-    return false;
+    return err;
 }
 
 std::string Project::ModelName() const {

--- a/src/project.h
+++ b/src/project.h
@@ -87,7 +87,7 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
     Json::Value SaveToJSON() const override;
     bool DuplicateResource(const toggl::error &err) const override;
     bool ResourceCannotBeCreated(const toggl::error &err) const override;
-    bool ResolveError(const toggl::error &err) override;
+    error ResolveError(const toggl::error &err) override;
 
     static std::vector<std::string> ColorCodes;
 

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -101,7 +101,7 @@ TEST(Project, ResolveOnlyAdminsCanChangeProjectVisibility) {
     ProtectedModel<Project> p { nullptr, true };
     p->SetPrivate(false);
     error err = error("Only admins can change project visibility");
-    ASSERT_TRUE(p->ResolveError(err));
+    ASSERT_EQ(p->ResolveError(err), noError);
     ASSERT_TRUE(p->IsPrivate());
 }
 

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -71,6 +71,13 @@ error TimeEntry::ResolveError(const error &err) {
         SetCreatedWith(HTTPSClient::Config.UserAgent());
         return noError;
     }
+    // Not found on server. Probably deleted already.
+    if (isNotFound(err)) {
+        MarkAsDeletedOnServer();
+        return noError;
+    }
+    // Mark the time entry as unsynced now
+    SetUnsynced();
     return err;
 }
 

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -28,13 +28,13 @@
 
 namespace toggl {
 
-bool TimeEntry::ResolveError(const error &err) {
+error TimeEntry::ResolveError(const error &err) {
     if (durationTooLarge(err) && Stop() && Start()) {
         Poco::Int64 seconds =
             (std::min)(Stop() - Start(),
                        Poco::Int64(kMaxTimeEntryDurationSeconds));
         SetDurationInSeconds(seconds);
-        return true;
+        return noError;
     }
     if (startTimeWrongYear(err) && Stop() && Start()) {
         Poco::Int64 seconds =
@@ -42,36 +42,36 @@ bool TimeEntry::ResolveError(const error &err) {
                        Poco::Int64(kMaxTimeEntryDurationSeconds));
         SetDurationInSeconds(seconds);
         SetStart(Stop() - Duration());
-        return true;
+        return noError;
     }
     if (stopTimeMustBeAfterStartTime(err) && Stop() && Start()) {
         SetStop(Start() + DurationInSeconds());
-        return true;
+        return noError;
     }
     if (userCannotAccessWorkspace(err)) {
         SetWID(0);
         SetPID(0);
         SetTID(0);
-        return true;
+        return noError;
     }
     if (userCannotAccessTheSelectedProject(err)) {
         SetPID(0);
         SetTID(0);
-        return true;
+        return noError;
     }
     if (userCannotAccessSelectedTask(err)) {
         SetTID(0);
-        return true;
+        return noError;
     }
     if (billableIsAPremiumFeature(err)) {
         SetBillable(false);
-        return true;
+        return noError;
     }
     if (isMissingCreatedWith(err)) {
         SetCreatedWith(HTTPSClient::Config.UserAgent());
-        return true;
+        return noError;
     }
-    return false;
+    return err;
 }
 
 bool TimeEntry::isNotFound(const error &err) const {

--- a/src/time_entry.h
+++ b/src/time_entry.h
@@ -128,7 +128,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string ModelName() const override;
     std::string ModelURL() const override;
     std::string String() const override;
-    virtual bool ResolveError(const error &err) override;
+    virtual error ResolveError(const error &err) override;
     void LoadFromJSON(Json::Value value) override;
     Json::Value SaveToJSON() const override;
 

--- a/src/user.cc
+++ b/src/user.cc
@@ -228,7 +228,8 @@ locked<TimeEntry> User::Start(
         }
     }
 
-    EnsureWID(te);
+    if (!te->WID())
+        te->SetWID(SupplementaryWID());
 
     te->SetUIModified();
 
@@ -1058,6 +1059,20 @@ bool User::SetTimeEntryID(Poco::UInt64 id,
     }
     timeEntry->SetID(id);
     return true;
+}
+
+Poco::UInt64 User::SupplementaryWID() const {
+    // Try to set default user WID
+    if (DefaultWID()) {
+        return DefaultWID();
+    }
+
+    // Try to set first WID available
+    auto it = GetRelatedData()->Workspaces.cbegin();
+    if (it != GetRelatedData()->Workspaces.cend()) {
+        locked<const Workspace> ws = *it;
+        return ws->ID();
+    }
 }
 
 void User::loadUserTimeEntryFromJSON(

--- a/src/user.cc
+++ b/src/user.cc
@@ -1073,6 +1073,8 @@ Poco::UInt64 User::SupplementaryWID() const {
         locked<const Workspace> ws = *it;
         return ws->ID();
     }
+
+    return 0;
 }
 
 void User::loadUserTimeEntryFromJSON(

--- a/src/user.h
+++ b/src/user.h
@@ -211,26 +211,8 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         Poco::UInt64 id,
         locked<TimeEntry> &timeEntry);
 
-    template<typename T>
-    void EnsureWID(locked<T> &model) const {
-        // Do nothing if TE already has WID assigned
-        if (model->WID()) {
-            return;
-        }
-
-        // Try to set default user WID
-        if (DefaultWID()) {
-            model->SetWID(DefaultWID());
-            return;
-        }
-
-        // Try to set first WID available
-        auto it = GetRelatedData()->Workspaces.cbegin();
-        if (it != GetRelatedData()->Workspaces.cend()) {
-            locked<const Workspace> ws = *it;
-            model->SetWID(ws->ID());
-        }
-    }
+    // Get either default or first available WID for items without it
+    Poco::UInt64 SupplementaryWID() const;
 
     static error UserID(
         const std::string &json_data_string,

--- a/src/util/memory.h
+++ b/src/util/memory.h
@@ -176,6 +176,8 @@ protected:
 template <class T>
 class ProtectedContainer : public ProtectedBase {
 public:
+    typedef ProtectedContainer<T> type;
+    typedef T value_type;
     class iterator {
     public:
         friend class ProtectedContainer;


### PR DESCRIPTION
### 📒 Description
This is another step in the direction of having everything as generic as possible for all models we're working with in the library.
Request construction is now delegated to `BaseModel` (and virtual methods are used to provide relevant data by the actual implementations) and instead of doing it in a ton of methods, I moved everything into lambdas - this is not necessarily the cleanest way to do this but (from my point of view) it helps to see the separation of business logic in the `Context` class so we can eventually rip this whole syncing thing out and have it as a completely separate class or something.

### 🕶️ Types of changes
Doesn't really fit neither of these categories :D

### 👫 Relationships
Part of the library overhaul slash kingfisher project.

### 🔎 Review hints
See if pushing changes still works as expected. Tell me if you like the code or not.

