### PR TITLE
Make Autotracker support multiple window titles

### DIFF
--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -14,7 +14,7 @@ static const char kTermSeparator = '\t';
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
     for (const auto& term : terms_) {
         if (Poco::UTF8::toLower(event.Title()).find(term)
-            != std::string::npos) {
+                != std::string::npos) {
             return true;
         }
     }

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -13,10 +13,6 @@ static const char kTermSeparator = '\t';
 
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
     for (const auto& term : terms_) {
-        if (Poco::UTF8::toLower(event.Filename()).find(term)
-            != std::string::npos) {
-            return true;
-        }
         if (Poco::UTF8::toLower(event.Title()).find(term)
             != std::string::npos) {
             return true;

--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -18,7 +18,6 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  public:
     AutotrackerRule()
         : BaseModel()
-    , term_("")
     , pid_(0)
     , tid_(0) {}
 
@@ -26,8 +25,9 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
 
     bool Matches(const TimelineEvent &event) const;
 
-    const std::string &Term() const;
-    void SetTerm(const std::string &value);
+    const std::vector<std::string> &Terms() const;
+    void SetTerms(const std::string &value);
+    const std::string TermsString() const;
 
     const Poco::UInt64 &PID() const;
     void SetPID(const Poco::UInt64 value);
@@ -41,7 +41,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     std::string ModelURL() const override;
 
  private:
-    std::string term_;
+    std::vector<std::string> terms_;
     Poco::UInt64 pid_;
     Poco::UInt64 tid_;
 };

--- a/src/context.cc
+++ b/src/context.cc
@@ -831,7 +831,7 @@ void Context::updateUI(const UIElements &what) {
                     view::AutotrackerRule rule;
                     rule.ProjectName = Formatter::JoinTaskName(t, p);
                     rule.ID = model->LocalID();
-                    rule.Term = model->Term();
+                    rule.Term = model->TermsString();
                     autotracker_rule_views.push_back(rule);
                 }
 
@@ -3934,7 +3934,7 @@ error Context::AddAutotrackerRule(
         }
 
         rule = new AutotrackerRule();
-        rule->SetTerm(lowercase);
+        rule->SetTerms(lowercase);
         if (t) {
             rule->SetTID(t->ID());
         }

--- a/src/context.cc
+++ b/src/context.cc
@@ -831,7 +831,7 @@ void Context::updateUI(const UIElements &what) {
                     view::AutotrackerRule rule;
                     rule.ProjectName = Formatter::JoinTaskName(t, p);
                     rule.ID = model->LocalID();
-                    rule.Term = model->TermsString();
+                    rule.Terms = model->TermsString();
                     autotracker_rule_views.push_back(rule);
                 }
 
@@ -3880,7 +3880,7 @@ error Context::DefaultTID(Poco::UInt64 *result) {
 }
 
 error Context::AddAutotrackerRule(
-    const std::string &term,
+    const std::string &terms,
     const Poco::UInt64 pid,
     const Poco::UInt64 tid,
     Poco::Int64 *rule_id) {
@@ -3888,14 +3888,14 @@ error Context::AddAutotrackerRule(
     poco_check_ptr(rule_id);
     *rule_id = 0;
 
-    if (term.empty()) {
-        return displayError("missing term");
+    if (terms.empty()) {
+        return displayError("missing terms");
     }
     if (!pid && !tid) {
         return displayError("missing project and task");
     }
 
-    std::string lowercase = Poco::UTF8::toLower(term);
+    std::string lowercase = Poco::UTF8::toLower(terms);
 
     AutotrackerRule *rule = nullptr;
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -3987,7 +3987,8 @@ error Context::UpdateAutotrackerRule(
             t = user_->related.TaskByID(tid);
         }
         if (tid && !t) {
-            return displayError("task not found");
+            logger.warning("task not found");
+            return noError;
         }
 
         Project* p = nullptr;
@@ -3995,14 +3996,16 @@ error Context::UpdateAutotrackerRule(
             p = user_->related.ProjectByID(pid);
         }
         if (pid && !p) {
-            return displayError("project not found");
+            logger.warning("project not found");
+            return noError;
         }
         if (t && t->PID() && !p) {
             p = user_->related.ProjectByID(t->PID());
         }
 
         if (p && t && p->ID() != t->PID()) {
-            return displayError("task does not belong to project");
+            logger.warning("task does not belong to project");
+            return noError;
         }
 
         error err = user_->related.UpdateAutotrackerRule(rule_id, terms, tid, pid);

--- a/src/context.cc
+++ b/src/context.cc
@@ -3959,7 +3959,7 @@ error Context::AddAutotrackerRule(
 
 error Context::UpdateAutotrackerRule(
     const Poco::Int64 rule_id,
-    const std::string& terms,
+    const std::string &terms,
     const Poco::UInt64 pid,
     const Poco::UInt64 tid) {
 

--- a/src/context.h
+++ b/src/context.h
@@ -519,6 +519,12 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const Poco::UInt64 tid,
         Poco::Int64 *rule_id);
 
+    error UpdateAutotrackerRule(
+        const Poco::Int64 rule_id,
+        const std::string& terms,
+        const Poco::UInt64 pid,
+        const Poco::UInt64 tid);
+
     error DeleteAutotrackerRule(
         const Poco::Int64 id);
 

--- a/src/context.h
+++ b/src/context.h
@@ -514,7 +514,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     }
 
     error AddAutotrackerRule(
-        const std::string &term,
+        const std::string &terms,
         const Poco::UInt64 pid,
         const Poco::UInt64 tid,
         Poco::Int64 *rule_id);

--- a/src/context.h
+++ b/src/context.h
@@ -521,7 +521,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error UpdateAutotrackerRule(
         const Poco::Int64 rule_id,
-        const std::string& terms,
+        const std::string &terms,
         const Poco::UInt64 pid,
         const Poco::UInt64 tid);
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -2432,7 +2432,7 @@ error Database::saveModel(
                       "tid = :tid "
                       "where local_id = :local_id",
                       useRef(model->UID()),
-                      useRef(model->TermsString()),
+                      bind(model->TermsString()),
                       useRef(model->PID()),
                       useRef(model->TID()),
                       useRef(model->LocalID()),
@@ -2461,7 +2461,7 @@ error Database::saveModel(
                       "insert into autotracker_settings(uid, term, pid, tid) "
                       "values(:uid, :term, :pid, :tid)",
                       useRef(model->UID()),
-                      useRef(model->TermsString()),
+                      bind(model->TermsString()),
                       useRef(model->PID()),
                       useRef(model->TID()),
                       now;

--- a/src/database.cc
+++ b/src/database.cc
@@ -1633,7 +1633,7 @@ error Database::loadAutotrackerRules(
                 AutotrackerRule *model = new AutotrackerRule();
                 model->SetLocalID(rs[0].convert<Poco::Int64>());
                 model->SetUID(rs[1].convert<Poco::UInt64>());
-                model->SetTerm(rs[2].convert<std::string>());
+                model->SetTerms(rs[2].convert<std::string>());
                 model->SetPID(rs[3].convert<Poco::UInt64>());
                 if (!rs[4].isEmpty()) {
                     model->SetTID(rs[4].convert<Poco::UInt64>());
@@ -2432,7 +2432,7 @@ error Database::saveModel(
                       "tid = :tid "
                       "where local_id = :local_id",
                       useRef(model->UID()),
-                      useRef(model->Term()),
+                      useRef(model->TermsString()),
                       useRef(model->PID()),
                       useRef(model->TID()),
                       useRef(model->LocalID()),
@@ -2461,7 +2461,7 @@ error Database::saveModel(
                       "insert into autotracker_settings(uid, term, pid, tid) "
                       "values(:uid, :term, :pid, :tid)",
                       useRef(model->UID()),
-                      useRef(model->Term()),
+                      useRef(model->TermsString()),
                       useRef(model->PID()),
                       useRef(model->TID()),
                       now;

--- a/src/database.cc
+++ b/src/database.cc
@@ -40,6 +40,7 @@ using Poco::Data::Keywords::useRef;
 using Poco::Data::Keywords::limit;
 using Poco::Data::Keywords::into;
 using Poco::Data::Keywords::now;
+using Poco::Data::Keywords::bind;
 
 Database::Database(const std::string &db_path)
     : session_(nullptr)

--- a/src/gui.h
+++ b/src/gui.h
@@ -294,11 +294,11 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule {
  public:
     AutotrackerRule()
         : ID(0)
-    , Term("")
+    , Terms("")
     , ProjectName("") {}
 
     int64_t ID;
-    std::string Term;
+    std::string Terms;
     std::string ProjectName;
 
     bool operator == (const AutotrackerRule& other) const;

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -90,7 +90,7 @@ bool RelatedData::HasMatchingAutotrackerRule(
         AutotrackerRules.begin();
             it != AutotrackerRules.end(); ++it) {
         AutotrackerRule *rule = *it;
-        if (rule->Term() == lowercase_term) {
+        if (rule->TermsString() == lowercase_term) {
             return true;
         }
     }

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -77,7 +77,7 @@ error RelatedData::UpdateAutotrackerRule(const Poco::Int64 local_id, std::string
     }
     for (std::vector<AutotrackerRule*>::iterator it =
         AutotrackerRules.begin();
-        it != AutotrackerRules.end(); ++it) {
+            it != AutotrackerRules.end(); ++it) {
         AutotrackerRule* rule = *it;
         // Autotracker settings are not saved to DB,
         // so the ID will be 0 always. But will have local ID

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -71,6 +71,26 @@ error RelatedData::DeleteAutotrackerRule(const Poco::Int64 local_id) {
     return noError;
 }
 
+error RelatedData::UpdateAutotrackerRule(const Poco::Int64 local_id, std::string terms, const Poco::UInt64 tid, const Poco::UInt64 pid) {
+    if (!local_id) {
+        return error("cannot update rule without an ID");
+    }
+    for (std::vector<AutotrackerRule*>::iterator it =
+        AutotrackerRules.begin();
+        it != AutotrackerRules.end(); ++it) {
+        AutotrackerRule* rule = *it;
+        // Autotracker settings are not saved to DB,
+        // so the ID will be 0 always. But will have local ID
+        if (rule->LocalID() == local_id) {
+            rule->SetTerms(terms);
+            rule->SetTID(tid);
+            rule->SetPID(pid);
+            break;
+        }
+    }
+    return noError;
+}
+
 AutotrackerRule *RelatedData::FindAutotrackerRule(
     const TimelineEvent &event) const {
     for (std::vector<AutotrackerRule *>::const_iterator it =

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -88,6 +88,7 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
     bool HasMatchingAutotrackerRule(const std::string &lowercase_term) const;
 
     error DeleteAutotrackerRule(const Poco::Int64 local_id);
+    error UpdateAutotrackerRule(const Poco::Int64 local_id, std::string terms, const Poco::UInt64 tid, const Poco::UInt64 pid);
 
     void TimeEntryAutocompleteItems(std::vector<view::Autocomplete> *) const;
     void MinitimerAutocompleteItems(std::vector<view::Autocomplete> *) const;

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1875,16 +1875,16 @@ TEST(AutotrackerRule, Matches) {
 
     ev.SetTitle("dork");
     ASSERT_FALSE(a.Matches(ev));
-    
+
     // multiple terms in a single autotracker rule
     a.SetTerms("edge\tchrome\tfirefox");
-    
+
     ev.SetTitle("toggl-open-source/toggldesktop: Toggl Desktop app for Windows, Mac and Linux - Google Chrome");
     ASSERT_TRUE(a.Matches(ev));
-    
+
     ev.SetTitle("(1) Home / Twitter - Mozilla Firefox");
     ASSERT_TRUE(a.Matches(ev));
-    
+
     ev.SetTitle("YouTube - Chromium");
     ASSERT_FALSE(a.Matches(ev));
 }

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1875,6 +1875,20 @@ TEST(AutotrackerRule, Matches) {
 
     ev.SetTitle("dork");
     ASSERT_FALSE(a.Matches(ev));
+    
+    // multiple terms in a single autotracker rule
+    a.SetTerms("edge\tchrome\tfirefox");
+    
+    ev.SetTitle("toggl-open-source/toggldesktop: Toggl Desktop app for Windows, Mac and Linux - Google Chrome");
+    ASSERT_TRUE(a.Matches(ev));
+    
+    ev.SetTitle("YouTube");
+    ev.SetFilename("msedge.exe");
+    ASSERT_TRUE(a.Matches(ev));
+    
+    ev.SetTitle("YouTube");
+    ev.SetFilename("chromium.exe");
+    ASSERT_FALSE(a.Matches(ev));
 }
 
 TEST(Settings, IsSame) {

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1861,7 +1861,7 @@ TEST(Proxy, String) {
 
 TEST(AutotrackerRule, Matches) {
     AutotrackerRule a;
-    a.SetTerm("work");
+    a.SetTerms("work");
     a.SetPID(123);
 
     TimelineEvent ev;

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1882,12 +1882,10 @@ TEST(AutotrackerRule, Matches) {
     ev.SetTitle("toggl-open-source/toggldesktop: Toggl Desktop app for Windows, Mac and Linux - Google Chrome");
     ASSERT_TRUE(a.Matches(ev));
     
-    ev.SetTitle("YouTube");
-    ev.SetFilename("msedge.exe");
+    ev.SetTitle("(1) Home / Twitter - Mozilla Firefox");
     ASSERT_TRUE(a.Matches(ev));
     
-    ev.SetTitle("YouTube");
-    ev.SetFilename("chromium.exe");
+    ev.SetTitle("YouTube - Chromium");
     ASSERT_FALSE(a.Matches(ev));
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1399,6 +1399,20 @@ int64_t toggl_autotracker_add_rule(
     return rule_id;
 }
 
+bool_t toggl_autotracker_update_rule(
+    void *context,
+    const int64_t rule_id,
+    const char_t *term,
+    const uint64_t project_id,
+    const uint64_t task_id) {
+    return toggl::noError ==
+           app(context)->UpdateAutotrackerRule(
+               rule_id,
+               to_string(term),
+               project_id,
+               task_id);
+}
+
 bool_t toggl_autotracker_delete_rule(
     void *context,
     const int64_t id) {

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1402,13 +1402,13 @@ int64_t toggl_autotracker_add_rule(
 bool_t toggl_autotracker_update_rule(
     void *context,
     const int64_t rule_id,
-    const char_t *term,
+    const char_t *terms,
     const uint64_t project_id,
     const uint64_t task_id) {
     return toggl::noError ==
            app(context)->UpdateAutotrackerRule(
                rule_id,
-               to_string(term),
+               to_string(terms),
                project_id,
                task_id);
 }

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1091,6 +1091,13 @@ extern "C" {
         const uint64_t project_id,
         const uint64_t task_id);
 
+    TOGGL_EXPORT bool_t toggl_autotracker_update_rule(
+        void *context,
+        const int64_t rule_id,
+        const char_t *term,
+        const uint64_t project_id,
+        const uint64_t task_id);
+
     TOGGL_EXPORT bool_t toggl_autotracker_delete_rule(
         void *context,
         const int64_t id);

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1094,7 +1094,7 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_autotracker_update_rule(
         void *context,
         const int64_t rule_id,
-        const char_t *term,
+        const char_t *terms,
         const uint64_t project_id,
         const uint64_t task_id);
 

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -197,7 +197,7 @@ extern "C" {
 
     typedef struct {
         int64_t ID;
-        char_t *Term;
+        char_t *Terms;
         char_t *ProjectAndTaskLabel;
         void *Next;
     } TogglAutotrackerRuleView;

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -111,10 +111,10 @@ TogglGenericView *generic_to_view_item(
 
 TogglAutotrackerRuleView *autotracker_rule_to_view_item(const toggl::view::AutotrackerRule &model) {
     TogglAutotrackerRuleView *view = new TogglAutotrackerRuleView();
-    // Autotracker settings are not saved to DB,
+    // Autotracker settings are not saved to the server DB,
     // so the ID will be 0 always. But will have local ID
     view->ID = static_cast<int>(model.ID);
-    view->Term = copy_string(model.Term);
+    view->Terms = copy_string(model.Terms);
     view->ProjectAndTaskLabel = copy_string(model.ProjectName);
     return view;
 }
@@ -126,8 +126,8 @@ void autotracker_view_item_clear(TogglAutotrackerRuleView *view) {
 
     view->ID = 0;
 
-    free(view->Term);
-    view->Term = nullptr;
+    free(view->Terms);
+    view->Terms = nullptr;
 
     free(view->ProjectAndTaskLabel);
     view->ProjectAndTaskLabel = nullptr;

--- a/src/ui/osx/TogglDesktop/test2/AutotrackerRuleItem.m
+++ b/src/ui/osx/TogglDesktop/test2/AutotrackerRuleItem.m
@@ -6,7 +6,7 @@
 - (void)load:(TogglAutotrackerRuleView *)data
 {
 	self.ID = data->ID;
-	self.Term = [NSString stringWithUTF8String:data->Term];
+	self.Term = [NSString stringWithUTF8String:data->Terms];
 	self.ProjectAndTaskLabel = [NSString stringWithUTF8String:data->ProjectAndTaskLabel];
 }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
@@ -400,6 +400,77 @@ namespace TogglDesktop.Tests
         {
             Toggl.SetIdleSeconds(123);
         }
+
+        [Fact]
+        public void ShouldAddAutotrackerRule()
+        {
+            var timeEntry = GetTimeEntry(_firstTimeEntryGuid);
+            var pid = timeEntry.PID;
+            var tid = timeEntry.TID;
+
+            var currentRulesList = new List<Toggl.TogglAutotrackerRuleView>();
+            Toggl.OnAutotrackerRules += (rules, terms) => { currentRulesList = rules; };
+
+            var ruleId = Toggl.AddAutotrackerRule("slack", pid, tid);
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId);
+        }
+
+        [Fact]
+        public void ShouldDeleteAutotrackerRule()
+        {
+            var timeEntry = GetTimeEntry(_firstTimeEntryGuid);
+            var pid = timeEntry.PID;
+            var tid = timeEntry.TID;
+
+            var currentRulesList = new List<Toggl.TogglAutotrackerRuleView>();
+            Toggl.OnAutotrackerRules += (rules, terms) => { currentRulesList = rules; };
+
+            var ruleId = Toggl.AddAutotrackerRule("slack", pid, tid);
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId);
+
+            Assert.True(Toggl.DeleteAutotrackerRule(ruleId));
+            Assert.Empty(currentRulesList);
+        }
+
+        [Fact]
+        public void ShouldUpdateAutotrackerRuleWithDifferentTerm()
+        {
+            var timeEntry = GetTimeEntry(_firstTimeEntryGuid);
+            var pid = timeEntry.PID;
+            var tid = timeEntry.TID;
+
+            var currentRulesList = new List<Toggl.TogglAutotrackerRuleView>();
+            Toggl.OnAutotrackerRules += (rules, terms) => { currentRulesList = rules; };
+
+            var ruleId = Toggl.AddAutotrackerRule("slack", pid, tid);
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId && rule.Terms == "slack");
+
+            Assert.True(Toggl.UpdateAutotrackerRule(ruleId, "teams", pid, tid));
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId && rule.Terms == "teams");
+        }
+
+        [Fact]
+        public void ShouldAddTermToExistingAutotrackerRule()
+        {
+            var timeEntry = GetTimeEntry(_firstTimeEntryGuid);
+            var pid = timeEntry.PID;
+            var tid = timeEntry.TID;
+
+            var currentRulesList = new List<Toggl.TogglAutotrackerRuleView>();
+            Toggl.OnAutotrackerRules += (rules, terms) => { currentRulesList = rules; };
+
+            var ruleId = Toggl.AddAutotrackerRule("slack", pid, tid);
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId && rule.Terms == "slack");
+
+            Assert.True(Toggl.UpdateAutotrackerRule(ruleId, "slack\tteams", pid, tid));
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId && rule.Terms == "slack\tteams");
+        }
+
         private Toggl.TogglTimeEntryView GetTimeEntry(string guid) => _state.TimeEntries.First(te => te.GUID == guid);
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
@@ -46,6 +46,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\lib\windows\TogglDesktopDLL\TogglDesktopDLL.vcxproj">
+      <Project>{3ace25dd-04ce-47d8-9658-3d0546521da2}</Project>
+      <Name>TogglDesktopDLL</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TogglDesktop\TogglDesktop.csproj">
       <Project>{27ac6261-3916-4683-b692-dc57e2fe0abd}</Project>
       <Name>TogglDesktop</Name>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -642,6 +642,11 @@ public static partial class Toggl
         return toggl_autotracker_add_rule(ctx, term, projectId, taskId);
     }
 
+    public static bool UpdateAutotrackerRule(long ruleId, string terms, ulong projectId, ulong taskId)
+    {
+        return toggl_autotracker_update_rule(ctx, ruleId, terms, projectId, taskId);
+    }
+
     public static bool DeleteAutotrackerRule(long id)
     {
         return toggl_autotracker_delete_rule(ctx, id);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -637,9 +637,9 @@ public static partial class Toggl
         return toggl_format_tracking_time_duration(duration_in_seconds);
     }
 
-    public static long AddAutotrackerRule(string term, ulong projectId, ulong taskId)
+    public static long AddAutotrackerRule(string terms, ulong projectId, ulong taskId)
     {
-        return toggl_autotracker_add_rule(ctx, term, projectId, taskId);
+        return toggl_autotracker_add_rule(ctx, terms, projectId, taskId);
     }
 
     public static bool UpdateAutotrackerRule(long ruleId, string terms, ulong projectId, ulong taskId)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -1650,7 +1650,7 @@ public static partial class Toggl
     private static extern Int64 toggl_autotracker_add_rule(
         IntPtr context,
         [MarshalAs(UnmanagedType.LPWStr)]
-        string term,
+        string terms,
         UInt64 project_id,
         UInt64 task_id);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -328,7 +328,7 @@ public static partial class Toggl
     {
         public         Int64 ID;
         [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Term;
+        public         string Terms;
         [MarshalAs(UnmanagedType.LPWStr)]
         public         string ProjectAndTaskLabel;
         public         IntPtr Next;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -880,6 +880,40 @@ public static partial class Toggl
         string access_token);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_apple_login(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string access_token);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_apple_login_async(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string access_token);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_apple_signup(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string access_token,
+        UInt64 country_id,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string full_name);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_apple_signup_async(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string access_token,
+        UInt64 country_id,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string full_name);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern void toggl_password_forgot(
         IntPtr context);
 
@@ -1421,6 +1455,13 @@ public static partial class Toggl
         UInt64 started,
         UInt64 ended);
 
+    // Create an Empty Time Entry without stopping the running TE
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern string toggl_create_empty_time_entry(
+        IntPtr context,
+        UInt64 started,
+        UInt64 ended);
+
     // returns GUID of the new project. you must free() the result
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern string toggl_add_project(
@@ -1608,6 +1649,16 @@ public static partial class Toggl
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern Int64 toggl_autotracker_add_rule(
         IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string term,
+        UInt64 project_id,
+        UInt64 task_id);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_autotracker_update_rule(
+        IntPtr context,
+        Int64 rule_id,
         [MarshalAs(UnmanagedType.LPWStr)]
         string term,
         UInt64 project_id,

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutotrackerSettings.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutotrackerSettings.xaml.cs
@@ -61,7 +61,7 @@ namespace TogglDesktop
 
             foreach (var rule in rules)
             {
-                var item = AutotrackerRuleItem.Make(rule.ID, rule.Term, rule.ProjectAndTaskLabel);
+                var item = AutotrackerRuleItem.Make(rule.ID, rule.Terms, rule.ProjectAndTaskLabel);
 
                 this.ruleItems.Add(item);
                 this.rulesPanel.Children.Add(item);


### PR DESCRIPTION
### 📒 Description
Make Autotracker rules support multiple window titles

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Saving to / reading from the database
- [x] Matching multiple titles with timeline events
- [x] ~Converting into view struct for passing to the platform clients~ no changes needed 
- [x] ~Change the API method for adding an autotracker rule to support multiple titles~ no changes needed
- [x] Add the API method for editing an autotracker rule
- [x] Make sure backward compatibility is maintained (add DB migration if necessary)
- [x] Add tests to cover the new functionality

### 👫 Relationships
Closes #3915

### 🔎 Review hints
Code review is most important as this PR doesn't really add any user-visible functionality.

Although it is possible to test multiple titles matching:
- Create some Autotracker rule and save it
- Quit the app
- Open `toggldesktop.db` and modify your Autotracker rule's `term` field (`autotracker_settings` table) to include several terms separated by \t character, for example, `slack	firefox` (\t character between `slack` and `firefox`).
- Open the app and check if Autotracker is matching a window by finding just one of the terms.