### PR TITLE
Added missing keyboard shortcuts to menubar menu

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -948,7 +948,7 @@ void *ctx;
 			 keyEquivalent:@""].tag = kMenuItemTagOpenBrowser;
 	[menu addItemWithTitle:@"Preferences"
 					action:@selector(onPreferencesMenuItem:)
-			 keyEquivalent:@""];
+			 keyEquivalent:@","];
 	self.manualModeMenuItem = [menu addItemWithTitle:@"Use manual mode"
 											  action:@selector(onModeChange:)
 									   keyEquivalent:@"d"];
@@ -965,7 +965,7 @@ void *ctx;
 			 keyEquivalent:@""].tag = kMenuItemTagLogout;
 	[menu addItemWithTitle:@"Quit"
 					action:@selector(onQuitMenuItem)
-			 keyEquivalent:@""];
+			 keyEquivalent:@"q"];
 
 	NSStatusBar *bar = [NSStatusBar systemStatusBar];
 


### PR DESCRIPTION
### 📒 Description
Adds Quit and Preferences keyboard shortcuts to menubar menu items.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3893

### 🔎 Review hints
Start the app and check if the shortcuts are there. They are automatically working as the same shortcuts are used for the app main menu.

