### PR TITLE
Windows app auto update improvements

### DIFF
--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -231,6 +231,7 @@ Section "Uninstall"
   Delete "$INSTDIR\TogglDesktop.exe.config"
   Delete "$INSTDIR\toggl.ico"
   RMDir "$INSTDIR\updates"
+  RMDir "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
 
   ;Delete desktop shortcut
   Delete "$DESKTOP\TogglDesktop.lnk"

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -49,7 +49,6 @@
 ;--------------------------------
 ;Global variables
 
-  Var keyLength
   Var isOldUpdater
   Var isNewUpdater
   Var deleteData

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -277,7 +277,8 @@ Function checkUpdater
   IfErrors +3 0
   StrCpy $isOldUpdater 1
   SetSilent silent
-  ${GetOptions} $cmdLineParams "/UN" $R0
+  StrCpy $isNewUpdater 0
+  ${GetOptions} $cmdLineParams "/autoupdate" $R0
   IfErrors +3 0
   StrCpy $isNewUpdater 1
   SetSilent silent

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -51,7 +51,6 @@
 
   Var keyLength
   Var isUpdater
-  Var fromOldVersion
   Var deleteData
   Var CHECKBOX
   Var cmdLineParams
@@ -157,12 +156,6 @@ Section
   completed:
   DetailPrint "Everything went okay :-D"
 
-  ;Rename Bugsnag so we can update
-  Rename $INSTDIR\Bugsnag.dll $INSTDIR\Bugsnag.1.2.dll
-
-  ;Delete the old Bugsnag file on reboot
-  Delete /REBOOTOK $INSTDIR\Bugsnag.1.2.dll
-
   ;ADD YOUR OWN FILES HERE...
   File "${redist}\*.dll"
   File "${srcdir}\*.dll"
@@ -262,24 +255,7 @@ Function .onInit
 !endif
 
   ${GetParameters} $cmdLineParams
-  Call checkOldVersion
   Call checkUpdater
-
-FunctionEnd
-
-Function checkOldVersion
-
-  StrCpy $fromOldVersion 0
-
-  ReadRegStr $3 HKLM "SOFTWARE\Toggl\TogglDesktop" "Version"
-  StrLen $keyLength $3
-
-  ${if} $keyLength != 0
-    StrCpy $R3 $3 3
-    StrCmp $R3 "7.1" 0 Newer
-    StrCpy $fromOldVersion 1
-    Newer:
-  ${Endif}
 
 FunctionEnd
 
@@ -296,11 +272,6 @@ FunctionEnd
 
 Function .onInstSuccess
 
-  ${If} $fromOldVersion == 1
-    ;Copy local database from 7.1 app to newer app location
-    CopyFiles "$PROFILE\AppData\Roaming\Kopsik\kopsik.db" "$INSTDIR\toggldesktop.db"
-  ${EndIf}
-  
   ${if} $isUpdater == 1
     Exec "$INSTDIR\TogglDesktop.exe --updated"
   ${Endif}

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -191,8 +191,8 @@ Section
       CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
     ${EndIf}
 
-  ${If} $isOldUpdater == 1
-  ${OrIf} $isNewUpdater == 1
+  ${If} $isOldUpdater == 0
+  ${AndIf} $isNewUpdater == 0
     ;Add/Remove programs entry
     !define REG_UNINSTALL "Software\Microsoft\Windows\CurrentVersion\Uninstall\TogglDesktop"
     WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "Toggl Desktop"

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -157,6 +157,9 @@ Section
 
     completed:
     DetailPrint "Everything went okay :-D"
+    
+    ; Delete the main executable to prevent it from being launched while an update is running
+    Delete "$INSTDIR\TogglDesktop.exe"
   ${EndIf}
   
   ;ADD YOUR OWN FILES HERE...

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -156,6 +156,9 @@ Section
 
     completed:
     DetailPrint "Everything went okay :-D"
+    
+    ; Delete the main executable to prevent it from being launched while an update is running
+    Delete "$INSTDIR\TogglDesktop.exe"
   ${EndIf}
 
   ;ADD YOUR OWN FILES HERE...

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -228,6 +228,7 @@ Section "Uninstall"
   Delete "$INSTDIR\TogglDesktop.exe.config"
   Delete "$INSTDIR\toggl.ico"
   RMDir "$INSTDIR\updates"
+  RMDir "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
 
   ;Delete desktop shortcut
   Delete "$DESKTOP\TogglDesktop.lnk"

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -182,7 +182,7 @@ Section
 !endif
 
   ;Create Desktop shortcut only when shortcut is not present or at first install
-  IfFileExists $DESKTOP\TogglDesktop.lnk 0
+  IfFileExists $DESKTOP\TogglDesktop.lnk 0 ShortcutDoesntExist
     CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
     ShortcutDoesntExist:
     ${If} $isOldUpdater == 0

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -274,7 +274,8 @@ Function checkUpdater
   IfErrors +3 0
   StrCpy $isOldUpdater 1
   SetSilent silent
-  ${GetOptions} $cmdLineParams "/UN" $R0
+  StrCpy $isNewUpdater 0
+  ${GetOptions} $cmdLineParams "/autoupdate" $R0
   IfErrors +3 0
   StrCpy $isNewUpdater 1
   SetSilent silent

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -49,7 +49,6 @@
 ;--------------------------------
 ;Global variables
 
-  Var keyLength
   Var isOldUpdater
   Var isNewUpdater
   Var deleteData

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -51,7 +51,6 @@
 
   Var keyLength
   Var isUpdater
-  Var fromOldVersion
   Var deleteData
   Var CHECKBOX
   Var cmdLineParams
@@ -156,12 +155,6 @@ Section
   completed:
   DetailPrint "Everything went okay :-D"
 
-  ;Rename Bugsnag so we can update
-  Rename $INSTDIR\Bugsnag.dll $INSTDIR\Bugsnag.1.2.dll
-
-  ;Delete the old Bugsnag file on reboot
-  Delete /REBOOTOK $INSTDIR\Bugsnag.1.2.dll
-
   ;ADD YOUR OWN FILES HERE...
   File "${redist}\*.dll"
   File "${srcdir}\*.dll"
@@ -261,24 +254,7 @@ Function .onInit
 !endif
 
   ${GetParameters} $cmdLineParams
-  Call checkOldVersion
   Call checkUpdater
-
-FunctionEnd
-
-Function checkOldVersion
-
-  StrCpy $fromOldVersion 0
-
-  ReadRegStr $3 HKLM "SOFTWARE\Toggl\TogglDesktop" "Version"
-  StrLen $keyLength $3
-
-  ${if} $keyLength != 0
-    StrCpy $R3 $3 3
-    StrCmp $R3 "7.1" 0 Newer
-    StrCpy $fromOldVersion 1
-    Newer:
-  ${Endif}
 
 FunctionEnd
 
@@ -294,11 +270,6 @@ Function checkUpdater
 FunctionEnd
 
 Function .onInstSuccess
-
-  ${If} $fromOldVersion == 1
-    ;Copy local database from 7.1 app to newer app location
-    CopyFiles "$PROFILE\AppData\Roaming\Kopsik\kopsik.db" "$INSTDIR\toggldesktop.db"
-  ${EndIf}
   
   ${if} $isUpdater == 1
     Exec "$INSTDIR\TogglDesktop.exe --updated"

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -190,25 +190,27 @@ Section
       CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
     ${EndIf}
 
-  ;Add/Remove programs entry
-  !define REG_UNINSTALL "Software\Microsoft\Windows\CurrentVersion\Uninstall\TogglDesktop"
-  WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "Toggl Desktop"
-  WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayIcon" "$\"$INSTDIR\TogglDesktop.exe$\""
-  WriteRegStr HKCU "${REG_UNINSTALL}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
-  WriteRegStr HKCU "${REG_UNINSTALL}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
-  WriteRegStr HKCU "${REG_UNINSTALL}" "Publisher" "Toggl"
-  WriteRegStr HKCU "${REG_UNINSTALL}" "HelpLink" "https://support.toggl.com/desktop-apps"
-  WriteRegStr HKCU "${REG_UNINSTALL}" "URLInfoAbout" "https://www.toggl.com/"
-  WriteRegStr HKCU "${REG_UNINSTALL}" "InstallLocation" "$\"$INSTDIR$\""
-  WriteRegStr HKCU "${REG_UNINSTALL}" "NoModify" 1
-  WriteRegStr HKCU "${REG_UNINSTALL}" "NoRepair" 1
-  WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls Toggl Desktop"
+  ${If} $isOldUpdater == 0
+  ${AndIf} $isNewUpdater == 0
+    ;Add/Remove programs entry
+    !define REG_UNINSTALL "Software\Microsoft\Windows\CurrentVersion\Uninstall\TogglDesktop"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "Toggl Desktop"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayIcon" "$\"$INSTDIR\TogglDesktop.exe$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" "Publisher" "Toggl"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "HelpLink" "https://support.toggl.com/desktop-apps"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "URLInfoAbout" "https://www.toggl.com/"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "InstallLocation" "$\"$INSTDIR$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" "NoModify" 1
+    WriteRegStr HKCU "${REG_UNINSTALL}" "NoRepair" 1
+    WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls Toggl Desktop"
 
-  ;Create start menu entry
-  createDirectory "$SMPROGRAMS\Toggl"
-  createShortCut "$SMPROGRAMS\Toggl\Toggl Desktop.lnk" "$INSTDIR\TogglDesktop.exe" "" "$INSTDIR\toggl.ico"
-  createShortCut "$SMPROGRAMS\Toggl\Uninstall Toggl Desktop.lnk" "$INSTDIR\uninstall.exe" "" ""
-
+    ;Create start menu entry
+    createDirectory "$SMPROGRAMS\Toggl"
+    createShortCut "$SMPROGRAMS\Toggl\Toggl Desktop.lnk" "$INSTDIR\TogglDesktop.exe" "" "$INSTDIR\toggl.ico"
+    createShortCut "$SMPROGRAMS\Toggl\Uninstall Toggl Desktop.lnk" "$INSTDIR\uninstall.exe" "" ""
+  ${EndIf}
 SectionEnd
 
 ;--------------------------------

--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.config
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.config
@@ -42,16 +42,4 @@
             </setting>
         </TogglDesktop.Properties.Settings>
     </userSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Properties/AssemblyInfo.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Toggl")]
 [assembly: AssemblyProduct("TogglDesktop")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
@@ -8,7 +8,7 @@ namespace TogglDesktop.Services
 {
     public class NsisPackageExtractor : IPackageExtractor
     {
-        public async Task ExtractPackageAsync(string sourceFilePath, string destDirPath, IProgress<double>? progress = null,
+        public async Task ExtractPackageAsync(string sourceFilePath, string destDirPath, IProgress<double> progress = null,
             CancellationToken cancellationToken = new CancellationToken())
         {
             await Task.Run(() =>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Onova.Services;
+
+namespace TogglDesktop.Services
+{
+    public class NsisPackageExtractor : IPackageExtractor
+    {
+        public async Task ExtractPackageAsync(string sourceFilePath, string destDirPath, IProgress<double>? progress = null,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            await Task.Run(() =>
+            {
+                var process = new Process();
+                process.StartInfo.FileName = sourceFilePath;
+                process.StartInfo.Arguments = $"/S /U /D={destDirPath}";
+                process.StartInfo.UseShellExecute = false;
+                process.Start();
+                process.WaitForExit();
+            }, cancellationToken);
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
@@ -15,7 +15,7 @@ namespace TogglDesktop.Services
             {
                 var process = new Process();
                 process.StartInfo.FileName = sourceFilePath;
-                process.StartInfo.Arguments = $"/S /U /D={destDirPath}";
+                process.StartInfo.Arguments = $"/S /UN /D={destDirPath}";
                 process.StartInfo.UseShellExecute = false;
                 process.Start();
                 process.WaitForExit();

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/NsisPackageExtractor.cs
@@ -15,7 +15,7 @@ namespace TogglDesktop.Services
             {
                 var process = new Process();
                 process.StartInfo.FileName = sourceFilePath;
-                process.StartInfo.Arguments = $"/S /UN /D={destDirPath}";
+                process.StartInfo.Arguments = $"/S /autoupdate /D={destDirPath}";
                 process.StartInfo.UseShellExecute = false;
                 process.Start();
                 process.WaitForExit();

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
@@ -27,13 +27,11 @@ namespace TogglDesktop.Services
             Toggl.OnUpdateDownloadStatus
                 .Where(x => x.DownloadStatus == Toggl.DownloadStatus.Done)
                 .Subscribe(PrepareUpdate);
-            _updateStatusSubject.Subscribe(x => this.HasPendingUpdate = x.DownloadStatus == Toggl.DownloadStatus.Done);
             UpdateStatus = _updateStatusSubject.AsObservable();
         }
 
         public bool IsUpdateCheckEnabled { get; }
         public IObservable<UpdateStatus> UpdateStatus { get; }
-        public bool HasPendingUpdate { get; private set; }
 
         public void Update(bool withRestart = true)
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
@@ -34,7 +34,7 @@ namespace TogglDesktop.Services
         public bool IsUpdateCheckEnabled { get; }
         public IObservable<UpdateStatus> UpdateStatus { get; }
 
-        public void InstallPendingUpdate(bool withRestart = true)
+        public bool InstallPendingUpdate(bool withRestart = true)
         {
             var lastPreparedVersion = _updateManager.GetPreparedUpdates().LastOrDefault();
             if (lastPreparedVersion != null)
@@ -42,6 +42,7 @@ namespace TogglDesktop.Services
                 try
                 {
                     _updateManager.LaunchUpdater(lastPreparedVersion, withRestart);
+                    return true;
                 }
                 catch (Exception e)
                     when (e is UpdaterAlreadyLaunchedException || e is LockFileNotAcquiredException)
@@ -49,6 +50,8 @@ namespace TogglDesktop.Services
                     // Ignore race conditions
                 }
             }
+
+            return false;
         }
         public void Dispose()
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
@@ -1,43 +1,72 @@
 using System;
+using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Onova;
+using Onova.Services;
 
 namespace TogglDesktop.Services
 {
     public class UpdateService : IDisposable
     {
+        private readonly IUpdateManager _updateManager;
+        private IObservable<bool> _prepareUpdateObservable;
+        private readonly Subject<UpdateStatus> _updateStatusSubject = new Subject<UpdateStatus>();
         public UpdateService()
         {
             IsUpdateCheckEnabled = !Toggl.IsUpdateCheckDisabled();
+            _updateManager = new UpdateManager(
+                new LocalPackageResolver("updates", "TogglDesktopInstaller*.exe"),
+                new NsisPackageExtractor());
+
+            Toggl.OnUpdateDownloadStatus
+                .Where(x => x.DownloadStatus != Toggl.DownloadStatus.Done)
+                .Subscribe(_updateStatusSubject);
+            Toggl.OnUpdateDownloadStatus
+                .Where(x => x.DownloadStatus == Toggl.DownloadStatus.Done)
+                .Subscribe(PrepareUpdate);
+            _updateStatusSubject.Subscribe(x => this.HasPendingUpdate = x.DownloadStatus == Toggl.DownloadStatus.Done);
+            UpdateStatus = _updateStatusSubject.AsObservable();
         }
 
         public bool IsUpdateCheckEnabled { get; }
-        public IObservable<UpdateStatus> UpdateStatus { get; } = Observable.Return(new UpdateStatus());
+        public IObservable<UpdateStatus> UpdateStatus { get; }
+        public bool HasPendingUpdate { get; private set; }
 
-        public bool HasPendingUpdate { get; }
-        public void UpdateAndQuit(int exitCode = 0){}
-        public void UpdateAndRestart(){}
-
+        public void Update(bool withRestart = true)
+        {
+            var lastPreparedVersion = _updateManager.GetPreparedUpdates().LastOrDefault();
+            if (lastPreparedVersion != null)
+            {
+                _updateManager.LaunchUpdater(lastPreparedVersion, withRestart);
+            }
+        }
         public void Dispose()
         {
+            _updateManager.Dispose();
         }
-    }
 
-    public class UpdateStatus
-    {
-        public UpdateStatus()
+        private void PrepareUpdate(UpdateStatus updateStatus)
         {
-            HasUpdate = false;
+            if (_prepareUpdateObservable == null)
+            {
+                _prepareUpdateObservable = PrepareUpdateAsync().ToObservable();
+                _prepareUpdateObservable.Where(x => x).Subscribe(_ => _updateStatusSubject.OnNext(updateStatus));
+            }
         }
 
-        public UpdateStatus(Version version, Toggl.DownloadStatus downloadStatus)
+        private async Task<bool> PrepareUpdateAsync()
         {
-            HasUpdate = true;
-            Version = version;
-            DownloadStatus = downloadStatus;
-        }
+            var check = await _updateManager.CheckForUpdatesAsync();
+            if (check.CanUpdate)
+            {
+                await _updateManager.PrepareUpdateAsync(check.LastVersion);
+                return true;
+            }
 
-        public bool HasUpdate { get; }
-        public Version Version { get; }
-        public Toggl.DownloadStatus DownloadStatus { get; }
+            return false;
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Reactive.Linq;
+
+namespace TogglDesktop.Services
+{
+    public class UpdateService : IDisposable
+    {
+        public UpdateService()
+        {
+            IsUpdateCheckEnabled = !Toggl.IsUpdateCheckDisabled();
+        }
+
+        public bool IsUpdateCheckEnabled { get; }
+        public IObservable<UpdateStatus> UpdateStatus { get; } = Observable.Return(new UpdateStatus());
+
+        public bool HasPendingUpdate { get; }
+        public void UpdateAndQuit(int exitCode = 0){}
+        public void UpdateAndRestart(){}
+
+        public void Dispose()
+        {
+        }
+    }
+
+    public class UpdateStatus
+    {
+        public UpdateStatus()
+        {
+            HasUpdate = false;
+        }
+
+        public UpdateStatus(Version version, Toggl.DownloadStatus downloadStatus)
+        {
+            HasUpdate = true;
+            Version = version;
+            DownloadStatus = downloadStatus;
+        }
+
+        public bool HasUpdate { get; }
+        public Version Version { get; }
+        public Toggl.DownloadStatus DownloadStatus { get; }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateStatus.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateStatus.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace TogglDesktop.Services
+{
+    public class UpdateStatus
+    {
+        public UpdateStatus()
+        {
+            HasUpdate = false;
+        }
+
+        public UpdateStatus(Version version, Toggl.DownloadStatus downloadStatus)
+        {
+            HasUpdate = true;
+            Version = version;
+            DownloadStatus = downloadStatus;
+        }
+
+        public bool HasUpdate { get; }
+        public Version Version { get; }
+        public Toggl.DownloadStatus DownloadStatus { get; }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/Win10/RunOnStartup.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/Win10/RunOnStartup.cs
@@ -3,7 +3,7 @@ using System;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 
-namespace TogglDesktop.Win10
+namespace TogglDesktop.Services.Win10
 {
     public static class RunOnStartup
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1128,7 +1128,7 @@ public static partial class Toggl
 
         listenToLibEvents();
 
-        if (IsUpdateCheckDisabled())
+        if (Utils.GetIsUpdateCheckDisabledFromRegistry())
         {
             toggl_disable_update_check(ctx);
         }
@@ -1270,17 +1270,11 @@ public static partial class Toggl
 
     public static bool IsUpdateCheckDisabled()
     {
-        // On Windows platform, system admin can disable
-        // automatic update check via registry key.
-        object value = Microsoft.Win32.Registry.GetValue(
-            "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Toggl\\TogglDesktop",
-            "UpdateCheckDisabled",
-            false);
-        if (value == null)
-        {
-            return false;
-        }
-        return Convert.ToBoolean(value);
+#if TOGGL_ALLOW_UPDATE_CHECK
+        return Utils.GetIsUpdateCheckDisabledFromRegistry();
+#else
+        return true;
+#endif
     }
     #endregion
 
@@ -1456,6 +1450,11 @@ public static partial class Toggl
         Clear();
 
         update();
+    }
+
+    public static void PrepareShutdown()
+    {
+        mainWindow.PrepareShutdown(true);
     }
 
     public static void SetManualMode(bool manualMode)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1139,7 +1139,7 @@ public static partial class Toggl
             Environment.SpecialFolder.LocalApplicationData), "TogglDesktop");
 
 #if TOGGL_ALLOW_UPDATE_CHECK
-        cleanupUpdateDownloads();
+        installPendingUpdates();
 #endif
 
         // Configure log, db path
@@ -1163,7 +1163,7 @@ public static partial class Toggl
 
     // ReSharper disable once UnusedMember.Local
     // (updates are disabled in Debug configuration to allow for proper debugging)
-    private static void cleanupUpdateDownloads()
+    private static void installPendingUpdates()
     {
         var di = new DirectoryInfo(UpdatesPath);
         foreach (var file in di.GetFiles("TogglDesktopInstaller*.exe", SearchOption.TopDirectoryOnly))
@@ -1177,6 +1177,13 @@ public static partial class Toggl
                 BugsnagService.NotifyBugsnag(e);
                 Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
             }
+        }
+
+        var aboutWindowViewModel = mainWindow.GetWindow<AboutWindow>().ViewModel;
+        if (aboutWindowViewModel.InstallPendingUpdate())
+        {
+            // quit, updater will restart the app
+            Environment.Exit(0);
         }
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1165,6 +1165,7 @@ public static partial class Toggl
     // (updates are disabled in Debug configuration to allow for proper debugging)
     private static void installPendingUpdates()
     {
+        Directory.CreateDirectory(UpdatesPath); // make sure the directory exists
         var di = new DirectoryInfo(UpdatesPath);
         foreach (var file in di.GetFiles("TogglDesktopInstaller*.exe", SearchOption.TopDirectoryOnly))
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -189,7 +189,9 @@
     <Compile Include="BugsnagService.cs" />
     <Compile Include="Diagnostics\IPerformanceToken.cs" />
     <Compile Include="Diagnostics\Performance.cs" />
+    <Compile Include="Services\NsisPackageExtractor.cs" />
     <Compile Include="Services\UpdateService.cs" />
+    <Compile Include="Services\UpdateStatus.cs" />
     <Compile Include="Services\Win10\RunOnStartup.cs" />
     <Compile Include="SingleInstanceManager.cs" />
     <Compile Include="ui\Behaviors\ActivateParentWindowOnMouseClick.cs" />
@@ -872,6 +874,9 @@
     </PackageReference>
     <PackageReference Include="NHotkey.Wpf">
       <Version>1.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Onova">
+      <Version>2.5.2</Version>
     </PackageReference>
     <PackageReference Include="ReactiveUI.Fody">
       <Version>11.1.23</Version>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -189,6 +189,8 @@
     <Compile Include="BugsnagService.cs" />
     <Compile Include="Diagnostics\IPerformanceToken.cs" />
     <Compile Include="Diagnostics\Performance.cs" />
+    <Compile Include="Services\UpdateService.cs" />
+    <Compile Include="Services\Win10\RunOnStartup.cs" />
     <Compile Include="SingleInstanceManager.cs" />
     <Compile Include="ui\Behaviors\ActivateParentWindowOnMouseClick.cs" />
     <Compile Include="ui\Behaviors\ButtonHelper.cs" />
@@ -235,6 +237,7 @@
       <DependentUpon>TrayToolTipControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="ui\Converters\AndConverter.cs" />
+    <Compile Include="ui\Converters\CapitalizeConverter.cs" />
     <Compile Include="ui\Converters\EmptyStringToCollapsedConverter.cs" />
     <Compile Include="ui\Converters\IsSelectableItemConverter.cs" />
     <Compile Include="ui\Converters\StringFormatIfNotEmptyConverter.cs" />
@@ -302,6 +305,7 @@
     </Compile>
     <Compile Include="ui\Tutorial\TutorialManager.cs" />
     <Compile Include="ui\Tutorial\TutorialScreen.cs" />
+    <Compile Include="ui\ViewModels\AboutWindowViewModel.cs" />
     <Compile Include="ui\ViewModels\DayHeaderViewModel.cs" />
     <Compile Include="ui\ViewModels\FeedbackWindowViewModel.cs" />
     <Compile Include="ui\ViewModels\LoginViewModel.cs" />
@@ -406,7 +410,6 @@
     <Compile Include="ui\views\Timer.xaml.cs">
       <DependentUpon>Timer.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Win10\RunOnStartup.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/CapitalizeConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/CapitalizeConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace TogglDesktop.Converters
+{
+    public class CapitalizeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var stringValue = value as string;
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                return value;
+            }
+
+            return char.ToUpper(stringValue[0]) + stringValue.Substring(1);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
@@ -44,7 +44,8 @@ namespace TogglDesktop.ViewModels
         private void UpdateAndRestart()
         {
             Toggl.PrepareShutdown();
-            _updateService.UpdateAndRestart();
+            _updateService.Update();
+            Program.Shutdown(0);
         }
 
         private static void SetUpdateChannel(string channel) => Toggl.SetUpdateChannel(channel);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
@@ -23,7 +23,9 @@ namespace TogglDesktop.ViewModels
                     .ToPropertyEx(this, x => x.UpdateStatusText);
             }
             UpdateAndRestartCommand = ReactiveCommand.Create(UpdateAndRestart,
-                updateStatus.Select(status => status.DownloadStatus == Toggl.DownloadStatus.Done));
+                updateStatus
+                    .Select(status => status.DownloadStatus == Toggl.DownloadStatus.Done)
+                    .ObserveOnDispatcher());
         }
 
         public string VersionText { get; }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Reactive.Linq;
+using DynamicData.Binding;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using TogglDesktop.Services;
+
+namespace TogglDesktop.ViewModels
+{
+    public class AboutWindowViewModel : ReactiveObject
+    {
+        private readonly UpdateService _updateService;
+        public string[] Channels { get; } = {"stable", "beta", "dev"};
+
+        public AboutWindowViewModel(UpdateService updateService)
+        {
+            VersionText = $"Version {Program.Version()} {Utils.Bitness()}";
+            _updateService = updateService;
+            var updateStatus = updateService.UpdateStatus;
+            IsUpdateCheckEnabled = updateService.IsUpdateCheckEnabled;
+            if (IsUpdateCheckEnabled)
+            {
+                updateStatus.Select(GetUpdateStatusText)
+                    .ToPropertyEx(this, x => x.UpdateStatusText);
+                this.WhenPropertyChanged(x => x.SelectedChannel)
+                    .Select(x => x.Value)
+                    .Subscribe(SetUpdateChannel);
+            }
+            UpdateAndRestartCommand = ReactiveCommand.Create(UpdateAndRestart,
+                updateStatus.Select(status => status.DownloadStatus == Toggl.DownloadStatus.Done));
+        }
+
+        public string VersionText { get; }
+
+        public bool IsUpdateCheckEnabled { get; }
+
+        [Reactive]
+        public string SelectedChannel { get; set; }
+
+        public string UpdateStatusText { [ObservableAsProperty] get; }
+
+        public IReactiveCommand UpdateAndRestartCommand { get; }
+
+        private void UpdateAndRestart()
+        {
+            Toggl.PrepareShutdown();
+            _updateService.UpdateAndRestart();
+        }
+
+        private static void SetUpdateChannel(string channel) => Toggl.SetUpdateChannel(channel);
+
+        private static string GetUpdateStatusText(UpdateStatus status) =>
+            status.HasUpdate
+                ? (status.DownloadStatus == Toggl.DownloadStatus.Started
+                    ? $"Downloading version {status.Version} ..."
+                    : $"New version {status.Version} available!")
+                : string.Empty;
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
@@ -39,9 +39,9 @@ namespace TogglDesktop.ViewModels
 
         public IReactiveCommand UpdateAndRestartCommand { get; }
 
-        public void InstallPendingUpdate()
+        public bool InstallPendingUpdate()
         {
-            _updateService.InstallPendingUpdate();
+            return _updateService.InstallPendingUpdate();
         }
 
         private void UpdateAndRestart()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml
@@ -6,18 +6,21 @@
         xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
+        xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
+        xmlns:converters="clr-namespace:TogglDesktop.Converters"
         mc:Ignorable="d" 
         Height="460" Width="300"
         Title="About"
         Background="{DynamicResource Toggl.CardBackground}"
         WindowStartupLocation="CenterOwner"
-        DataContext="{Binding RelativeSource={RelativeSource Self}}"
+        d:DataContext="{d:DesignInstance viewModels:AboutWindowViewModel, IsDesignTimeCreatable=False}"
         Style="{StaticResource Toggl.ToolWindow}">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../Resources/DesignUpdate/MahApps.Overrides.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <converters:CapitalizeConverter x:Key="CapitalizeConverter" />
         </ResourceDictionary>
     </Window.Resources>
     <i:Interaction.Behaviors>
@@ -37,24 +40,24 @@
             <TextBlock Text="Toggl Desktop" HorizontalAlignment="Center"
                        Style="{StaticResource Toggl.TitleText}"
                        Margin="0 0 0 10"/>
-            <TextBlock Name="versionText" x:FieldModifier="private"
-                       Style="{StaticResource Toggl.CaptionText}"
-                       Text="Version 1.33.7" HorizontalAlignment="Center"
+            <TextBlock Style="{StaticResource Toggl.CaptionText}"
+                       Text="{Binding VersionText, Mode=OneTime}"
+                       HorizontalAlignment="Center"
                        Margin="0 0 0 16"/>
             
-            <TextBlock Name="updateText" x:FieldModifier="private"
-                       Style="{StaticResource Toggl.BaseText}"
+            <TextBlock Style="{StaticResource Toggl.BaseText}"
                        Foreground="{DynamicResource Toggl.AccentBrush}"
-                       Text="Downloading version X&#10;This is a test"
+                       Text="{Binding UpdateStatusText}"
                        HorizontalAlignment="Center"
                        TextAlignment="Center"
                        Margin="0 0 0 8"/>
 
-            <Button Name="restartButton" x:FieldModifier="private"
-                    Width="152"
-                    Click="onRestartButtonClick"
-                    Content="Update &amp; restart" Style="{StaticResource Toggl.AccentButton}"
-                    HorizontalAlignment="Center" />
+            <Button Width="152"
+                    Content="Update &amp; restart"
+                    Style="{StaticResource Toggl.AccentButton}"
+                    HorizontalAlignment="Center"
+                    Command="{Binding UpdateAndRestartCommand}"
+                    Visibility="{Binding RelativeSource={RelativeSource Self}, Path=IsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
         </StackPanel>
         
         <StackPanel Grid.Row="0" VerticalAlignment="Bottom">
@@ -80,15 +83,20 @@
         </StackPanel>
 
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
-            <TextBlock Name="releaseChannelLabel" x:FieldModifier="private"
-                       Style="{StaticResource Toggl.CaptionBlackText}"
+            <TextBlock Style="{StaticResource Toggl.CaptionBlackText}"
                        Text="Release channel:"
-                       Margin="8,4,8,32" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-            <ComboBox Name="releaseChannelComboBox" x:FieldModifier="private"
-                      Margin="8,0,8,28" Height="24" Width="114"
+                       Margin="8,4,8,32" HorizontalAlignment="Left" VerticalAlignment="Center"
+                       Visibility="{Binding IsUpdateCheckEnabled, Converter={StaticResource FalseToHiddenVisibilityConverter}}"/>
+            <ComboBox Margin="8,0,8,28" Height="24" Width="114"
                       ItemsSource="{Binding Channels}"
+                      SelectedItem="{Binding SelectedChannel}"
                       HorizontalAlignment="Right"
-                      SelectionChanged="onReleaseChannelSelectionChanged">
+                      Visibility="{Binding IsUpdateCheckEnabled, Converter={StaticResource FalseToHiddenVisibilityConverter}}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Path='', Converter={StaticResource CapitalizeConverter}}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
             </ComboBox>
         </StackPanel>
     </Grid>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
@@ -1,90 +1,25 @@
-﻿using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
+﻿using System.Windows;
+using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
 {
     public partial class AboutWindow
     {
-        public string[] Channels { get; } = new[] {"Stable", "Beta", "Dev"};
-
-        public AboutWindow()
+        public AboutWindowViewModel ViewModel
         {
+            get => (AboutWindowViewModel)DataContext;
+            set => DataContext = value;
+        }
+
+        public AboutWindow(AboutWindowViewModel viewModel)
+        {
+            ViewModel = viewModel;
             this.InitializeComponent();
-
-            this.updateText.Text = "";
-            this.restartButton.Visibility = Visibility.Collapsed;
-
-            this.versionText.Text = $"Version {Program.Version()} {Utils.Bitness()}";
-
-            var isUpdatCheckDisabled = Toggl.IsUpdateCheckDisabled();
-            this.releaseChannelComboBox.ShowOnlyIf(!isUpdatCheckDisabled, true);
-            this.releaseChannelLabel.ShowOnlyIf(!isUpdatCheckDisabled, true);
-
-            Toggl.OnDisplayUpdateDownloadState += this.onDisplayUpdateDownloadState;
-        }
-
-        private void onDisplayUpdateDownloadState(string version, Toggl.DownloadStatus status)
-        {
-            if (this.TryBeginInvoke(this.onDisplayUpdateDownloadState, version, status))
-                return;
-
-            string format;
-            switch (status)
-            {
-                case Toggl.DownloadStatus.Started:
-                {
-                    format = "Downloading version {0} ...";
-                    this.restartButton.Visibility = Visibility.Collapsed;
-                    break;
-                }
-                case Toggl.DownloadStatus.Done:
-                {
-                    format = "New version {0} available!";
-                    this.restartButton.IsEnabled = true;
-                    this.restartButton.Visibility = Visibility.Visible;
-                    break;
-                }
-                default:
-                    throw new ArgumentOutOfRangeException("status", status, null);
-            }
-
-            this.updateText.Text = string.Format(format, version);
-            this.updateText.Visibility = Visibility.Visible;
-        }
-
-        private void onReleaseChannelSelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            var value = this.releaseChannelComboBox.SelectedValue;
-            if (value == null)
-                return;
-            var channel = value.ToString().ToLower();
-            Toggl.SetUpdateChannel(channel);
-        }
-
-        public void UpdateReleaseChannel()
-        {
-            var channel = Toggl.UpdateChannel();
-            this.releaseChannelComboBox.SelectedItem = Channels.First(x => x.Equals(channel, StringComparison.OrdinalIgnoreCase));
         }
 
         private void onGithubLinkClick(object sender, RoutedEventArgs e)
         {
             Toggl.OpenInBrowser("https://github.com/toggl/toggldesktop");
-        }
-
-        private void onRestartButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.restartButton.IsEnabled = false;
-
-            this.Hide();
-
-            Toggl.RestartAndUpdate();
-
-            MessageBox.Show(this, "Something went wrong.\nPlease restart Toggl Desktop manually.");
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -704,8 +704,8 @@ namespace TogglDesktop
             this.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
             {
                 // TODO: move this to startup if it causes issues here
-                _updateService.UpdateAndQuit(exitCode);
-                // Program.Shutdown(exitCode);
+                _updateService.Update(withRestart: false);
+                Program.Shutdown(exitCode);
             }));
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -701,10 +701,11 @@ namespace TogglDesktop
 
             this.PrepareShutdown(exitCode == 0);
 
+            // TODO: move this to startup if it causes issues here
+            _updateService.Update(withRestart: false);
+
             this.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
             {
-                // TODO: move this to startup if it causes issues here
-                _updateService.Update(withRestart: false);
                 Program.Shutdown(exitCode);
             }));
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -736,6 +736,7 @@ namespace TogglDesktop
                 Utils.SaveWindowLocation(this, this.editPopup, this.miniTimer);
             }
 
+            this.childWindows.ForEach(w => w.Hide());
             this.Close();
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -700,10 +700,6 @@ namespace TogglDesktop
 
             this.PrepareShutdown(exitCode == 0);
 
-            // TODO: move this to startup if it causes issues here
-
-            this.GetWindow<AboutWindow>().ViewModel.InstallPendingUpdate();
-
             this.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
             {
                 Program.Shutdown(exitCode);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -14,7 +14,7 @@ using TogglDesktop.Theming;
 using TogglDesktop.ViewModels;
 
 #if MS_STORE
-using TogglDesktop.Win10;
+using TogglDesktop.Services.Win10;
 #endif
 namespace TogglDesktop
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -282,6 +282,7 @@ public static class Utils
         #region registry
 
         private const string StartupAppsRegistryPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
+        private const string PoliciesRegistryPath = @"Software\Policies\Toggl\TogglDesktop";
         public static bool GetLaunchOnStartupRegistry()
         {
             var subKey = Registry.CurrentUser.OpenSubKey(StartupAppsRegistryPath);
@@ -312,6 +313,15 @@ public static class Utils
                     subKey.DeleteValue("TogglDesktop");
                 }
             }
+        }
+
+        public static bool GetIsUpdateCheckDisabledFromRegistry()
+        {
+            // On Windows platform, system admin can disable
+            // automatic update check via registry key.
+            var subKey = Registry.LocalMachine.OpenSubKey(PoliciesRegistryPath, false);
+            var value = subKey?.GetValue("UpdateCheckDisabled", false);
+            return value != null && Convert.ToBoolean(value);
         }
 
         public static bool TryOpenInDefaultBrowser(string url)


### PR DESCRIPTION
### 📒 Description
Windows app auto-update process improvements

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Switch to Onova library for performing auto-updates (new auto-update flow, see #3853)
- [x] New cmd line argument for the installer for lightweight auto-update (no registry overwrites or process force-quit)
- [x] Delete the main executable to prevent it from being launched while an update is running
- [x] Remove database file migration from v7.1 app
- [x] Refactor About view to MVVM

### 👫 Relationships
Closes #3853

### 🔎 Review hints

# Test scenarios

1. Clean install of the new installer
- Fully uninstall any installed app
- Install 7.5.75 app from the pre-built installer linked below
- Check that the app works correctly

2. Auto-update from 7.5.46 to new
- skip, can't test until we do a dev release

3. Auto-update from new to new
  3.1. About view
  - Install 7.5.74 version from the link below
  - Verify that the app can be auto-updated to 7.5.75 from About view.
  3.2. App restart
  - Install 7.5.74 version from the link below
  - Wait until the new version is downloaded
  - Verify that the app is auto-updated with a simple app restart.
  3.3. Not fully downloaded
  - Install 7.5.74 version from the link below
  - Quickly restart the app before the update is fully downloaded and make sure the app works properly

4. Manual install of the new installer on top of 7.5.46
  - Manually install pre-built 7.5.74 or 7.5.75 on top of installed 7.5.46 version.

5. Manual install of the new installer on top of a new app
  - Manually install 7.5.75 or 7.5.74 on top of installed 7.5.75 or 7.5.74 version

6. Debug mode → no auto-updates
  - Run the app in Debug mode. Make sure no updates are being downloaded (check in the About view or by network activity).

7. MS Store app → no auto-updates
  - Run the app in `StoreDebug` or `StoreRelease` configurations. Make sure no updates are being downloaded (check in the About view or by network activity).

Randomly test a couple of these scenarios on a 32-bit version.

Manually built installers, hardcoded to update to a custom 7.5.75 version by the second link:
32-bit:
https://github.com/skel35/toggldesktop/releases/download/v7.5.74/TogglDesktopInstaller-v7.5.74.exe
https://github.com/skel35/toggldesktop/releases/download/v7.5.75/TogglDesktopInstaller-v7.5.75.exe

64-bit:
https://github.com/skel35/toggldesktop/releases/download/v7.5.74/TogglDesktopInstaller-x64-v7.5.74.exe
https://github.com/skel35/toggldesktop/releases/download/v7.5.75/TogglDesktopInstaller-x64-v7.5.75.exe