### PR TITLE
Menu isn't responsive after launching the app

### DIFF
--- a/src/ui/osx/TogglDesktop/TogglDesktop-AppStore-Info.plist
+++ b/src/ui/osx/TogglDesktop/TogglDesktop-AppStore-Info.plist
@@ -59,8 +59,6 @@
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.11</string>
-	<key>LSUIElement</key>
-	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Toggl Desktop developers. All rights reserved.</string>
 	<key>NSMainNibFile</key>

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -116,7 +116,6 @@ void *ctx;
 	self.showMenuBarTimer = NO;
 	self.manualMode = NO;
 	self.onTop = NO;
-	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification

--- a/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
+++ b/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
@@ -59,8 +59,6 @@
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.11</string>
-	<key>LSUIElement</key>
-	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Toggl Desktop developers. All rights reserved.</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
### 📒 Description
This PR would fix the issue which causes the Menu Bar is not responsive

## Problem
We have `LSUIElement` in TogglDesktop and TogglDesktop-AppStore which cause the bug.
[LSUIElement](https://developer.apple.com/documentation/bundleresources/information_property_list/lsuielement?language=objc) intends for the app, which doesn't have a dock icon. Usually an app from Menu Status Bar. However, TogglDesktop is a normal app (have Dock, Main Window and Status Menu), so it causes a bug.

In the past, we override by using `[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];`, but it doesn't work anymore

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Remove LSUIElement and [NSApp setActivationPolicy]

### 👫 Relationships
Closes #3873

### 🔎 Review hints
- Make sure we can click on the menu bar when the app is launched
- All menu bar functionality and shortcuts are working as usual

