### PR TITLE
Improve the resize area in the Timeline Pill

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DateSelectionView/DatePickerView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -78,7 +78,7 @@
                                 </view>
                                 <color key="borderColor" name="upload-border-color"/>
                             </box>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ge4-G4-Vqd">
+                            <button toolTip="Next day ⌘]" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ge4-G4-Vqd">
                                 <rect key="frame" x="428" y="0.0" width="30" height="28"/>
                                 <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="next_date_arrow" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="2zx-Kp-QTZ">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -88,7 +88,7 @@
                                     <action selector="nextDateBtnOnTap:" target="c22-O7-iKe" id="sOk-CX-l6G"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eFj-dP-iWE">
+                            <button toolTip="Previous day ⌘[" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eFj-dP-iWE">
                                 <rect key="frame" x="0.0" y="0.0" width="30" height="28"/>
                                 <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="previous_date_arrow" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="V77-QB-Zs6">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -357,6 +357,7 @@ extension TimelineDashboardViewController: DatePickerViewDelegate {
         editorPopover.close()
         DesktopLibraryBridge.shared().timelineSetDate(date)
         delegate?.timelineDidChangeDate(date)
+        scrollToVisibleItem()
     }
 
     func datePickerShouldClose(_ sender: DatePickerView) {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -135,7 +135,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                                             <rect key="frame" x="33" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSAddTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="as8-De-WrX">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="label" size="13"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelIncreaseOnChange:" target="-2" id="QsV-0i-5La"/>
@@ -145,7 +145,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                                             <rect key="frame" x="10" y="9" width="11" height="11"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSRemoveTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="kr9-Ry-BUy">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="label" size="13"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="zoomLevelDecreaseOnChange:" target="-2" id="ksx-ak-4he"/>
@@ -227,7 +227,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                                 <constraint firstAttribute="width" constant="140" id="mdj-ct-y7d"/>
                             </constraints>
                             <textFieldCell key="cell" alignment="center" title="No entries here…  Go ahead and track some time!" id="rM7-R2-ABZ">
-                                <font key="font" metaFont="label" size="13"/>
+                                <font key="font" metaFont="system"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -235,7 +235,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                         <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3EE-on-mJF">
                             <rect key="frame" x="327" y="287" width="252" height="16"/>
                             <textFieldCell key="cell" alignment="center" title="Turn on activity recording to see results." id="PUb-OL-l5z">
-                                <font key="font" metaFont="label" size="13"/>
+                                <font key="font" metaFont="system"/>
                                 <color key="textColor" name="timeline-time-label-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineBaseCell.swift
@@ -136,7 +136,7 @@ extension TimelineBaseCell {
 extension TimelineBaseCell {
 
     private func initHoverTrackers() {
-        guard let view = foregroundBox, isHoverable else { return }
+        guard isHoverable else { return }
         trackingArea = NSTrackingArea(rect: view.bounds, options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect, .mouseMoved], owner: self, userInfo: nil)
         view.addTrackingArea(trackingArea!)
     }
@@ -272,7 +272,7 @@ extension TimelineBaseCell {
             if isSmallEntry {
                 return CGRect(x: 0, y: Constants.SideHideSmall, width: foregroundBox.frame.width, height: foregroundBox.frame.height - Constants.SideHideSmall * 2)
             }
-            return NSRect(x: 0, y: Constants.SideHit, width: foregroundBox.frame.width, height: foregroundBox.frame.height - Constants.SideHit * 2)
+            return NSRect(x: 0, y: Constants.SideHit, width: resizeView.frame.width, height: foregroundBox.frame.height - Constants.SideHit * 2)
         }
         return foregroundBox.bounds
     }
@@ -282,7 +282,7 @@ extension TimelineBaseCell {
         if isSmallEntry {
             return NSRect(x: 0, y: foregroundBox.frame.height - Constants.SideHideSmall, width: foregroundBox.frame.width, height: Constants.SideHideSmall)
         }
-        return NSRect(x: 0, y: foregroundBox.frame.height - Constants.SideHit, width: foregroundBox.frame.width, height: Constants.SideHit)
+        return NSRect(x: 0, y: foregroundBox.frame.height - Constants.SideHit, width: resizeView.frame.width, height: Constants.SideHit)
     }
 
     private func suitableBottomResizeRect() -> CGRect {
@@ -290,7 +290,7 @@ extension TimelineBaseCell {
         if isSmallEntry {
             return NSRect(x: 0, y: 0, width: foregroundBox.frame.width, height: Constants.SideHideSmall)
         }
-        return NSRect(x: 0, y: 0, width: foregroundBox.frame.width, height: Constants.SideHit)
+        return NSRect(x: 0, y: 0, width: resizeView.frame.width, height: Constants.SideHit)
     }
 
     private func convertToLocalPoint(for event: NSEvent) -> CGPoint {
@@ -298,5 +298,9 @@ extension TimelineBaseCell {
         let position = event.locationInWindow
         let localPosition = foregroundBox.convert(position, from: nil)
         return localPosition
+    }
+
+    private var resizeView: NSView {
+        return backgroundBox ?? foregroundBox
     }
 }


### PR DESCRIPTION
### 📒 Description
This PR would improve some UIUX from Timeline feature.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Add ToolTip for Next/Preview day button in Timeline
- Scroll to visible view (Timeline event, current moment or Timeline Pill) when switching dates
- Improve the Resize Area in the Pill

### 👫 Relationships
Closes #3876

### 🔎 Review hints
- Try the Resize + Drag&Drop on two kind of Timeline Pill (The big one and the small one)
=> Make sure we're able to resize from the bottom and top handler of the Time Entry

![2020-03-13 14 07 20](https://user-images.githubusercontent.com/5878421/76598100-a8a03d80-6534-11ea-8380-68546f968a9f.gif)
