### PR TITLE
Make Autotracker support time range and days of week

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,6 @@ third_party/google-astyle/build/google-astyle:
 
 fmt_lib: third_party/google-astyle/build/google-astyle
 	third_party/google-astyle/build/google-astyle -n $(source_dirs)
-	third_party/google-astyle/build/google-astyle -n src/ui/windows/TogglDesktop/TogglDesktopDLLInteropTest//*.cs
 
 fmt_ui:
 	./third_party/Xcode-formatter/CodeFormatter/scripts/formatAllSources.sh src/ui/osx/TogglDesktop

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -13,7 +13,7 @@ static const char kTermSeparator = '\t';
 
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
     const Poco::LocalDateTime event_time(Poco::DateTime(event.EndTime()));
-    if (!days_of_week_[event_time.dayOfWeek()]) {
+    if (!days_of_week_.none() && !days_of_week_[event_time.dayOfWeek()]) {
         logger().debug("Autotracker rule is not enabled on this weekday");
         return false;
     }

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -41,7 +41,7 @@ bool AutotrackerRule::Matches(const TimelineEvent &event) const {
         }
     }
 
-    for (const auto& term : terms_) {
+for (const auto& term : terms_) {
         if (Poco::UTF8::toLower(event.Title()).find(term)
                 != std::string::npos) {
             return true;

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -41,7 +41,7 @@ bool AutotrackerRule::Matches(const TimelineEvent &event) const {
         }
     }
 
-for (const auto& term : terms_) {
+    for (const auto& term : terms_) {
         if (Poco::UTF8::toLower(event.Title()).find(term)
                 != std::string::npos) {
             return true;

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -12,6 +12,11 @@ namespace toggl {
 static const char kTermSeparator = '\t';
 
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
+    const Poco::LocalDateTime localDateTime(Poco::DateTime(event.EndTime()));
+    if (!days_of_week_[localDateTime.dayOfWeek()]) {
+        return false;
+    }
+
     for (const auto& term : terms_) {
         if (Poco::UTF8::toLower(event.Title()).find(term)
                 != std::string::npos) {
@@ -89,6 +94,18 @@ const std::string AutotrackerRule::TermsString() const {
         ss << *it;
     }
     return ss.str();
+}
+
+const std::bitset<7> &AutotrackerRule::DaysOfWeek() const {
+    return days_of_week_;
+}
+
+void AutotrackerRule::SetDaysOfWeek(const Poco::UInt32 daysOfWeek) {
+    days_of_week_ = std::bitset<7>(daysOfWeek);
+}
+
+Poco::UInt32 AutotrackerRule::DaysOfWeekUInt32() const {
+    return days_of_week_.to_ulong();
 }
 
 }  // namespace toggl

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -12,8 +12,8 @@ namespace toggl {
 static const char kTermSeparator = '\t';
 
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
-    if (!days_of_week_.none() && !days_of_week_[event_time.dayOfWeek()]) {
     const Poco::LocalDateTime event_time(Poco::Timestamp::fromEpochTime(event.EndTime()));
+    if (days_of_week_ != 0 && !std::bitset<7>(days_of_week_)[event_time.dayOfWeek()]) {
         logger().debug("Autotracker rule is not enabled on this weekday");
         return false;
     }
@@ -120,16 +120,12 @@ const std::string AutotrackerRule::TermsString() const {
     return ss.str();
 }
 
-const std::bitset<7> &AutotrackerRule::DaysOfWeek() const {
+void AutotrackerRule::SetDaysOfWeek(const Poco::UInt8 daysOfWeek) {
+    days_of_week_ = daysOfWeek;
+}
+
+Poco::UInt8 AutotrackerRule::DaysOfWeek() const {
     return days_of_week_;
-}
-
-void AutotrackerRule::SetDaysOfWeek(const Poco::UInt32 daysOfWeek) {
-    days_of_week_ = std::bitset<7>(daysOfWeek);
-}
-
-Poco::UInt32 AutotrackerRule::DaysOfWeekUInt32() const {
-    return days_of_week_.to_ulong();
 }
 
 const std::string &AutotrackerRule::StartTime() const {

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -150,4 +150,21 @@ void AutotrackerRule::SetEndTime(const std::string &value) {
     }
 }
 
+Poco::UInt8 AutotrackerRule::DaysOfWeekIntoUInt8(
+    const bool sunday,
+    const bool monday,
+    const bool tuesday,
+    const bool wednesday,
+    const bool thursday,
+    const bool friday,
+    const bool saturday) {
+    return sunday << 0 |
+           monday << 1 |
+           tuesday << 2 |
+           wednesday << 3 |
+           thursday << 4 |
+           friday << 5 |
+           saturday << 6;
+}
+
 }  // namespace toggl

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -12,8 +12,8 @@ namespace toggl {
 static const char kTermSeparator = '\t';
 
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
-    const Poco::LocalDateTime event_time(Poco::DateTime(event.EndTime()));
     if (!days_of_week_.none() && !days_of_week_[event_time.dayOfWeek()]) {
+    const Poco::LocalDateTime event_time(Poco::Timestamp::fromEpochTime(event.EndTime()));
         logger().debug("Autotracker rule is not enabled on this weekday");
         return false;
     }

--- a/src/autotracker.cc
+++ b/src/autotracker.cc
@@ -12,9 +12,33 @@ namespace toggl {
 static const char kTermSeparator = '\t';
 
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
-    const Poco::LocalDateTime localDateTime(Poco::DateTime(event.EndTime()));
-    if (!days_of_week_[localDateTime.dayOfWeek()]) {
+    const Poco::LocalDateTime event_time(Poco::DateTime(event.EndTime()));
+    if (!days_of_week_[event_time.dayOfWeek()]) {
+        logger().debug("Autotracker rule is not enabled on this weekday");
         return false;
+    }
+    if (!start_time_.empty()) {
+        int h(0), m(0);
+        if (toggl::Formatter::ParseTimeInput(start_time_, &h, &m)) {
+            Poco::LocalDateTime start(
+                event_time.year(), event_time.month(), event_time.day(), h, m, event_time.second());
+            if (event_time < start) {
+                logger().debug("It's too early for this autotracker rule", " [", event_time.hour(), ":", event_time.minute(), "]", " (allowed from ", h, ":", m, ")");
+                return false;
+            }
+        }
+    }
+
+    if (!end_time_.empty()) {
+        int h(0), m(0);
+        if (toggl::Formatter::ParseTimeInput(end_time_, &h, &m)) {
+            Poco::LocalDateTime end(
+                event_time.year(), event_time.month(), event_time.day(), h, m, event_time.second());
+            if (event_time > end) {
+                logger().debug("It's too late for this autotracker rule", " [", event_time.hour(), ":", event_time.minute(), "]", " (allowed until ", h, ":", m, ")");
+                return false;
+            }
+        }
     }
 
     for (const auto& term : terms_) {
@@ -106,6 +130,28 @@ void AutotrackerRule::SetDaysOfWeek(const Poco::UInt32 daysOfWeek) {
 
 Poco::UInt32 AutotrackerRule::DaysOfWeekUInt32() const {
     return days_of_week_.to_ulong();
+}
+
+const std::string &AutotrackerRule::StartTime() const {
+    return start_time_;
+}
+
+void AutotrackerRule::SetStartTime(const std::string &value) {
+    if (start_time_ != value) {
+        start_time_ = value;
+        SetDirty();
+    }
+}
+
+const std::string &AutotrackerRule::EndTime() const {
+    return end_time_;
+}
+
+void AutotrackerRule::SetEndTime(const std::string &value) {
+    if (end_time_ != value) {
+        end_time_ = value;
+        SetDirty();
+    }
 }
 
 }  // namespace toggl

--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -19,7 +19,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  public:
     AutotrackerRule()
         : BaseModel()
-    , days_of_week_(std::bitset<7>(0x7F))
+    , days_of_week_(std::bitset<7>(0))
     , start_time_("")
     , end_time_("")
     , pid_(0)

--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <bitset>
 
 #include <Poco/Types.h>
 
@@ -18,6 +19,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  public:
     AutotrackerRule()
         : BaseModel()
+    , days_of_week_(std::bitset<7>(0x7F))
     , pid_(0)
     , tid_(0) {}
 
@@ -28,6 +30,10 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     const std::vector<std::string> &Terms() const;
     void SetTerms(const std::string &value);
     const std::string TermsString() const;
+
+    const std::bitset<7> &DaysOfWeek() const;
+    void SetDaysOfWeek(const Poco::UInt32 daysOfWeek);
+    Poco::UInt32 DaysOfWeekUInt32() const;
 
     const Poco::UInt64 &PID() const;
     void SetPID(const Poco::UInt64 value);
@@ -42,6 +48,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
 
  private:
     std::vector<std::string> terms_;
+    std::bitset<7> days_of_week_;
     Poco::UInt64 pid_;
     Poco::UInt64 tid_;
 };

--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -48,6 +48,15 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     const Poco::UInt64 &TID() const;
     void SetTID(const Poco::UInt64 value);
 
+    static Poco::UInt8 DaysOfWeekIntoUInt8(
+        const bool sunday,
+        const bool monday,
+        const bool tuesday,
+        const bool wednesday,
+        const bool thursday,
+        const bool friday,
+        const bool saturday);
+
     // Override BaseModel
     std::string String() const override;
     std::string ModelName() const override;

--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -19,7 +19,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  public:
     AutotrackerRule()
         : BaseModel()
-    , days_of_week_(std::bitset<7>(0))
+    , days_of_week_(0)
     , start_time_("")
     , end_time_("")
     , pid_(0)
@@ -33,9 +33,8 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     void SetTerms(const std::string &value);
     const std::string TermsString() const;
 
-    const std::bitset<7> &DaysOfWeek() const;
-    void SetDaysOfWeek(const Poco::UInt32 daysOfWeek);
-    Poco::UInt32 DaysOfWeekUInt32() const;
+    void SetDaysOfWeek(const Poco::UInt8 daysOfWeek);
+    Poco::UInt8 DaysOfWeek() const;
 
     const std::string &StartTime() const;
     void SetStartTime(const std::string &value);
@@ -56,7 +55,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
 
  private:
     std::vector<std::string> terms_;
-    std::bitset<7> days_of_week_;
+    Poco::UInt8 days_of_week_;
     std::string start_time_;
     std::string end_time_;
     Poco::UInt64 pid_;

--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -20,6 +20,8 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     AutotrackerRule()
         : BaseModel()
     , days_of_week_(std::bitset<7>(0x7F))
+    , start_time_("")
+    , end_time_("")
     , pid_(0)
     , tid_(0) {}
 
@@ -35,6 +37,12 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     void SetDaysOfWeek(const Poco::UInt32 daysOfWeek);
     Poco::UInt32 DaysOfWeekUInt32() const;
 
+    const std::string &StartTime() const;
+    void SetStartTime(const std::string &value);
+
+    const std::string &EndTime() const;
+    void SetEndTime(const std::string &value);
+
     const Poco::UInt64 &PID() const;
     void SetPID(const Poco::UInt64 value);
 
@@ -49,6 +57,8 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  private:
     std::vector<std::string> terms_;
     std::bitset<7> days_of_week_;
+    std::string start_time_;
+    std::string end_time_;
     Poco::UInt64 pid_;
     Poco::UInt64 tid_;
 };

--- a/src/autotracker.h
+++ b/src/autotracker.h
@@ -19,11 +19,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  public:
     AutotrackerRule()
         : BaseModel()
-    , days_of_week_(0)
-    , start_time_("")
-    , end_time_("")
-    , pid_(0)
-    , tid_(0) {}
+    {}
 
     virtual ~AutotrackerRule() {}
 
@@ -64,11 +60,11 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
 
  private:
     std::vector<std::string> terms_;
-    Poco::UInt8 days_of_week_;
-    std::string start_time_;
-    std::string end_time_;
-    Poco::UInt64 pid_;
-    Poco::UInt64 tid_;
+    Poco::UInt8 days_of_week_ { 0 };
+    std::string start_time_ { "" };
+    std::string end_time_ { "" };
+    Poco::UInt64 pid_ { 0 };
+    Poco::UInt64 tid_ { 0 };
 };
 
 };  // namespace toggl

--- a/src/context.cc
+++ b/src/context.cc
@@ -832,6 +832,9 @@ void Context::updateUI(const UIElements &what) {
                     rule.ProjectName = Formatter::JoinTaskName(t, p);
                     rule.ID = model->LocalID();
                     rule.Terms = model->TermsString();
+                    rule.StartTime = model->StartTime();
+                    rule.EndTime = model->EndTime();
+                    rule.DaysOfWeek = model->DaysOfWeekUInt32();
                     autotracker_rule_views.push_back(rule);
                 }
 
@@ -3883,6 +3886,9 @@ error Context::AddAutotrackerRule(
     const std::string &terms,
     const Poco::UInt64 pid,
     const Poco::UInt64 tid,
+    const std::string &start_time,
+    const std::string &end_time,
+    const Poco::UInt32 days_of_week,
     Poco::Int64 *rule_id) {
 
     poco_check_ptr(rule_id);
@@ -3941,6 +3947,9 @@ error Context::AddAutotrackerRule(
         if (p) {
             rule->SetPID(p->ID());
         }
+        rule->SetStartTime(start_time);
+        rule->SetEndTime(end_time);
+        rule->SetDaysOfWeek(days_of_week);
         rule->SetUID(user_->ID());
         user_->related.AutotrackerRules.push_back(rule);
     }
@@ -3961,7 +3970,10 @@ error Context::UpdateAutotrackerRule(
     const Poco::Int64 rule_id,
     const std::string &terms,
     const Poco::UInt64 pid,
-    const Poco::UInt64 tid) {
+    const Poco::UInt64 tid,
+    const std::string &start_time,
+    const std::string &end_time,
+    const Poco::UInt32 days_of_week) {
 
     if (!rule_id) {
         return displayError("missing rule id");
@@ -4008,7 +4020,7 @@ error Context::UpdateAutotrackerRule(
             return noError;
         }
 
-        error err = user_->related.UpdateAutotrackerRule(rule_id, terms, tid, pid);
+        error err = user_->related.UpdateAutotrackerRule(rule_id, terms, tid, pid, start_time, end_time, days_of_week);
         if (noError != err) {
             return displayError(err);
         }

--- a/src/context.cc
+++ b/src/context.cc
@@ -834,7 +834,7 @@ void Context::updateUI(const UIElements &what) {
                     rule.Terms = model->TermsString();
                     rule.StartTime = model->StartTime();
                     rule.EndTime = model->EndTime();
-                    rule.DaysOfWeek = model->DaysOfWeekUInt32();
+                    rule.DaysOfWeek = model->DaysOfWeek();
                     autotracker_rule_views.push_back(rule);
                 }
 
@@ -3888,7 +3888,7 @@ error Context::AddAutotrackerRule(
     const Poco::UInt64 tid,
     const std::string &start_time,
     const std::string &end_time,
-    const Poco::UInt32 days_of_week,
+    const Poco::UInt8 days_of_week,
     Poco::Int64 *rule_id) {
 
     poco_check_ptr(rule_id);
@@ -3973,7 +3973,7 @@ error Context::UpdateAutotrackerRule(
     const Poco::UInt64 tid,
     const std::string &start_time,
     const std::string &end_time,
-    const Poco::UInt32 days_of_week) {
+    const Poco::UInt8 days_of_week) {
 
     if (!rule_id) {
         return displayError("missing rule id");

--- a/src/context.h
+++ b/src/context.h
@@ -517,13 +517,19 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const std::string &terms,
         const Poco::UInt64 pid,
         const Poco::UInt64 tid,
+        const std::string &start_time,
+        const std::string &end_time,
+        const Poco::UInt32 days_of_week,
         Poco::Int64 *rule_id);
 
     error UpdateAutotrackerRule(
         const Poco::Int64 rule_id,
         const std::string &terms,
         const Poco::UInt64 pid,
-        const Poco::UInt64 tid);
+        const Poco::UInt64 tid,
+        const std::string &start_time,
+        const std::string &end_time,
+        const Poco::UInt32 days_of_week);
 
     error DeleteAutotrackerRule(
         const Poco::Int64 id);

--- a/src/context.h
+++ b/src/context.h
@@ -519,7 +519,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const Poco::UInt64 tid,
         const std::string &start_time,
         const std::string &end_time,
-        const Poco::UInt32 days_of_week,
+        const Poco::UInt8 days_of_week,
         Poco::Int64 *rule_id);
 
     error UpdateAutotrackerRule(
@@ -529,7 +529,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const Poco::UInt64 tid,
         const std::string &start_time,
         const std::string &end_time,
-        const Poco::UInt32 days_of_week);
+        const Poco::UInt8 days_of_week);
 
     error DeleteAutotrackerRule(
         const Poco::Int64 id);

--- a/src/database.cc
+++ b/src/database.cc
@@ -1617,7 +1617,7 @@ error Database::loadAutotrackerRules(
 
         Poco::Data::Statement select(*session_);
         select <<
-               "SELECT local_id, uid, term, pid, tid "
+               "SELECT local_id, uid, term, pid, tid, start_time, end_time, days_of_week "
                "FROM autotracker_settings "
                "WHERE uid = :uid "
                "ORDER BY term DESC",
@@ -1639,6 +1639,13 @@ error Database::loadAutotrackerRules(
                 if (!rs[4].isEmpty()) {
                     model->SetTID(rs[4].convert<Poco::UInt64>());
                 }
+                if (!rs[5].isEmpty()) {
+                    model->SetStartTime(rs[5].convert<std::string>());
+                }
+                if (!rs[6].isEmpty()) {
+                    model->SetEndTime(rs[6].convert<std::string>());
+                }
+                model->SetDaysOfWeek(rs[7].convert<Poco::UInt32>());
                 model->ClearDirty();
                 list->push_back(model);
                 more = rs.moveNext();
@@ -2430,12 +2437,16 @@ error Database::saveModel(
             *session_ <<
                       "update autotracker_settings set "
                       "uid = :uid, term = :term, pid = :pid, "
-                      "tid = :tid "
+                      "tid = :tid, start_time = :start_time, end_time = :end_time, "
+                      "days_of_week = :days_of_week "
                       "where local_id = :local_id",
                       useRef(model->UID()),
                       bind(model->TermsString()),
                       useRef(model->PID()),
                       useRef(model->TID()),
+                      useRef(model->StartTime()),
+                      useRef(model->EndTime()),
+                      bind(model->DaysOfWeekUInt32()),
                       useRef(model->LocalID()),
                       now;
             error err = last_error("saveAutotrackerRule");
@@ -2459,12 +2470,15 @@ error Database::saveModel(
         } else {
             logger.trace("Inserting autotracker rule ", model->String(), " in thread ", Poco::Thread::currentTid());
             *session_ <<
-                      "insert into autotracker_settings(uid, term, pid, tid) "
-                      "values(:uid, :term, :pid, :tid)",
+                      "insert into autotracker_settings(uid, term, pid, tid, start_time, end_time, days_of_week) "
+                      "values(:uid, :term, :pid, :tid, :start_time, :end_time, :days_of_week)",
                       useRef(model->UID()),
                       bind(model->TermsString()),
                       useRef(model->PID()),
                       useRef(model->TID()),
+                      useRef(model->StartTime()),
+                      useRef(model->EndTime()),
+                      bind(model->DaysOfWeekUInt32()),
                       now;
             error err = last_error("saveAutotrackerRule");
             if (err != noError) {

--- a/src/database.cc
+++ b/src/database.cc
@@ -1645,7 +1645,7 @@ error Database::loadAutotrackerRules(
                 if (!rs[6].isEmpty()) {
                     model->SetEndTime(rs[6].convert<std::string>());
                 }
-                model->SetDaysOfWeek(rs[7].convert<Poco::UInt32>());
+                model->SetDaysOfWeek(rs[7].convert<Poco::UInt8>());
                 model->ClearDirty();
                 list->push_back(model);
                 more = rs.moveNext();
@@ -2446,7 +2446,7 @@ error Database::saveModel(
                       useRef(model->TID()),
                       useRef(model->StartTime()),
                       useRef(model->EndTime()),
-                      bind(model->DaysOfWeekUInt32()),
+                      bind(model->DaysOfWeek()),
                       useRef(model->LocalID()),
                       now;
             error err = last_error("saveAutotrackerRule");
@@ -2478,7 +2478,7 @@ error Database::saveModel(
                       useRef(model->TID()),
                       useRef(model->StartTime()),
                       useRef(model->EndTime()),
-                      bind(model->DaysOfWeekUInt32()),
+                      bind(model->DaysOfWeek()),
                       now;
             error err = last_error("saveAutotrackerRule");
             if (err != noError) {

--- a/src/gui.h
+++ b/src/gui.h
@@ -295,11 +295,17 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule {
     AutotrackerRule()
         : ID(0)
     , Terms("")
-    , ProjectName("") {}
+    , ProjectName("")
+    , StartTime("")
+    , EndTime("")
+    , DaysOfWeek(0) {}
 
     int64_t ID;
     std::string Terms;
     std::string ProjectName;
+    std::string StartTime;
+    std::string EndTime;
+    uint32_t DaysOfWeek;
 
     bool operator == (const AutotrackerRule& other) const;
 };

--- a/src/gui.h
+++ b/src/gui.h
@@ -292,20 +292,14 @@ class TOGGL_INTERNAL_EXPORT Settings {
 
 class TOGGL_INTERNAL_EXPORT AutotrackerRule {
  public:
-    AutotrackerRule()
-        : ID(0)
-    , Terms("")
-    , ProjectName("")
-    , StartTime("")
-    , EndTime("")
-    , DaysOfWeek(0) {}
+    AutotrackerRule() {}
 
-    int64_t ID;
-    std::string Terms;
-    std::string ProjectName;
-    std::string StartTime;
-    std::string EndTime;
-    uint8_t DaysOfWeek;
+    int64_t ID { 0 };
+    std::string Terms { "" };
+    std::string ProjectName { "" };
+    std::string StartTime { "" };
+    std::string EndTime { "" };
+    uint8_t DaysOfWeek { 0 };
 
     bool operator == (const AutotrackerRule& other) const;
 };

--- a/src/gui.h
+++ b/src/gui.h
@@ -305,7 +305,7 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule {
     std::string ProjectName;
     std::string StartTime;
     std::string EndTime;
-    uint32_t DaysOfWeek;
+    uint8_t DaysOfWeek;
 
     bool operator == (const AutotrackerRule& other) const;
 };

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -117,7 +117,7 @@ error Migrations::migrateAutotracker() {
     err = db_->Migrate(
         "autotracker_settings.days_of_week",
         "alter table autotracker_settings"
-        " add column days_of_week integer not null default 127;"); // 127 == 0x7F == "1111111"
+        " add column days_of_week integer not null default 0;");
     if (err != noError) {
         return err;
     }

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -98,6 +98,30 @@ error Migrations::migrateAutotracker() {
         return err;
     }
 
+    err = db_->Migrate(
+        "autotracker_settings.start_time",
+        "alter table autotracker_settings"
+        " add column start_time varchar not null;");
+    if (err != noError) {
+        return err;
+    }
+
+    err = db_->Migrate(
+        "autotracker_settings.end_time",
+        "alter table autotracker_settings"
+        " add column end_time varchar not null;");
+    if (err != noError) {
+        return err;
+    }
+
+    err = db_->Migrate(
+        "autotracker_settings.days_of_week",
+        "alter table autotracker_settings"
+        " add column days_of_week integer not null default 127;"); // 127 == 0x7F == "1111111"
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -101,7 +101,7 @@ error Migrations::migrateAutotracker() {
     err = db_->Migrate(
         "autotracker_settings.start_time",
         "alter table autotracker_settings"
-        " add column start_time varchar not null;");
+        " add column start_time varchar not null default '';");
     if (err != noError) {
         return err;
     }
@@ -109,7 +109,7 @@ error Migrations::migrateAutotracker() {
     err = db_->Migrate(
         "autotracker_settings.end_time",
         "alter table autotracker_settings"
-        " add column end_time varchar not null;");
+        " add column end_time varchar not null default '';");
     if (err != noError) {
         return err;
     }

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -71,7 +71,15 @@ error RelatedData::DeleteAutotrackerRule(const Poco::Int64 local_id) {
     return noError;
 }
 
-error RelatedData::UpdateAutotrackerRule(const Poco::Int64 local_id, std::string terms, const Poco::UInt64 tid, const Poco::UInt64 pid) {
+error RelatedData::UpdateAutotrackerRule(
+    const Poco::Int64 local_id,
+    std::string terms,
+    const Poco::UInt64 tid,
+    const Poco::UInt64 pid,
+    std::string start_time,
+    std::string end_time,
+    const Poco::UInt32 days_of_week) {
+
     if (!local_id) {
         return error("cannot update rule without an ID");
     }
@@ -85,6 +93,9 @@ error RelatedData::UpdateAutotrackerRule(const Poco::Int64 local_id, std::string
             rule->SetTerms(terms);
             rule->SetTID(tid);
             rule->SetPID(pid);
+            rule->SetStartTime(start_time);
+            rule->SetEndTime(end_time);
+            rule->SetDaysOfWeek(days_of_week);
             break;
         }
     }

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -78,7 +78,7 @@ error RelatedData::UpdateAutotrackerRule(
     const Poco::UInt64 pid,
     std::string start_time,
     std::string end_time,
-    const Poco::UInt32 days_of_week) {
+    const Poco::UInt8 days_of_week) {
 
     if (!local_id) {
         return error("cannot update rule without an ID");

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -88,7 +88,14 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
     bool HasMatchingAutotrackerRule(const std::string &lowercase_term) const;
 
     error DeleteAutotrackerRule(const Poco::Int64 local_id);
-    error UpdateAutotrackerRule(const Poco::Int64 local_id, std::string terms, const Poco::UInt64 tid, const Poco::UInt64 pid);
+    error UpdateAutotrackerRule(
+        const Poco::Int64 local_id,
+        std::string terms,
+        const Poco::UInt64 tid,
+        const Poco::UInt64 pid,
+        std::string start_time,
+        std::string end_time,
+        const Poco::UInt32 days_of_week);
 
     void TimeEntryAutocompleteItems(std::vector<view::Autocomplete> *) const;
     void MinitimerAutocompleteItems(std::vector<view::Autocomplete> *) const;

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -95,7 +95,7 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
         const Poco::UInt64 pid,
         std::string start_time,
         std::string end_time,
-        const Poco::UInt32 days_of_week);
+        const Poco::UInt8 days_of_week);
 
     void TimeEntryAutocompleteItems(std::vector<view::Autocomplete> *) const;
     void MinitimerAutocompleteItems(std::vector<view::Autocomplete> *) const;

--- a/src/script/generate_cs_api.go
+++ b/src/script/generate_cs_api.go
@@ -30,6 +30,9 @@ func convert(s string, public bool) string {
 	if strings.Contains(s, "uint8_t") {
 		return visibility + strings.Replace(s, "uint8_t", "byte", -1)
 	}
+	if strings.Contains(s, "uint32_t") {
+		return visibility + strings.Replace(s, "uint32_t", "uint", -1)
+	}
 	if strings.Contains(s, "void *") {
 		return visibility + strings.Replace(s, "void *", "IntPtr ", -1)
 	}

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1892,20 +1892,20 @@ TEST(AutotrackerRule, Matches) {
     a.SetEndTime("17:00");
 
     Poco::LocalDateTime eventTime(2020, 4, 3, 21); // Friday, 21:00
-    ev.SetEndTime(eventTime.timestamp().epochTime());
+    ev.SetEndTime(eventTime.utc().timestamp().epochTime());
     ASSERT_FALSE(a.Matches(ev));
 
     eventTime = Poco::LocalDateTime(2020, 4, 3, 14); // Friday, 14:00
-    ev.SetEndTime(eventTime.timestamp().epochTime());
+    ev.SetEndTime(eventTime.utc().timestamp().epochTime());
     ASSERT_TRUE(a.Matches(ev));
 
-    a.SetDaysOfWeek(0);
-    ASSERT_FALSE(a.Matches(ev));
-
-    a.SetDaysOfWeek(std::bitset<7>("0111110").to_ulong()); // weekdays
+    a.SetDaysOfWeek(0); // default value, means no days restrictions
     ASSERT_TRUE(a.Matches(ev));
 
-    a.SetDaysOfWeek(std::bitset<7>("0111100").to_ulong()); // Monday - Thursday
+    a.SetDaysOfWeek(toggl::AutotrackerRule::DaysOfWeekIntoUInt8(false, true, true, true, true, true, false)); // weekdays
+    ASSERT_TRUE(a.Matches(ev));
+
+    a.SetDaysOfWeek(toggl::AutotrackerRule::DaysOfWeekIntoUInt8(false, true, true, true, true, false, false)); // Monday - Thursday
     ASSERT_FALSE(a.Matches(ev));
 }
 

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1881,11 +1881,31 @@ TEST(AutotrackerRule, Matches) {
 
     ev.SetTitle("toggl-open-source/toggldesktop: Toggl Desktop app for Windows, Mac and Linux - Google Chrome");
     ASSERT_TRUE(a.Matches(ev));
+    
+    ev.SetTitle("YouTube - Chromium");
+    ASSERT_FALSE(a.Matches(ev));
 
     ev.SetTitle("(1) Home / Twitter - Mozilla Firefox");
     ASSERT_TRUE(a.Matches(ev));
+    
+    a.SetStartTime("9:00");
+    a.SetEndTime("17:00");
+    
+    Poco::LocalDateTime eventTime(2020, 4, 3, 21); // Friday, 21:00
+    ev.SetEndTime(eventTime.timestamp().epochTime());
+    ASSERT_FALSE(a.Matches(ev));
+    
+    eventTime = Poco::LocalDateTime(2020, 4, 3, 14); // Friday, 14:00
+    ev.SetEndTime(eventTime.timestamp().epochTime());
+    ASSERT_TRUE(a.Matches(ev));
+    
+    a.SetDaysOfWeek(0);
+    ASSERT_FALSE(a.Matches(ev));
 
-    ev.SetTitle("YouTube - Chromium");
+    a.SetDaysOfWeek(std::bitset<7>("0111110").to_ulong()); // weekdays
+    ASSERT_TRUE(a.Matches(ev));
+
+    a.SetDaysOfWeek(std::bitset<7>("0111100").to_ulong()); // Monday - Thursday
     ASSERT_FALSE(a.Matches(ev));
 }
 

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1881,24 +1881,24 @@ TEST(AutotrackerRule, Matches) {
 
     ev.SetTitle("toggl-open-source/toggldesktop: Toggl Desktop app for Windows, Mac and Linux - Google Chrome");
     ASSERT_TRUE(a.Matches(ev));
-    
+
     ev.SetTitle("YouTube - Chromium");
     ASSERT_FALSE(a.Matches(ev));
 
     ev.SetTitle("(1) Home / Twitter - Mozilla Firefox");
     ASSERT_TRUE(a.Matches(ev));
-    
+
     a.SetStartTime("9:00");
     a.SetEndTime("17:00");
-    
+
     Poco::LocalDateTime eventTime(2020, 4, 3, 21); // Friday, 21:00
     ev.SetEndTime(eventTime.timestamp().epochTime());
     ASSERT_FALSE(a.Matches(ev));
-    
+
     eventTime = Poco::LocalDateTime(2020, 4, 3, 14); // Friday, 14:00
     ev.SetEndTime(eventTime.timestamp().epochTime());
     ASSERT_TRUE(a.Matches(ev));
-    
+
     a.SetDaysOfWeek(0);
     ASSERT_FALSE(a.Matches(ev));
 

--- a/src/test/toggl_api_test.cc
+++ b/src/test/toggl_api_test.cc
@@ -1868,13 +1868,13 @@ TEST(toggl_api, toggl_autotracker_add_rule) {
     const uint64_t existing_project_id = 2598305;
 
     int64_t rule_id = toggl_autotracker_add_rule(
-        app.ctx(), STR("delfi"), existing_project_id, 0);
+        app.ctx(), STR("delfi"), existing_project_id, 0, STR(""), STR(""), 0);
     ASSERT_EQ(noError, testing::testresult::error);
     ASSERT_TRUE(rule_id);
 
     testing::testresult::error = noError;
     rule_id = toggl_autotracker_add_rule(
-        app.ctx(), STR("delfi"), existing_project_id, 0);
+        app.ctx(), STR("delfi"), existing_project_id, 0, STR(""), STR(""), 0);
     ASSERT_EQ("rule already exists", testing::testresult::error);
     ASSERT_FALSE(rule_id);
 
@@ -1882,7 +1882,7 @@ TEST(toggl_api, toggl_autotracker_add_rule) {
 
     testing::testresult::error = noError;
     rule_id = toggl_autotracker_add_rule(
-        app.ctx(), STR("with task"), 0, existing_task_id);
+        app.ctx(), STR("with task"), 0, existing_task_id, STR(""), STR(""), 0);
     ASSERT_EQ(noError, testing::testresult::error);
     ASSERT_TRUE(rule_id);
 
@@ -1891,7 +1891,10 @@ TEST(toggl_api, toggl_autotracker_add_rule) {
         app.ctx(),
         STR("with task and project"),
         existing_project_id,
-        existing_task_id);
+        existing_task_id,
+        STR(""),
+        STR(""),
+        0);
     ASSERT_EQ(noError, testing::testresult::error);
     ASSERT_TRUE(rule_id);
 }

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1389,12 +1389,18 @@ int64_t toggl_autotracker_add_rule(
     void *context,
     const char_t *term,
     const uint64_t project_id,
-    const uint64_t task_id) {
+    const uint64_t task_id,
+    const char_t *start_time,
+    const char_t *end_time,
+    const uint32_t days_of_week) {
     Poco::Int64 rule_id(0);
     app(context)->AddAutotrackerRule(
         to_string(term),
         project_id,
         task_id,
+        to_string(start_time),
+        to_string(end_time),
+        days_of_week,
         &rule_id);
     return rule_id;
 }
@@ -1404,13 +1410,19 @@ bool_t toggl_autotracker_update_rule(
     const int64_t rule_id,
     const char_t *terms,
     const uint64_t project_id,
-    const uint64_t task_id) {
+    const uint64_t task_id,
+    const char_t *start_time,
+    const char_t *end_time,
+    const uint32_t days_of_week) {
     return toggl::noError ==
            app(context)->UpdateAutotrackerRule(
                rule_id,
                to_string(terms),
                project_id,
-               task_id);
+               task_id,
+               to_string(start_time),
+               to_string(end_time),
+               days_of_week);
 }
 
 bool_t toggl_autotracker_delete_rule(

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1392,7 +1392,7 @@ int64_t toggl_autotracker_add_rule(
     const uint64_t task_id,
     const char_t *start_time,
     const char_t *end_time,
-    const uint32_t days_of_week) {
+    const uint8_t days_of_week) {
     Poco::Int64 rule_id(0);
     app(context)->AddAutotrackerRule(
         to_string(term),
@@ -1413,7 +1413,7 @@ bool_t toggl_autotracker_update_rule(
     const uint64_t task_id,
     const char_t *start_time,
     const char_t *end_time,
-    const uint32_t days_of_week) {
+    const uint8_t days_of_week) {
     return toggl::noError ==
            app(context)->UpdateAutotrackerRule(
                rule_id,

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1071,6 +1071,17 @@ int64_t toggl_parse_duration_string_into_seconds(
     return toggl::Formatter::ParseDurationString(to_string(duration_string));
 }
 
+uint8_t toggl_days_of_week_into_uint8(
+    const bool_t sun,
+    const bool_t mon,
+    const bool_t tue,
+    const bool_t wed,
+    const bool_t thu,
+    const bool_t fri,
+    const bool_t sat) {
+    return toggl::AutotrackerRule::DaysOfWeekIntoUInt8(sun, mon, tue, wed, thu, fri, sat);
+}
+
 void toggl_on_show_app(
     void *context,
     TogglDisplayApp cb) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -199,6 +199,9 @@ extern "C" {
         int64_t ID;
         char_t *Terms;
         char_t *ProjectAndTaskLabel;
+        char_t *StartTime;
+        char_t *EndTime;
+        uint32_t DaysOfWeek;
         void *Next;
     } TogglAutotrackerRuleView;
 
@@ -1087,16 +1090,22 @@ extern "C" {
 
     TOGGL_EXPORT int64_t toggl_autotracker_add_rule(
         void *context,
-        const char_t *term,
+        const char_t *terms,
         const uint64_t project_id,
-        const uint64_t task_id);
+        const uint64_t task_id,
+        const char_t *start_time,
+        const char_t *end_time,
+        const uint32_t days_of_week);
 
     TOGGL_EXPORT bool_t toggl_autotracker_update_rule(
         void *context,
         const int64_t rule_id,
         const char_t *terms,
         const uint64_t project_id,
-        const uint64_t task_id);
+        const uint64_t task_id,
+        const char_t *start_time,
+        const char_t *end_time,
+        const uint32_t days_of_week);
 
     TOGGL_EXPORT bool_t toggl_autotracker_delete_rule(
         void *context,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -201,7 +201,7 @@ extern "C" {
         char_t *ProjectAndTaskLabel;
         char_t *StartTime;
         char_t *EndTime;
-        uint32_t DaysOfWeek;
+        uint8_t DaysOfWeek;
         void *Next;
     } TogglAutotrackerRuleView;
 
@@ -1095,7 +1095,7 @@ extern "C" {
         const uint64_t task_id,
         const char_t *start_time,
         const char_t *end_time,
-        const uint32_t days_of_week);
+        const uint8_t days_of_week);
 
     TOGGL_EXPORT bool_t toggl_autotracker_update_rule(
         void *context,
@@ -1105,7 +1105,7 @@ extern "C" {
         const uint64_t task_id,
         const char_t *start_time,
         const char_t *end_time,
-        const uint32_t days_of_week);
+        const uint8_t days_of_week);
 
     TOGGL_EXPORT bool_t toggl_autotracker_delete_rule(
         void *context,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1073,6 +1073,15 @@ extern "C" {
     TOGGL_EXPORT int64_t toggl_parse_duration_string_into_seconds(
         const char_t *duration_string);
 
+    TOGGL_EXPORT uint8_t toggl_days_of_week_into_uint8(
+        const bool_t sun,
+        const bool_t mon,
+        const bool_t tue,
+        const bool_t wed,
+        const bool_t thu,
+        const bool_t fri,
+        const bool_t sat);
+
     // Write to the lib logger
     TOGGL_EXPORT void toggl_debug(
         const char_t *text);

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -116,6 +116,9 @@ TogglAutotrackerRuleView *autotracker_rule_to_view_item(const toggl::view::Autot
     view->ID = static_cast<int>(model.ID);
     view->Terms = copy_string(model.Terms);
     view->ProjectAndTaskLabel = copy_string(model.ProjectName);
+    view->StartTime = copy_string(model.StartTime);
+    view->EndTime = copy_string(model.EndTime);
+    view->DaysOfWeek = model.DaysOfWeek;
     return view;
 }
 

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -135,6 +135,12 @@ void autotracker_view_item_clear(TogglAutotrackerRuleView *view) {
     free(view->ProjectAndTaskLabel);
     view->ProjectAndTaskLabel = nullptr;
 
+    free(view->StartTime);
+    view->StartTime = nullptr;
+
+    free(view->EndTime);
+    view->EndTime = nullptr;
+
     delete view;
 }
 

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -591,7 +591,7 @@ const int kUseProxyToConnectToToggl = 2;
 		return;
 	}
 
-	if (!toggl_autotracker_add_rule(ctx, [term UTF8String], pid, tid))
+	if (!toggl_autotracker_add_rule(ctx, [term UTF8String], pid, tid, "", "", 0))
 	{
 		return;
 	}

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
@@ -469,6 +469,26 @@ namespace TogglDesktop.Tests
         }
 
         [Fact]
+        public void ShouldUpdateAutotrackerRuleWithTimeOfDayAndDaysOfWeek()
+        {
+            var timeEntry = GetTimeEntry(_firstTimeEntryGuid);
+            var pid = timeEntry.PID;
+            var tid = timeEntry.TID;
+
+            var currentRulesList = new List<Toggl.TogglAutotrackerRuleView>();
+            Toggl.OnAutotrackerRules += (rules, terms) => { currentRulesList = rules; };
+
+            var ruleId = Toggl.AddAutotrackerRule("slack", pid, tid);
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId && rule.Terms == "slack");
+
+            var weekDays = Toggl.DaysOfWeekIntoByte(false, true, true, true, true, true, false);
+            Assert.True(Toggl.UpdateAutotrackerRule(ruleId, "slack", pid, tid, "09:00", "17:00", weekDays));
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId && rule.Terms == "slack" && rule.DaysOfWeek == weekDays);
+        }
+
+        [Fact]
         public void ShouldAddTermToExistingAutotrackerRule()
         {
             var timeEntry = GetTimeEntry(_firstTimeEntryGuid);

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -412,6 +413,21 @@ namespace TogglDesktop.Tests
             Toggl.OnAutotrackerRules += (rules, terms) => { currentRulesList = rules; };
 
             var ruleId = Toggl.AddAutotrackerRule("slack", pid, tid);
+
+            Assert.Contains(currentRulesList, rule => rule.ID == ruleId);
+        }
+
+        [Fact]
+        public void ShouldAddAutotrackerRuleWithStartTimeEndTime()
+        {
+            var timeEntry = GetTimeEntry(_firstTimeEntryGuid);
+            var pid = timeEntry.PID;
+            var tid = timeEntry.TID;
+
+            var currentRulesList = new List<Toggl.TogglAutotrackerRuleView>();
+            Toggl.OnAutotrackerRules += (rules, terms) => { currentRulesList = rules; };
+
+            var ruleId = Toggl.AddAutotrackerRule("slack", pid, tid, "10:00", "19:00");
 
             Assert.Contains(currentRulesList, rule => rule.ID == ruleId);
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -639,12 +639,12 @@ public static partial class Toggl
 
     public static long AddAutotrackerRule(string terms, ulong projectId, ulong taskId)
     {
-        return toggl_autotracker_add_rule(ctx, terms, projectId, taskId);
+        return toggl_autotracker_add_rule(ctx, terms, projectId, taskId, "", "", 0);
     }
 
     public static bool UpdateAutotrackerRule(long ruleId, string terms, ulong projectId, ulong taskId)
     {
-        return toggl_autotracker_update_rule(ctx, ruleId, terms, projectId, taskId);
+        return toggl_autotracker_update_rule(ctx, ruleId, terms, projectId, taskId, "", "", 0);
     }
 
     public static bool DeleteAutotrackerRule(long id)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -637,12 +637,12 @@ public static partial class Toggl
         return toggl_format_tracking_time_duration(duration_in_seconds);
     }
 
-    public static long AddAutotrackerRule(string terms, ulong projectId, ulong taskId, string startTime = "", string endTime = "", uint daysOfWeek = 0)
+    public static long AddAutotrackerRule(string terms, ulong projectId, ulong taskId, string startTime = "", string endTime = "", byte daysOfWeek = 0)
     {
         return toggl_autotracker_add_rule(ctx, terms, projectId, taskId, startTime, endTime, daysOfWeek);
     }
 
-    public static bool UpdateAutotrackerRule(long ruleId, string terms, ulong projectId, ulong taskId, string startTime = "", string endTime = "", uint daysOfWeek = 0)
+    public static bool UpdateAutotrackerRule(long ruleId, string terms, ulong projectId, ulong taskId, string startTime = "", string endTime = "", byte daysOfWeek = 0)
     {
         return toggl_autotracker_update_rule(ctx, ruleId, terms, projectId, taskId, startTime, endTime, daysOfWeek);
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1091,6 +1091,11 @@ public static partial class Toggl
         }
     }
 
+    public static string LogAndDbFileName(string environment)
+    {
+        return environment == "production" ? "toggldesktop" : $"toggldesktop_{environment}";
+    }
+
     public static void InitialiseLog()
     {
         string path = Path.Combine(Environment.GetFolderPath(
@@ -1099,7 +1104,7 @@ public static partial class Toggl
 
         if (null == LogPath)
         {
-            LogPath = Path.Combine(path, "toggldesktop.log");
+            LogPath = Path.Combine(path, $"{LogAndDbFileName(Env)}.log");
         }
         toggl_set_log_path(LogPath);
         toggl_set_log_level("debug");
@@ -1152,7 +1157,7 @@ public static partial class Toggl
 
         if (null == DatabasePath)
         {
-            DatabasePath = Path.Combine(path, "toggldesktop.db");
+            DatabasePath = Path.Combine(path, $"{LogAndDbFileName(Env)}.db");
         }
 
         if (!toggl_set_db_path(ctx, DatabasePath))

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1430,5 +1430,10 @@ public static partial class Toggl
     {
         toggl_toggle_entries_group(ctx, groupName);
     }
+
+    public static byte DaysOfWeekIntoByte(bool sun, bool mon, bool tue, bool wed, bool thu, bool fri, bool sat)
+    {
+        return toggl_days_of_week_into_uint8(sun, mon, tue, wed, thu, fri, sat);
+    }
 }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -637,14 +637,14 @@ public static partial class Toggl
         return toggl_format_tracking_time_duration(duration_in_seconds);
     }
 
-    public static long AddAutotrackerRule(string terms, ulong projectId, ulong taskId)
+    public static long AddAutotrackerRule(string terms, ulong projectId, ulong taskId, string startTime = "", string endTime = "", uint daysOfWeek = 0)
     {
-        return toggl_autotracker_add_rule(ctx, terms, projectId, taskId, "", "", 0);
+        return toggl_autotracker_add_rule(ctx, terms, projectId, taskId, startTime, endTime, daysOfWeek);
     }
 
-    public static bool UpdateAutotrackerRule(long ruleId, string terms, ulong projectId, ulong taskId)
+    public static bool UpdateAutotrackerRule(long ruleId, string terms, ulong projectId, ulong taskId, string startTime = "", string endTime = "", uint daysOfWeek = 0)
     {
-        return toggl_autotracker_update_rule(ctx, ruleId, terms, projectId, taskId, "", "", 0);
+        return toggl_autotracker_update_rule(ctx, ruleId, terms, projectId, taskId, startTime, endTime, daysOfWeek);
     }
 
     public static bool DeleteAutotrackerRule(long id)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -331,11 +331,16 @@ public static partial class Toggl
         public         string Terms;
         [MarshalAs(UnmanagedType.LPWStr)]
         public         string ProjectAndTaskLabel;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public         string StartTime;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public         string EndTime;
+        public         uint DaysOfWeek;
         public         IntPtr Next;
 
         public override string ToString()
         {
-            return ProjectAndTaskLabel;
+            return EndTime;
         }
 
     }
@@ -1652,7 +1657,12 @@ public static partial class Toggl
         [MarshalAs(UnmanagedType.LPWStr)]
         string terms,
         UInt64 project_id,
-        UInt64 task_id);
+        UInt64 task_id,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string start_time,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string end_time,
+        uint days_of_week);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]
@@ -1660,9 +1670,14 @@ public static partial class Toggl
         IntPtr context,
         Int64 rule_id,
         [MarshalAs(UnmanagedType.LPWStr)]
-        string term,
+        string terms,
         UInt64 project_id,
-        UInt64 task_id);
+        UInt64 task_id,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string start_time,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string end_time,
+        uint days_of_week);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]
@@ -1782,6 +1797,23 @@ public static partial class Toggl
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern void track_expand_all_days(
         IntPtr context);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return:MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_update_time_entry(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string guid,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string description,
+        UInt64 task_id,
+        UInt64 project_id,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string project_guid,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string tags,
+        [MarshalAs(UnmanagedType.I1)]
+        bool billable);
 
 
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -1634,6 +1634,23 @@ public static partial class Toggl
         [MarshalAs(UnmanagedType.LPWStr)]
         string duration_string);
 
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern byte toggl_days_of_week_into_uint8(
+        [MarshalAs(UnmanagedType.I1)]
+        bool sun,
+        [MarshalAs(UnmanagedType.I1)]
+        bool mon,
+        [MarshalAs(UnmanagedType.I1)]
+        bool tue,
+        [MarshalAs(UnmanagedType.I1)]
+        bool wed,
+        [MarshalAs(UnmanagedType.I1)]
+        bool thu,
+        [MarshalAs(UnmanagedType.I1)]
+        bool fri,
+        [MarshalAs(UnmanagedType.I1)]
+        bool sat);
+
     // Write to the lib logger
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern void toggl_debug(

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -335,7 +335,7 @@ public static partial class Toggl
         public         string StartTime;
         [MarshalAs(UnmanagedType.LPWStr)]
         public         string EndTime;
-        public         uint DaysOfWeek;
+        public         byte DaysOfWeek;
         public         IntPtr Next;
 
         public override string ToString()
@@ -1662,7 +1662,7 @@ public static partial class Toggl
         string start_time,
         [MarshalAs(UnmanagedType.LPWStr)]
         string end_time,
-        uint days_of_week);
+        byte days_of_week);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]
@@ -1677,7 +1677,7 @@ public static partial class Toggl
         string start_time,
         [MarshalAs(UnmanagedType.LPWStr)]
         string end_time,
-        uint days_of_week);
+        byte days_of_week);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]


### PR DESCRIPTION
### 📒 Description
Make Autotracker support time range and days of week

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Saving to / reading from the database
- [x] Matching a time range and days of the week with timeline events
- [x] Converting into view struct for passing to the platform clients
- [x] Change the API method for adding an autotracker rule
- [x] Change the API method for editing an autotracker rule
- [x] Make sure backward compatibility is maintained (add DB migration if necessary)
- [x] App tests
- [x] API tests

### 👫 Relationships
Closes #3916
Closes #3855 

### 🔎 Review hints

The code review should be the main focus, as this PR doesn't change any user-facing functionality.
The thing I'm most unsure of is the days of week API - I decided to go for `uint8` as a representation of days of week bitset for the reason of API simplicity (1 field instead of 7 fields or a separate struct) and memory efficiency. The downside is that it's not clear which bit corresponds to which days of the week. This is why I added a small API method `toggl_days_of_week_into_uint8()` that can be used to make the conversion or as a reference.

Manual test scenario:
1. Run the app to make sure the database has been migrated. Verify the app is running without issues.
2. Create an autotracker rule and save it.
3. Open the database file and set start time, end time, and/or days of the week to the added autotracker rule.
4. Reopen the app to make sure the edited rule is loaded.
5. See if the start time, end time, and days of the week settings are respected.