### PR TITLE
Fix ArgumentException crash when restoring edit view width

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -21,7 +21,15 @@ public static class Utils
     {
         if (editPopup != null)
         {
-            editPopup.Width = Toggl.GetEditViewWidth();
+            var editWidth = Toggl.GetEditViewWidth();
+            if (editWidth > 0 && editWidth < int.MaxValue)
+            {
+                editPopup.Width = editWidth;
+            }
+            else
+            {
+                editPopup.Width = editPopup.MinWidth;
+            }
         }
         if (Toggl.GetWindowMaximized())
         {


### PR DESCRIPTION
### 📒 Description
Fix ArgumentException crash when restoring edit view width

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Validate edit view width before restoring it 

### 👫 Relationships
Closes #3938

### 🔎 Review hints
#### Scenario 1
- Open `toggldesktop.db`
- Change the value of `settings.window_edit_size_width` to -9223372036854775808.
- Open the app
- Verify the app doesn't crash, the edit view is displayed with a normal size

#### Scenario 2
- Open the app
- Change the size of the edit view
- Quit the app and open it again
- Verify that the size of the edit view has been restored