### PR TITLE
Fix window size and location on first app launch

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml
@@ -29,7 +29,7 @@
     <Grid Background="{StaticResource ViewBackground}">
         <Border BorderThickness="1"
                 BorderBrush="{DynamicResource Toggl.LoginView.Border}"
-                Width="300" Height="432"
+                Width="302" Height="432"
                 Background="{DynamicResource Toggl.CardBackground}"
                 VerticalAlignment="Center" HorizontalAlignment="Center">
             <DockPanel>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -44,8 +44,8 @@ public static class Utils
         }
         else
         {
-            mainWindow.Width = 330;
-            mainWindow.Height = 510;
+            mainWindow.Width = 300;
+            mainWindow.Height = 458;
             Toggl.Debug("Failed to retrieve window location and size. Setting the default size.");
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -44,6 +44,7 @@ public static class Utils
         }
         else
         {
+            mainWindow.WindowStartupLocation = WindowStartupLocation.CenterScreen;
             mainWindow.Width = 300;
             mainWindow.Height = 458;
             Toggl.Debug("Failed to retrieve window location and size. Setting the default size.");


### PR DESCRIPTION
### 📒 Description
Fix window size and location on first app launch

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Make default window size match LoginView's minimum size
- [x] fix 1px grey horizontal border in the Login view when resized to minimum
- [x] Set window's default location to be the center of the screen

### 👫 Relationships
Closes #3906

### 🔎 Review hints
First app launch -> window size is equal to the minimum size of the window in the Login view, window is positioned at the screen center.
Subsequent app launches -> window size and position are retrieved from what they were when it was last closed.