### PR TITLE
Shut down the app process in the uninstaller

### DIFF
--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -223,6 +223,7 @@ SectionEnd
 !ifdef INNER
 Section "Uninstall"
 
+  Call un.killAppProcess
   ;ADD YOUR OWN FILES HERE...
   Delete "$INSTDIR\*.dll"
   Delete "$INSTDIR\*.xml"
@@ -231,7 +232,7 @@ Section "Uninstall"
   Delete "$INSTDIR\TogglDesktop.exe.config"
   Delete "$INSTDIR\toggl.ico"
   RMDir "$INSTDIR\updates"
-  RMDir "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
+  RMDir /r "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
 
   ;Delete desktop shortcut
   Delete "$DESKTOP\TogglDesktop.lnk"
@@ -330,6 +331,24 @@ Function un.customPage
 
   nsDialogs::Show
 
+FunctionEnd
+
+Function un.killAppProcess
+  ;Check if Old version of the app is still running and close it
+  DetailPrint "Closing all old TogglDesktop processes"
+  File "NSIS_plugins\KillProc.exe"
+  nsExec::Exec "$INSTDIR\KillProc.exe TogglDesktop"
+  Delete "$INSTDIR\KillProc.exe"
+  StrCmp $0 "-1" wooops
+
+  Goto completed
+
+  wooops:
+  DetailPrint "-> Error: Something went wrong :-("
+  Abort
+
+  completed:
+  DetailPrint "Everything went okay :-D"
 FunctionEnd
 
 Function un.OnCheckbox

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -222,6 +222,7 @@ SectionEnd
 !ifdef INNER
 Section "Uninstall"
 
+  Call un.killAppProcess
   ;ADD YOUR OWN FILES HERE...
   Delete "$INSTDIR\*.dll"
   Delete "$INSTDIR\*.xml"
@@ -230,7 +231,7 @@ Section "Uninstall"
   Delete "$INSTDIR\TogglDesktop.exe.config"
   Delete "$INSTDIR\toggl.ico"
   RMDir "$INSTDIR\updates"
-  RMDir "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
+  RMDir /r "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
 
   ;Delete desktop shortcut
   Delete "$DESKTOP\TogglDesktop.lnk"
@@ -328,6 +329,25 @@ Function un.customPage
   nsDialogs::OnClick $CHECKBOX $0
 
   nsDialogs::Show
+
+FunctionEnd
+
+Function un.killAppProcess
+  ;Check if Old version of the app is still running and close it
+  DetailPrint "Closing all old TogglDesktop processes"
+  File "NSIS_plugins\KillProc.exe"
+  nsExec::Exec "$INSTDIR\KillProc.exe TogglDesktop"
+  Delete "$INSTDIR\KillProc.exe"
+  StrCmp $0 "-1" wooops
+
+  Goto completed
+
+  wooops:
+  DetailPrint "-> Error: Something went wrong :-("
+  Abort
+
+  completed:
+  DetailPrint "Everything went okay :-D"
 
 FunctionEnd
 


### PR DESCRIPTION
### 📒 Description
The solution is to simply kill the app process during the uninstallation. This is both simple to implement and simple to the user because it doesn't introduce any dialogs which the user would probably not want to see.
This will also make the app reinstall be a more reliable last resort option to fix some odd user issues.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] If Toggl Desktop process is open during uninstallation - force shut down the process
- [x] Remove Onova/TogglDesktop directory with /r switch (remove all subfiles and subdirectories recursively)

### 👫 Relationships
Closes #3929

### 🔎 Review hints

1. Install the app
2. Run the app
3. While the app is running, run the uninstaller (either find it using Start -> Settings -> Apps&features or look inside `%LOCALAPPDATA%/TogglDesktop/Uninstall.exe`)

Expected result:
1. Uninstallation is successful - app files are properly deleted.
2. %LOCALAPPDATA%/Onova/TogglDesktop directory is deleted.

Try both 64-bit and 32-bit versions.

Pre-built installers:

[TogglDesktopInstaller-x64.zip](https://github.com/toggl-open-source/toggldesktop/files/4382343/TogglDesktopInstaller-x64.zip)
[TogglDesktopInstaller.zip](https://github.com/toggl-open-source/toggldesktop/files/4382344/TogglDesktopInstaller.zip)