### PR TITLE
Fix possible crash when selecting the default workspace (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/AutoCompleteViewDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/AutoCompleteViewDataSource.swift
@@ -86,8 +86,7 @@ class AutoCompleteViewDataSource: NSObject {
     }
 
     func selectRow(at index: Int) {
-        guard index >= 0 else { return }
-        let item = items[index]
+        guard let item = items[safe: index] else { return }
         delegate?.autoCompleteSelectionDidChange(sender: self, item: item)
     }
 


### PR DESCRIPTION
### 📒 Description
I couldn't reproduce this bug and found no race condition issue on macOS UI, but we have some in TogglLibrary

<img width="358" alt="Screen Shot 2020-03-23 at 14 46 38" src="https://user-images.githubusercontent.com/5878421/77294059-2246e100-6d16-11ea-8124-5f6475c3f3e1.png">

The [crash log](https://app.bugsnag.com/toggldesktop/toggldesktop/timeline?filters%5Bevent.since%5D%5B0%5D%5Btype%5D=eq&filters%5Bevent.since%5D%5B0%5D%5Bvalue%5D=30d&filters%5Berror.status%5D%5B0%5D%5Btype%5D=eq&filters%5Berror.status%5D%5B0%5D%5Bvalue%5D=open&filters%5Bsearch%5D%5B0%5D%5Btype%5D=eq&filters%5Bsearch%5D%5B0%5D%5Bvalue%5D=TogglDesktop.ProjectCreationView&filters%5Bsearch%5D%5B1%5D%5Btype%5D=eq&filters%5Bsearch%5D%5B1%5D%5Bvalue%5D=selectDefaultWorkspace&pivot_tab=event) and the [code base](https://github.com/toggl-open-source/toggldesktop/blob/master/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift#L308-L313) are totally fine (Use guard statement to safely cast objs).

The only thing it could cause the crash is in 
```
func selectRow(at index: Int) { }
```
since it might access an invalid range.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Get item safely from the workspace arrays

### 👫 Relationships
Closes #3909

### 🔎 Review hints
- Play around (Start/Stop/Create Project/Workspace, ...) and make sure no crash

