### PR TITLE
Typo in Apple Sign In

### DIFF
--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -207,7 +207,7 @@ extern void *ctx;
             self.signUpGroupView.hidden = YES;
             self.appleBtn.title = @" Log in with Apple";
             self.googleBtn.title = @" Log in with Google";
-            self.userActionBtn.title = @"Login with email";
+            self.userActionBtn.title = @"Log in with email";
             self.forgotPasswordTextField.hidden = NO;
             self.signUpLink.stringValue = @"Sign up for free";
             self.donotHaveAccountLbl.hidden = NO;


### PR DESCRIPTION
### 📒 Description
There are some feedbacks from the design 
- On login page the CTA text should be "Log in with email"
- ~Country picker styling is missing~
- ~Error state if no google account is wrong. Please change it as per design~

After a discussion, we decide to don't do it. Conversation at https://toggl.slack.com/archives/CSE5U3ZUN/p1585147120002400?thread_ts=1585146374.002200&cid=CSE5U3ZUN

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Fix the type "Log in"

### 👫 Relationships
No

### 🔎 Review hints
- Make sure "On the login page, the CTA text should be "Log in with email"

