### PR TITLE
Improve Google Error message and layout

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/SystemMessage/FloatingErrorView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/SystemMessage/FloatingErrorView.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,18 +17,18 @@
                 <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KwU-6U-Riq">
                     <rect key="frame" x="15" y="10" width="205" height="54"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ur6-hb-DKX">
-                            <rect key="frame" x="-2" y="18" width="101" height="18"/>
+                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ur6-hb-DKX">
+                            <rect key="frame" x="-2" y="19" width="101" height="17"/>
                             <textFieldCell key="cell" selectable="YES" title="Multiline Label " id="B1S-5c-RPX">
-                                <font key="font" metaFont="system" size="14"/>
+                                <font key="font" metaFont="menu" size="14"/>
                                 <color key="textColor" name="error-title-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0Gx-33-val">
-                            <rect key="frame" x="-2" y="38" width="209" height="16"/>
+                        <textField hidden="YES" verticalHuggingPriority="749" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="0Gx-33-val">
+                            <rect key="frame" x="-2" y="39" width="209" height="15"/>
                             <textFieldCell key="cell" selectable="YES" title="Label Label Label Label Label Label " id="Qco-aY-dFI">
-                                <font key="font" metaFont="cellTitle"/>
+                                <font key="font" metaFont="label" size="12"/>
                                 <color key="textColor" name="grey-text-color"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -71,7 +72,7 @@
     <resources>
         <image name="close-button" width="7" height="7"/>
         <namedColor name="error-title-color">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23100000619888306" blue="0.18799999356269836" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="grey-text-color">
             <color red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -262,12 +262,14 @@ extern void *ctx;
 	if ([errorStr isEqualToString:@"access_denied"])
 	{
 		errorStr = @"Google login access was denied to app.";
-	}
-
-	if ([errorStr isEqualToString:@"The operation couldn’t be completed. (com.google.GTMOAuth2 error -1000.)"])
+	} else if ([errorStr isEqualToString:@"The operation couldn’t be completed. (com.google.GTMOAuth2 error -1000.)"])
 	{
 		errorStr = @"Window was closed before login completed.";
-	}
+    } else if (error.code == -1009) {
+        errorStr = @"The Internet connection appears to be offline.";
+    } else {
+        errorStr = [NSString stringWithFormat:@"Google Authorization Failed. Code %ld", (long)error.code];
+    }
 
 	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
 																object:errorStr];

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -117,6 +117,7 @@ extern void *ctx;
 	[self.messageView addConstraint:height];
 	[self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0]];
 	[self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0]];
+    [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationGreaterThanOrEqual toItem:self.contentView attribute:NSLayoutAttributeTop multiplier:1 constant:16]];
 
 	// Hidden by default
 	self.messageView.hidden = YES;


### PR DESCRIPTION
### 📒 Description
Improve error message and prevent the Error Layout doesn't grow out of the main window bounds

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Improve error message from Google
- Add some constraints and change compression and content hugging priority

### 👫 Relationships
Closes #3824

### 🔎 Review hints
#### The error message view shouldn't grow outside the window view.
1. Add this code to end of method `windowDidLoad` of `MainWindowController` class
```objective-c
    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
        [self displayError:@"Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long error "];
    });
```
2. Run the app
3. Verify that the error message doesn't go out the bound and we can hit X to close the view
<img width="549" alt="Screen Shot 2020-03-26 at 15 04 47" src="https://user-images.githubusercontent.com/5878421/77624633-b1513480-6f74-11ea-895c-6ec24ddf5eda.png">

4. Try to login with invalid email/password
Verify that the short message is still small size.
<img width="549" alt="Screen Shot 2020-03-26 at 15 04 53" src="https://user-images.githubusercontent.com/5878421/77624698-cb8b1280-6f74-11ea-9be8-3f27f4b62ca6.png">

### Long Google error message should not show up.
1. Try to login with Google while a computer is offline (I'm not sure how to do it)
2. Make sure the error message is now clean.