### PR TITLE
Fix Windows app not respecting the default project

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml.cs
@@ -242,6 +242,8 @@ namespace TogglDesktop
                 {
                     Toggl.SetTimeEntryBillable(guid, true);
                 }
+
+                this.clearSelectedProject();
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
@@ -269,6 +269,8 @@ namespace TogglDesktop
                 {
                     Toggl.SetTimeEntryBillable(guid, true);
                 }
+
+                this.clearSelectedProject();
             }
         }
 


### PR DESCRIPTION
### 📒 Description
Fix Windows app not respecting the default project

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Clear saved project after starting the timer

### 👫 Relationships
Closes #3948

### 🔎 Review hints
STR:
1. Autocomplete a time entry which contains a project and start this time entry
2. Stop the time entry
3. Start the time entry with just text, without any project
The time entry should be started with the default project or without any project if the default project hasn't been set.

Test both Main window timer and the Mini timer.
