### PR TITLE
Fix the conflict between the shortcut to switch to next/previous day on Timeline and built-in macOS shortcut

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -230,14 +230,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="KUm-TA-aKU"/>
-                            <menuItem title="Next Day" tag="3" keyEquivalent="" toolTip="Change a current Timeliine day to next day" id="HEB-2o-715">
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                            <menuItem title="Next Day" tag="3" keyEquivalent="]" toolTip="Change a current Timeliine day to next day" id="HEB-2o-715">
                                 <connections>
                                     <action selector="nextDayMenuOnClick:" target="-1" id="uVN-Lv-UoP"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Previous Day" tag="3" keyEquivalent="" toolTip="Change a current Timeliine day to previous day" id="kdC-8f-3ea">
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                            <menuItem title="Previous Day" tag="3" keyEquivalent="[" toolTip="Change a current Timeliine day to previous day" id="kdC-8f-3ea">
                                 <connections>
                                     <action selector="previouosDayMenuOnClick:" target="-1" id="kIq-Tb-6ik"/>
                                 </connections>


### PR DESCRIPTION
### 📒 Description
Fix the conflict between the shortcut to switch to next/previous day on Timeline and built-in macOS shortcut

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Change CMD+SHIFT+Arrow to **CMD+[** (previous) and **CMD + ]** (next)

### 👫 Relationships
Closes #3887

### 🔎 Review hints
- Make sure we're not able to reproduce the ticket
- CMD + [ or ] will change the day

