### PR TITLE
Basic Hint Popover and UI preparation 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingBackgroundView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingBackgroundView.swift
@@ -1,0 +1,62 @@
+//
+//  OnboardingBackgroundView.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 4/3/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Cocoa
+
+final class OnboardingBackgroundView: NSView {
+
+    // MARK: Variable
+
+    private lazy var maskLayer = CALayer()
+    private lazy var backgroundColor: NSColor = {
+        if #available(OSX 10.13, *) {
+            return NSColor(named: NSColor.Name("onboarding-background-color"))!
+        } else {
+            return NSColor(calibratedWhite: 0, alpha: 0.5)
+        }
+    }()
+
+    // MARK: Init
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        initCommon()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        initCommon()
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        initCommon()
+    }
+
+    // MARK: Public
+
+    func setMaskPosition(at view: NSView) {
+        maskLayer.backgroundColor = NSColor.white.cgColor
+        maskLayer.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        if layer?.mask == nil {
+            layer?.mask = maskLayer
+        }
+    }
+
+}
+
+// MARK: Private
+
+extension OnboardingBackgroundView {
+
+    private func initCommon() {
+        wantsLayer = true
+        layer?.backgroundColor = backgroundColor.cgColor
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingBackgroundView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingBackgroundView.swift
@@ -12,7 +12,7 @@ final class OnboardingBackgroundView: NSView {
 
     // MARK: Variable
 
-    private lazy var maskLayer = CALayer()
+    private lazy var maskLayer = CAShapeLayer()
     private lazy var backgroundColor: NSColor = {
         if #available(OSX 10.13, *) {
             return NSColor(named: NSColor.Name("onboarding-background-color"))!
@@ -40,15 +40,12 @@ final class OnboardingBackgroundView: NSView {
 
     // MARK: Public
 
-    func setMaskPosition(at view: NSView) {
-        maskLayer.backgroundColor = NSColor.white.cgColor
-        maskLayer.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
-
-        if layer?.mask == nil {
-            layer?.mask = maskLayer
-        }
+    func drawMask(at frame: CGRect) {
+        let path = NSBezierPath(rect: frame)
+        path.append(NSBezierPath(rect: bounds))
+        maskLayer.path = path.cgPath
+        layer?.mask = maskLayer
     }
-
 }
 
 // MARK: Private
@@ -58,5 +55,7 @@ extension OnboardingBackgroundView {
     private func initCommon() {
         wantsLayer = true
         layer?.backgroundColor = backgroundColor.cgColor
+        maskLayer.backgroundColor = NSColor.white.cgColor
+        maskLayer.fillRule = .evenOdd // invert mask
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.swift
@@ -1,0 +1,27 @@
+//
+//  OnboardingContentViewController.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 4/1/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Cocoa
+
+final class OnboardingContentViewController: NSViewController {
+
+    // MARK: OUTLET
+
+    @IBOutlet weak var titleTextField: NSTextField!
+    weak var popover: NSPopover?
+
+    // MARK: Public
+
+    func config(with payload: OnboardingPayload) {
+        self.title = payload.title
+    }
+
+    @IBAction func exitBtnOnClick(_ sender: Any) {
+        popover?.performClose(self)
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.swift
@@ -18,7 +18,7 @@ final class OnboardingContentViewController: NSViewController {
     // MARK: Public
 
     func config(with payload: OnboardingPayload) {
-        self.title = payload.title
+        self.titleTextField.stringValue = payload.title
     }
 
     @IBAction func exitBtnOnClick(_ sender: Any) {

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="OnboardingContentViewController" customModule="TogglDesktop" customModuleProvider="target">
+            <connections>
+                <outlet property="titleTextField" destination="jYZ-L3-Wrw" id="aBX-sK-nvb"/>
+                <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView misplaced="YES" id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="292" height="45"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jYZ-L3-Wrw">
+                    <rect key="frame" x="13" y="15" width="246" height="15"/>
+                    <textFieldCell key="cell" selectable="YES" title="Multiline Label" id="5Mi-HB-13h">
+                        <font key="font" metaFont="system" size="12"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CHB-sF-vBe">
+                    <rect key="frame" x="264" y="17" width="24" height="24"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="24" id="fMG-wp-7kG"/>
+                        <constraint firstAttribute="width" constant="24" id="nDy-kl-M0q"/>
+                    </constraints>
+                    <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="close-button" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="Eia-Ae-m9m">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="label" size="13"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="exitBtnOnClick:" target="-2" id="Eb1-iO-QiP"/>
+                    </connections>
+                </button>
+            </subviews>
+            <constraints>
+                <constraint firstItem="jYZ-L3-Wrw" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="15" id="6uE-cu-Acd"/>
+                <constraint firstItem="CHB-sF-vBe" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="4" id="CH8-tq-azB"/>
+                <constraint firstAttribute="bottom" secondItem="jYZ-L3-Wrw" secondAttribute="bottom" constant="15" id="Tfv-rJ-bej"/>
+                <constraint firstItem="jYZ-L3-Wrw" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="15" id="VCf-wL-xCe"/>
+                <constraint firstAttribute="trailing" secondItem="jYZ-L3-Wrw" secondAttribute="trailing" constant="35" id="Yzh-pH-D01"/>
+                <constraint firstAttribute="trailing" secondItem="CHB-sF-vBe" secondAttribute="trailing" constant="4" id="mC0-H1-Bhr"/>
+            </constraints>
+            <point key="canvasLocation" x="45" y="84.5"/>
+        </customView>
+    </objects>
+    <resources>
+        <image name="close-button" width="7" height="7"/>
+    </resources>
+</document>

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
@@ -3,6 +3,7 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,11 +19,19 @@
             <rect key="frame" x="0.0" y="0.0" width="292" height="45"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
+                <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="ztJ-kK-jyl">
+                    <rect key="frame" x="0.0" y="0.0" width="292" height="45"/>
+                    <view key="contentView" id="XK1-w6-eSW">
+                        <rect key="frame" x="0.0" y="0.0" width="292" height="45"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </view>
+                    <color key="fillColor" name="onboarding-hint-background-color"/>
+                </box>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jYZ-L3-Wrw">
                     <rect key="frame" x="13" y="15" width="246" height="15"/>
                     <textFieldCell key="cell" selectable="YES" title="Multiline Label" id="5Mi-HB-13h">
                         <font key="font" metaFont="controlContent"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
@@ -44,7 +53,11 @@
             <constraints>
                 <constraint firstItem="jYZ-L3-Wrw" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="15" id="6uE-cu-Acd"/>
                 <constraint firstItem="CHB-sF-vBe" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="4" id="CH8-tq-azB"/>
+                <constraint firstItem="ztJ-kK-jyl" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="P3m-Af-tfq"/>
+                <constraint firstAttribute="trailing" secondItem="ztJ-kK-jyl" secondAttribute="trailing" id="S2E-Vq-KJ6"/>
                 <constraint firstAttribute="bottom" secondItem="jYZ-L3-Wrw" secondAttribute="bottom" constant="15" id="Tfv-rJ-bej"/>
+                <constraint firstItem="ztJ-kK-jyl" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="U88-uw-Gne"/>
+                <constraint firstAttribute="bottom" secondItem="ztJ-kK-jyl" secondAttribute="bottom" id="V4o-ws-woR"/>
                 <constraint firstItem="jYZ-L3-Wrw" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="15" id="VCf-wL-xCe"/>
                 <constraint firstAttribute="trailing" secondItem="jYZ-L3-Wrw" secondAttribute="trailing" constant="35" id="Yzh-pH-D01"/>
                 <constraint firstAttribute="trailing" secondItem="CHB-sF-vBe" secondAttribute="trailing" constant="4" id="mC0-H1-Bhr"/>
@@ -54,5 +67,8 @@
     </objects>
     <resources>
         <image name="close-button" width="7" height="7"/>
+        <namedColor name="onboarding-hint-background-color">
+            <color red="0.023529411764705882" green="0.66666666666666663" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,13 +24,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="292" height="45"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     </view>
-                    <color key="fillColor" name="onboarding-hint-background-color"/>
                 </box>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jYZ-L3-Wrw">
                     <rect key="frame" x="13" y="15" width="246" height="15"/>
                     <textFieldCell key="cell" selectable="YES" title="Multiline Label" id="5Mi-HB-13h">
-                        <font key="font" metaFont="controlContent"/>
-                        <color key="textColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        <font key="font" metaFont="label" size="12"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
@@ -67,8 +65,5 @@
     </objects>
     <resources>
         <image name="close-button" width="7" height="7"/>
-        <namedColor name="onboarding-hint-background-color">
-            <color red="0.023529411764705882" green="0.66666666666666663" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
     </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingContentViewController.xib
@@ -8,20 +8,20 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="OnboardingContentViewController" customModule="TogglDesktop" customModuleProvider="target">
             <connections>
-                <outlet property="titleTextField" destination="jYZ-L3-Wrw" id="aBX-sK-nvb"/>
+                <outlet property="titleTextField" destination="jYZ-L3-Wrw" id="2fG-7V-rBd"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView misplaced="YES" id="Hz6-mo-xeY">
+        <customView id="Hz6-mo-xeY">
             <rect key="frame" x="0.0" y="0.0" width="292" height="45"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jYZ-L3-Wrw">
                     <rect key="frame" x="13" y="15" width="246" height="15"/>
                     <textFieldCell key="cell" selectable="YES" title="Multiline Label" id="5Mi-HB-13h">
-                        <font key="font" metaFont="system" size="12"/>
+                        <font key="font" metaFont="controlContent"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -34,7 +34,7 @@
                     </constraints>
                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="close-button" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="Eia-Ae-m9m">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="label" size="13"/>
+                        <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
                         <action selector="exitBtnOnClick:" target="-2" id="Eb1-iO-QiP"/>

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
@@ -38,7 +38,7 @@ struct OnboardingPayload {
         case .timelineActivity: self.title = "Having troubles recalling what you were working on?"
         case .timelineTab: self.title = "See your Time Entries on Timeline!"
         case .timelineTimeEntry: self.title = "Add and edit Time Entries in this area"
-        case .timelineView: self.title = "See all your Time Entries visualised  in chronological order! "
+        case .timelineView: self.title = "See all your Time Entries visualised in chronological order! "
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
@@ -8,28 +8,40 @@
 
 import Foundation
 
-struct OnboardingPayload {
+// compatible with objc
+@objc enum OnboardingHint: Int {
+    case newUser
+    case oldUser
+    case manualMode
+    case timelineTab
+    case editTimeEntry
+    case timelineTimeEntry
+    case timelineView
+    case timelineActivity // Use TimelineActivityRecorderViewController instead
+    case recordActivity
+}
 
-    enum Mode {
-        case newUser
-        case oldUser
-        case manualMode
-        case timelineTab
-        case editTimeEntry
-        case timelineTimeEntry
-        case timelineView
-        case timelineActivity // Use TimelineActivityRecorderViewController instead
-        case recordActivity
-    }
+struct OnboardingPayload {
 
     // MARK: Variable
 
     let title: String
+    let hint: OnboardingHint
+
+    var preferEdges: NSRectEdge {
+        switch hint {
+        case .timelineTab:
+            return .minY
+        default: // Fill more later
+            return .maxX
+        }
+    }
 
     // MARK: Init
 
-    init(mode: Mode) {
-        switch mode {
+    init(hint: OnboardingHint) {
+        self.hint = hint
+        switch hint {
         case .editTimeEntry: self.title = "Click on Time Entry to edit it!"
         case .manualMode: self.title = "It’s also possible to add Time Entries manually!\n\nChange to manual mode there..."
         case .newUser: self.title = "Describe your task and start tracking!"

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
@@ -1,0 +1,44 @@
+//
+//  OnboardingPayload.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 4/1/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Foundation
+
+struct OnboardingPayload {
+
+    enum Mode {
+        case newUser
+        case oldUser
+        case manualMode
+        case timelineTab
+        case editTimeEntry
+        case timelineTimeEntry
+        case timelineView
+        case timelineActivity // Use TimelineActivityRecorderViewController instead
+        case recordActivity
+    }
+
+    // MARK: Variable
+
+    let title: String
+
+    // MARK: Init
+
+    init(mode: Mode) {
+        switch mode {
+        case .editTimeEntry: self.title = "Click on Time Entry to edit it!"
+        case .manualMode: self.title = "It’s also possible to add Time Entries manually!\n\nChange to manual mode there..."
+        case .newUser: self.title = "Describe your task and start tracking!"
+        case .oldUser: self.title = "Start typing to access your tasks"
+        case .recordActivity: self.title = "Your recorded activity will be shown right here"
+        case .timelineActivity: self.title = "Having troubles recalling what you were working on?"
+        case .timelineTab: self.title = "See your Time Entries on Timeline!"
+        case .timelineTimeEntry: self.title = "Add and edit Time Entries in this area"
+        case .timelineView: self.title = "See all your Time Entries visualised  in chronological order! "
+        }
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingPayload.swift
@@ -31,7 +31,7 @@ struct OnboardingPayload {
     var preferEdges: NSRectEdge {
         switch hint {
         case .timelineTab:
-            return .minY
+            return .maxY
         default: // Fill more later
             return .maxX
         }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService+Objc.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService+Objc.swift
@@ -1,0 +1,16 @@
+//
+//  OnboardingService+Objc.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 4/1/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Foundation
+
+final class OnboardingServiceObjc: NSObject {
+
+    @objc class func present(hint: OnboardingHint, atView: NSView) {
+        OnboardingService.shared.present(hint: hint, view: atView)
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
@@ -1,0 +1,13 @@
+//
+//  OnboardingService.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 4/1/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Foundation
+
+final class OnboardingService {
+    
+}

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
@@ -12,9 +12,29 @@ final class OnboardingService {
 
     static let shared = OnboardingService()
 
+    // MARK: Variables
+
+    private lazy var controller: OnboardingViewController = OnboardingViewController(nibName: "OnboardingViewController", bundle: nil)
+
     // MARK: Public
 
-    func present(mode: OnboardingPayload.Mode, atView: NSView) {
-        
+    func present(hint: OnboardingHint, view: NSView) {
+        guard let windowContentView = view.window?.contentView else { return }
+
+        // Prevent crash if it's already added to the view hierarchy
+        guard controller.view.superview == nil else { return}
+
+        // Add to entire windows
+        windowContentView.addSubview(controller.view)
+        controller.view.edgesToSuperView()
+
+        // Present
+        let payload = OnboardingPayload(hint: hint)
+        controller.present(payload: payload, view: view)
+    }
+
+    func dismiss() {
+        controller.removeFromParent()
+        controller.dismiss()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
@@ -16,6 +16,12 @@ final class OnboardingService {
 
     private lazy var controller: OnboardingViewController = OnboardingViewController(nibName: "OnboardingViewController", bundle: nil)
 
+    // MARK: Init
+
+    private init() {
+        controller.delegate = self
+    }
+
     // MARK: Public
 
     func present(hint: OnboardingHint, view: NSView) {
@@ -34,7 +40,16 @@ final class OnboardingService {
     }
 
     func dismiss() {
-        controller.removeFromParent()
+        guard controller.view.superview != nil else { return }
         controller.dismiss()
+    }
+}
+
+// MARK: OnboardingViewControllerDelegate
+
+extension OnboardingService: OnboardingViewControllerDelegate {
+
+    func onboardingViewControllerDidClose() {
+        controller.view.removeFromSuperview()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
@@ -36,7 +36,7 @@ final class OnboardingService {
 
         // Present
         let payload = OnboardingPayload(hint: hint)
-        controller.present(payload: payload, view: view)
+        controller.present(payload: payload, hintView: view)
     }
 
     func dismiss() {

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingService.swift
@@ -9,5 +9,12 @@
 import Foundation
 
 final class OnboardingService {
-    
+
+    static let shared = OnboardingService()
+
+    // MARK: Public
+
+    func present(mode: OnboardingPayload.Mode, atView: NSView) {
+        
+    }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
@@ -1,0 +1,35 @@
+//
+//  OnboardingViewController.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 4/1/20.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Cocoa
+
+final class OnboardingViewController: NSViewController {
+
+    // MARK: OUTLET
+
+    @IBOutlet weak var containerView: NSView!
+
+    // MARK: Variable
+
+    private lazy var contentController: OnboardingContentViewController = OnboardingContentViewController(nibName: "OnboardingContentViewController", bundle: nil)
+    private lazy var popover: NoVibrantPopoverView = {
+        let popover = NoVibrantPopoverView()
+        popover.animates = true
+        popover.behavior = .semitransient
+        popover.contentViewController = contentController
+        return popover
+    }()
+
+    // MARK: View Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+    
+}

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
@@ -17,7 +17,7 @@ final class OnboardingViewController: NSViewController {
 
     // MARK: OUTLET
 
-    @IBOutlet weak var containerView: NSView!
+    @IBOutlet weak var backgroundView: OnboardingBackgroundView!
 
     // MARK: Variable
 
@@ -44,6 +44,7 @@ final class OnboardingViewController: NSViewController {
     // MARK: Public
 
     func present(payload: OnboardingPayload, view: NSView) {
+        backgroundView.setMaskPosition(at: view)
         contentController.config(with: payload)
         popover.present(from: view.bounds, of: view, preferredEdge: payload.preferEdges)
     }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
@@ -43,10 +43,16 @@ final class OnboardingViewController: NSViewController {
 
     // MARK: Public
 
-    func present(payload: OnboardingPayload, view: NSView) {
-        backgroundView.setMaskPosition(at: view)
+    func present(payload: OnboardingPayload, hintView: NSView) {
+        // Force render to get the correct size after autolayout
+        view.setNeedsDisplay(view.bounds)
+        view.displayIfNeeded()
+
+        // Render
+        let hintFrame = view.convert(hintView.frame, from: hintView.superview)
+        backgroundView.drawMask(at: hintFrame)
         contentController.config(with: payload)
-        popover.present(from: view.bounds, of: view, preferredEdge: payload.preferEdges)
+        popover.present(from: hintView.bounds, of: hintView, preferredEdge: payload.preferEdges)
     }
 
     func dismiss() {

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
@@ -31,5 +31,26 @@ final class OnboardingViewController: NSViewController {
         super.viewDidLoad()
 
     }
-    
+
+    // MARK: Public
+
+    func present(payload: OnboardingPayload, view: NSView) {
+        contentController.config(with: payload)
+        popover.present(from: view.bounds, of: view, preferredEdge: payload.preferEdges)
+    }
+
+    func dismiss() {
+        popover.performClose(self)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
+        guard popover.isShown else { return }
+
+        // Dismiss if we select on the grey background
+        let contentFrame = view.convert(contentController.view.bounds, from: contentController.view)
+        if !view.frame.contains(contentFrame) {
+            dismiss()
+        }
+    }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
@@ -8,6 +8,11 @@
 
 import Cocoa
 
+protocol OnboardingViewControllerDelegate: class {
+
+    func onboardingViewControllerDidClose()
+}
+
 final class OnboardingViewController: NSViewController {
 
     // MARK: OUTLET
@@ -16,12 +21,14 @@ final class OnboardingViewController: NSViewController {
 
     // MARK: Variable
 
+    weak var delegate: OnboardingViewControllerDelegate?
     private lazy var contentController: OnboardingContentViewController = OnboardingContentViewController(nibName: "OnboardingContentViewController", bundle: nil)
     private lazy var popover: NoVibrantPopoverView = {
         let popover = NoVibrantPopoverView()
         popover.animates = true
         popover.behavior = .semitransient
         popover.contentViewController = contentController
+        popover.delegate = self
         return popover
     }()
 
@@ -40,17 +47,15 @@ final class OnboardingViewController: NSViewController {
     }
 
     func dismiss() {
-        popover.performClose(self)
+        popover.close()
     }
+}
 
-    override func mouseUp(with event: NSEvent) {
-        super.mouseUp(with: event)
-        guard popover.isShown else { return }
+// MARK: NSPopoverDelegate
 
-        // Dismiss if we select on the grey background
-        let contentFrame = view.convert(contentController.view.bounds, from: contentController.view)
-        if !view.frame.contains(contentFrame) {
-            dismiss()
-        }
+extension OnboardingViewController: NSPopoverDelegate {
+
+    func popoverWillClose(_ notification: Notification) {
+        delegate?.onboardingViewControllerDidClose()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.swift
@@ -28,6 +28,7 @@ final class OnboardingViewController: NSViewController {
         popover.animates = true
         popover.behavior = .semitransient
         popover.contentViewController = contentController
+        contentController.popover = popover
         popover.delegate = self
         return popover
     }()
@@ -37,6 +38,7 @@ final class OnboardingViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        initCommon()
     }
 
     // MARK: Public
@@ -48,6 +50,16 @@ final class OnboardingViewController: NSViewController {
 
     func dismiss() {
         popover.close()
+    }
+}
+
+// MARK: Private
+
+extension OnboardingViewController {
+
+    private func initCommon() {
+        // Pre-load the view
+        _ = popover
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.xib
@@ -3,13 +3,12 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="OnboardingViewController" customModule="TogglDesktop" customModuleProvider="target">
             <connections>
-                <outlet property="containerView" destination="glZ-8Q-BCF" id="gb1-a2-sf9"/>
+                <outlet property="backgroundView" destination="glZ-8Q-BCF" id="1Gd-ei-7gQ"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
         </customObject>
@@ -19,38 +18,17 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="oRd-Ok-Fk6">
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="glZ-8Q-BCF" customClass="OnboardingBackgroundView" customModule="TogglDesktop" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
-                    <view key="contentView" id="rV9-CZ-4dj">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="glZ-8Q-BCF">
-                                <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
-                            </customView>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="glZ-8Q-BCF" firstAttribute="top" secondItem="rV9-CZ-4dj" secondAttribute="top" id="R8Q-G2-gyy"/>
-                            <constraint firstItem="glZ-8Q-BCF" firstAttribute="leading" secondItem="rV9-CZ-4dj" secondAttribute="leading" id="Wy0-Sr-csr"/>
-                            <constraint firstAttribute="trailing" secondItem="glZ-8Q-BCF" secondAttribute="trailing" id="ZW2-tc-4xv"/>
-                            <constraint firstAttribute="bottom" secondItem="glZ-8Q-BCF" secondAttribute="bottom" id="eau-U5-gHQ"/>
-                        </constraints>
-                    </view>
-                    <color key="fillColor" name="onboarding-background-color"/>
-                </box>
+                </customView>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="oRd-Ok-Fk6" secondAttribute="bottom" id="3S0-oW-0kY"/>
-                <constraint firstItem="oRd-Ok-Fk6" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="AGl-Hw-WWQ"/>
-                <constraint firstAttribute="trailing" secondItem="oRd-Ok-Fk6" secondAttribute="trailing" id="OCX-Sb-fzA"/>
-                <constraint firstItem="oRd-Ok-Fk6" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="fsf-59-CSY"/>
+                <constraint firstItem="glZ-8Q-BCF" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="bbx-Qy-PBb"/>
+                <constraint firstAttribute="trailing" secondItem="glZ-8Q-BCF" secondAttribute="trailing" id="gsH-Gu-qjh"/>
+                <constraint firstAttribute="bottom" secondItem="glZ-8Q-BCF" secondAttribute="bottom" id="lDi-PZ-DXv"/>
+                <constraint firstItem="glZ-8Q-BCF" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="vWy-gM-QMz"/>
             </constraints>
             <point key="canvasLocation" x="139" y="154"/>
         </customView>
     </objects>
-    <resources>
-        <namedColor name="onboarding-background-color">
-            <color red="1" green="1" blue="1" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-    </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingViewController.xib
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="OnboardingViewController" customModule="TogglDesktop" customModuleProvider="target">
+            <connections>
+                <outlet property="containerView" destination="glZ-8Q-BCF" id="gb1-a2-sf9"/>
+                <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="oRd-Ok-Fk6">
+                    <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+                    <view key="contentView" id="rV9-CZ-4dj">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="glZ-8Q-BCF">
+                                <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+                            </customView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="glZ-8Q-BCF" firstAttribute="top" secondItem="rV9-CZ-4dj" secondAttribute="top" id="R8Q-G2-gyy"/>
+                            <constraint firstItem="glZ-8Q-BCF" firstAttribute="leading" secondItem="rV9-CZ-4dj" secondAttribute="leading" id="Wy0-Sr-csr"/>
+                            <constraint firstAttribute="trailing" secondItem="glZ-8Q-BCF" secondAttribute="trailing" id="ZW2-tc-4xv"/>
+                            <constraint firstAttribute="bottom" secondItem="glZ-8Q-BCF" secondAttribute="bottom" id="eau-U5-gHQ"/>
+                        </constraints>
+                    </view>
+                    <color key="fillColor" name="onboarding-background-color"/>
+                </box>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="oRd-Ok-Fk6" secondAttribute="bottom" id="3S0-oW-0kY"/>
+                <constraint firstItem="oRd-Ok-Fk6" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="AGl-Hw-WWQ"/>
+                <constraint firstAttribute="trailing" secondItem="oRd-Ok-Fk6" secondAttribute="trailing" id="OCX-Sb-fzA"/>
+                <constraint firstItem="oRd-Ok-Fk6" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="fsf-59-CSY"/>
+            </constraints>
+            <point key="canvasLocation" x="139" y="154"/>
+        </customView>
+    </objects>
+    <resources>
+        <namedColor name="onboarding-background-color">
+            <color red="1" green="1" blue="1" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -96,6 +96,8 @@ extern void *ctx;
 
 	// Touch bar
 	[self initTouchBar];
+
+    [self handleOnboarding];
 }
 
 - (void)initTouchBar
@@ -419,6 +421,14 @@ extern void *ctx;
 - (NSTouchBar *)makeTouchBar
 {
     return [[TouchBarService shared] makeTouchBar];
+}
+
+#pragma mark - Onboarding
+
+-(void) handleOnboarding {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [OnboardingServiceObjc presentWithHint:OnboardingHintTimelineTab atView:self.mainDashboardViewController.timelineBtn];
+    });
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/Media.xcassets/Colors/onboarding-background-color.colorset/Contents.json
+++ b/src/ui/osx/TogglDesktop/Media.xcassets/Colors/onboarding-background-color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.500",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "mac"

--- a/src/ui/osx/TogglDesktop/Media.xcassets/Colors/onboarding-background-color.colorset/Contents.json
+++ b/src/ui/osx/TogglDesktop/Media.xcassets/Colors/onboarding-background-color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.500",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "mac"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.500",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/src/ui/osx/TogglDesktop/Media.xcassets/Colors/onboarding-hint-background-color.colorset/Contents.json
+++ b/src/ui/osx/TogglDesktop/Media.xcassets/Colors/onboarding-hint-background-color.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF5",
+          "green" : "0xAA",
+          "red" : "0x06"
+        }
+      },
+      "idiom" : "mac"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -270,6 +270,8 @@
 		BA65A24D22B79FEC00F895FD /* OGSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA65A22D22B79FEC00F895FD /* OGSwitch.swift */; };
 		BA65A25022B7A65D00F895FD /* DatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA65A24F22B7A65D00F895FD /* DatePickerView.swift */; };
 		BA65A25222B7A66A00F895FD /* DatePickerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA65A25122B7A66A00F895FD /* DatePickerView.xib */; };
+		BA683F6F24372B3400C3A3F1 /* OnboardingBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA683F6E24372B3400C3A3F1 /* OnboardingBackgroundView.swift */; };
+		BA683F7024372B3400C3A3F1 /* OnboardingBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA683F6E24372B3400C3A3F1 /* OnboardingBackgroundView.swift */; };
 		BA6EB8402248CBE3003BB8EF /* ProjectStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6EB83F2248CBE3003BB8EF /* ProjectStorage.swift */; };
 		BA6F1B3821EEE998009265E4 /* Theme+Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6F1B3721EEE998009265E4 /* Theme+Notification.swift */; };
 		BA6F81E422C5FB1E009B6828 /* TimelineTimeEntryHoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6F81E222C5FB1E009B6828 /* TimelineTimeEntryHoverViewController.swift */; };
@@ -937,6 +939,7 @@
 		BA65A22D22B79FEC00F895FD /* OGSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OGSwitch.swift; sourceTree = "<group>"; };
 		BA65A24F22B7A65D00F895FD /* DatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerView.swift; sourceTree = "<group>"; };
 		BA65A25122B7A66A00F895FD /* DatePickerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DatePickerView.xib; sourceTree = "<group>"; };
+		BA683F6E24372B3400C3A3F1 /* OnboardingBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackgroundView.swift; sourceTree = "<group>"; };
 		BA6EB83F2248CBE3003BB8EF /* ProjectStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectStorage.swift; sourceTree = "<group>"; };
 		BA6F1B3721EEE998009265E4 /* Theme+Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Notification.swift"; sourceTree = "<group>"; };
 		BA6F81E222C5FB1E009B6828 /* TimelineTimeEntryHoverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineTimeEntryHoverViewController.swift; sourceTree = "<group>"; };
@@ -1422,6 +1425,7 @@
 				BA13E575243476FA005244AD /* OnboardingViewController.xib */,
 				BA13E57A24347716005244AD /* OnboardingContentViewController.swift */,
 				BA13E57B24347716005244AD /* OnboardingContentViewController.xib */,
+				BA683F6E24372B3400C3A3F1 /* OnboardingBackgroundView.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -2456,6 +2460,7 @@
 				BA6EB8402248CBE3003BB8EF /* ProjectStorage.swift in Sources */,
 				BAAF567E2223CAC5003D0D73 /* NSButton+TextColor.swift in Sources */,
 				BA4791F722F0478A00E24F79 /* NotificationCenter+MainThread.swift in Sources */,
+				BA683F6F24372B3400C3A3F1 /* OnboardingBackgroundView.swift in Sources */,
 				BA75FF3922BCC6F800D3F08C /* TimelineData.swift in Sources */,
 				BA01405222571199000E5B91 /* TagTokenView.swift in Sources */,
 				BAF9364C23E8114800EE1076 /* TimelineResizeHoverController.swift in Sources */,
@@ -2782,6 +2787,7 @@
 				BA37ACF923D890250013EE26 /* NSView+LayoutConstraint.swift in Sources */,
 				BA13E56A243472EC005244AD /* OnboardingPayload.swift in Sources */,
 				BAE64DBF2368334000244D2B /* (null) in Sources */,
+				BA683F7024372B3400C3A3F1 /* OnboardingBackgroundView.swift in Sources */,
 				BAE64DC02368334000244D2B /* ResizablePopover.swift in Sources */,
 				BA37ACFB23D890250013EE26 /* NSView+Xib.swift in Sources */,
 				BAE64DC12368334000244D2B /* UndoManager.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		BA13E57D24347716005244AD /* OnboardingContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E57A24347716005244AD /* OnboardingContentViewController.swift */; };
 		BA13E57E24347716005244AD /* OnboardingContentViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13E57B24347716005244AD /* OnboardingContentViewController.xib */; };
 		BA13E57F24347716005244AD /* OnboardingContentViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13E57B24347716005244AD /* OnboardingContentViewController.xib */; };
+		BA13E581243480C5005244AD /* OnboardingService+Objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E580243480C5005244AD /* OnboardingService+Objc.swift */; };
+		BA13E582243480C5005244AD /* OnboardingService+Objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E580243480C5005244AD /* OnboardingService+Objc.swift */; };
 		BA19FC21226DA079006D8741 /* DateCellViewItem.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13D20D2269BAA600EB3833 /* DateCellViewItem.xib */; };
 		BA1FFE71231FB0F300EAD9DC /* PanelSwitcherButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FFE70231FB0F300EAD9DC /* PanelSwitcherButton.swift */; };
 		BA24E772230BDBB800B1D4B2 /* TimelineBaseCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA24E771230BDBB800B1D4B2 /* TimelineBaseCell.swift */; };
@@ -846,6 +848,7 @@
 		BA13E575243476FA005244AD /* OnboardingViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OnboardingViewController.xib; sourceTree = "<group>"; };
 		BA13E57A24347716005244AD /* OnboardingContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContentViewController.swift; sourceTree = "<group>"; };
 		BA13E57B24347716005244AD /* OnboardingContentViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OnboardingContentViewController.xib; sourceTree = "<group>"; };
+		BA13E580243480C5005244AD /* OnboardingService+Objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingService+Objc.swift"; sourceTree = "<group>"; };
 		BA1FFE70231FB0F300EAD9DC /* PanelSwitcherButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelSwitcherButton.swift; sourceTree = "<group>"; };
 		BA24E771230BDBB800B1D4B2 /* TimelineBaseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineBaseCell.swift; sourceTree = "<group>"; };
 		BA24E791230BE50600B1D4B2 /* TimelineActivityHoverController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineActivityHoverController.swift; sourceTree = "<group>"; };
@@ -1413,6 +1416,7 @@
 			isa = PBXGroup;
 			children = (
 				BA13E562243472A1005244AD /* OnboardingService.swift */,
+				BA13E580243480C5005244AD /* OnboardingService+Objc.swift */,
 				BA13E568243472EC005244AD /* OnboardingPayload.swift */,
 				BA13E574243476FA005244AD /* OnboardingViewController.swift */,
 				BA13E575243476FA005244AD /* OnboardingViewController.xib */,
@@ -2511,6 +2515,7 @@
 				BA412C25224E147A003CA17A /* ClientAutoCompleteTextField.swift in Sources */,
 				BA4791F322F0478A00E24F79 /* String+Search.swift in Sources */,
 				74D1D25617EB713F00E709B0 /* TimeEntryListViewController.m in Sources */,
+				BA13E581243480C5005244AD /* OnboardingService+Objc.swift in Sources */,
 				BAAF56A22223E18B003D0D73 /* TimeDecoratorView.swift in Sources */,
 				BAD15FFC223A52D600A8CCC9 /* TimeEntryEmptyView.swift in Sources */,
 				BA4059B7221D46F4002969B8 /* TimeEntryCollectionView.m in Sources */,
@@ -2730,6 +2735,7 @@
 				BA37AD0623D890570013EE26 /* DatePickerView.swift in Sources */,
 				BAE64D9C2368334000244D2B /* TimeEntryListViewController.m in Sources */,
 				BA37ACE223D8900C0013EE26 /* PanelSwitcherButton.swift in Sources */,
+				BA13E582243480C5005244AD /* OnboardingService+Objc.swift in Sources */,
 				BAE64D9D2368334000244D2B /* TimeDecoratorView.swift in Sources */,
 				BAB5FFD523F13F75003781D3 /* TimelineDraggingSession.swift in Sources */,
 				BAE64D9E2368334000244D2B /* TimeEntryEmptyView.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -113,6 +113,10 @@
 		BA13D2172269DE3400EB3833 /* NoVibrantPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13D2162269DE3400EB3833 /* NoVibrantPopoverView.swift */; };
 		BA13D21B2269E0B500EB3833 /* CalendarViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13D2192269E0B500EB3833 /* CalendarViewController.xib */; };
 		BA13E05C21C7BA6000835EC1 /* UserNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = BA13E05921C7B9D900835EC1 /* UserNotificationCenter.m */; };
+		BA13E563243472A1005244AD /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E562243472A1005244AD /* OnboardingService.swift */; };
+		BA13E564243472A1005244AD /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E562243472A1005244AD /* OnboardingService.swift */; };
+		BA13E569243472EC005244AD /* OnboardingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E568243472EC005244AD /* OnboardingPayload.swift */; };
+		BA13E56A243472EC005244AD /* OnboardingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E568243472EC005244AD /* OnboardingPayload.swift */; };
 		BA19FC21226DA079006D8741 /* DateCellViewItem.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13D20D2269BAA600EB3833 /* DateCellViewItem.xib */; };
 		BA1FFE71231FB0F300EAD9DC /* PanelSwitcherButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FFE70231FB0F300EAD9DC /* PanelSwitcherButton.swift */; };
 		BA24E772230BDBB800B1D4B2 /* TimelineBaseCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA24E771230BDBB800B1D4B2 /* TimelineBaseCell.swift */; };
@@ -828,6 +832,8 @@
 		BA13D2192269E0B500EB3833 /* CalendarViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CalendarViewController.xib; sourceTree = "<group>"; };
 		BA13E05921C7B9D900835EC1 /* UserNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = UserNotificationCenter.m; path = test2/UserNotificationCenter.m; sourceTree = SOURCE_ROOT; };
 		BA13E05A21C7B9D900835EC1 /* UserNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UserNotificationCenter.h; path = test2/UserNotificationCenter.h; sourceTree = SOURCE_ROOT; };
+		BA13E562243472A1005244AD /* OnboardingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingService.swift; sourceTree = "<group>"; };
+		BA13E568243472EC005244AD /* OnboardingPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPayload.swift; sourceTree = "<group>"; };
 		BA1FFE70231FB0F300EAD9DC /* PanelSwitcherButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelSwitcherButton.swift; sourceTree = "<group>"; };
 		BA24E771230BDBB800B1D4B2 /* TimelineBaseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineBaseCell.swift; sourceTree = "<group>"; };
 		BA24E791230BE50600B1D4B2 /* TimelineActivityHoverController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineActivityHoverController.swift; sourceTree = "<group>"; };
@@ -1391,6 +1397,15 @@
 			name = UserNotification;
 			sourceTree = "<unknown>";
 		};
+		BA13E5612434728B005244AD /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				BA13E562243472A1005244AD /* OnboardingService.swift */,
+				BA13E568243472EC005244AD /* OnboardingPayload.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
 		BA1B7FA122E5D52F001333D9 /* Swift */ = {
 			isa = PBXGroup;
 			children = (
@@ -1642,6 +1657,7 @@
 		BA712EAF21BF904E00A2D8DD /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				BA13E5612434728B005244AD /* Onboarding */,
 				BAB8CA8C240E3EA2002FF62B /* AppleSignIn */,
 				BA65A1FE22B7807300F895FD /* Timeline */,
 				BA47DEAF23966F80005216AD /* InAppMessage */,
@@ -2443,6 +2459,7 @@
 				BAF3ACCC2341F8AC00E41B33 /* GlobalTouchbarButton.swift in Sources */,
 				3C7B4E8D190FA6D200627DC3 /* NSTextFieldVerticallyAligned.m in Sources */,
 				BAB0027F22731248005ECC93 /* DayLabel.swift in Sources */,
+				BA13E563243472A1005244AD /* OnboardingService.swift in Sources */,
 				3C7B4EB3190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m in Sources */,
 				BA75FF3122BCC57700D3F08C /* TimelineTimeEntry.swift in Sources */,
 				BA0E38122225260B00D0121B /* TimeEntryCell+Ext.swift in Sources */,
@@ -2453,6 +2470,7 @@
 				BA0F67B7224A32F700ED0F91 /* CursorButton.swift in Sources */,
 				BA9C2E0C224C8F58002AD2A1 /* KeyboardTableView.swift in Sources */,
 				BA81896A23016148000710EA /* NSColor+VisibleColor.swift in Sources */,
+				BA13E569243472EC005244AD /* OnboardingPayload.swift in Sources */,
 				69FC180117E6534400B96425 /* main.m in Sources */,
 				74F1070118993FFE00E93BD5 /* FeedbackWindowController.m in Sources */,
 				BAB818E3228D594D008C2367 /* DescriptionTimeEntryStorage.swift in Sources */,
@@ -2594,6 +2612,7 @@
 				BAE64D562368334000244D2B /* AutocompleteItem.m in Sources */,
 				BA37AD0323D8902A0013EE26 /* PopoverRootView.swift in Sources */,
 				BAE64D572368334000244D2B /* Settings.m in Sources */,
+				BA13E564243472A1005244AD /* OnboardingService.swift in Sources */,
 				BA37ACD123D8900C0013EE26 /* TimelineBaseCell.swift in Sources */,
 				BAE64D582368334000244D2B /* NSCustomComboBox.m in Sources */,
 				BAE64D592368334000244D2B /* NSTextFieldDuration.m in Sources */,
@@ -2732,6 +2751,7 @@
 				BAE64DBE2368334000244D2B /* AutoCompleteRowView.swift in Sources */,
 				BA4A7D5523755A4200A42095 /* TouchBarService+Name.swift in Sources */,
 				BA37ACF923D890250013EE26 /* NSView+LayoutConstraint.swift in Sources */,
+				BA13E56A243472EC005244AD /* OnboardingPayload.swift in Sources */,
 				BAE64DBF2368334000244D2B /* (null) in Sources */,
 				BAE64DC02368334000244D2B /* ResizablePopover.swift in Sources */,
 				BA37ACFB23D890250013EE26 /* NSView+Xib.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -117,6 +117,14 @@
 		BA13E564243472A1005244AD /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E562243472A1005244AD /* OnboardingService.swift */; };
 		BA13E569243472EC005244AD /* OnboardingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E568243472EC005244AD /* OnboardingPayload.swift */; };
 		BA13E56A243472EC005244AD /* OnboardingPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E568243472EC005244AD /* OnboardingPayload.swift */; };
+		BA13E576243476FA005244AD /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E574243476FA005244AD /* OnboardingViewController.swift */; };
+		BA13E577243476FA005244AD /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E574243476FA005244AD /* OnboardingViewController.swift */; };
+		BA13E578243476FA005244AD /* OnboardingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13E575243476FA005244AD /* OnboardingViewController.xib */; };
+		BA13E579243476FA005244AD /* OnboardingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13E575243476FA005244AD /* OnboardingViewController.xib */; };
+		BA13E57C24347716005244AD /* OnboardingContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E57A24347716005244AD /* OnboardingContentViewController.swift */; };
+		BA13E57D24347716005244AD /* OnboardingContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA13E57A24347716005244AD /* OnboardingContentViewController.swift */; };
+		BA13E57E24347716005244AD /* OnboardingContentViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13E57B24347716005244AD /* OnboardingContentViewController.xib */; };
+		BA13E57F24347716005244AD /* OnboardingContentViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13E57B24347716005244AD /* OnboardingContentViewController.xib */; };
 		BA19FC21226DA079006D8741 /* DateCellViewItem.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA13D20D2269BAA600EB3833 /* DateCellViewItem.xib */; };
 		BA1FFE71231FB0F300EAD9DC /* PanelSwitcherButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FFE70231FB0F300EAD9DC /* PanelSwitcherButton.swift */; };
 		BA24E772230BDBB800B1D4B2 /* TimelineBaseCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA24E771230BDBB800B1D4B2 /* TimelineBaseCell.swift */; };
@@ -834,6 +842,10 @@
 		BA13E05A21C7B9D900835EC1 /* UserNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UserNotificationCenter.h; path = test2/UserNotificationCenter.h; sourceTree = SOURCE_ROOT; };
 		BA13E562243472A1005244AD /* OnboardingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingService.swift; sourceTree = "<group>"; };
 		BA13E568243472EC005244AD /* OnboardingPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPayload.swift; sourceTree = "<group>"; };
+		BA13E574243476FA005244AD /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
+		BA13E575243476FA005244AD /* OnboardingViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OnboardingViewController.xib; sourceTree = "<group>"; };
+		BA13E57A24347716005244AD /* OnboardingContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContentViewController.swift; sourceTree = "<group>"; };
+		BA13E57B24347716005244AD /* OnboardingContentViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OnboardingContentViewController.xib; sourceTree = "<group>"; };
 		BA1FFE70231FB0F300EAD9DC /* PanelSwitcherButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelSwitcherButton.swift; sourceTree = "<group>"; };
 		BA24E771230BDBB800B1D4B2 /* TimelineBaseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineBaseCell.swift; sourceTree = "<group>"; };
 		BA24E791230BE50600B1D4B2 /* TimelineActivityHoverController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineActivityHoverController.swift; sourceTree = "<group>"; };
@@ -1402,6 +1414,10 @@
 			children = (
 				BA13E562243472A1005244AD /* OnboardingService.swift */,
 				BA13E568243472EC005244AD /* OnboardingPayload.swift */,
+				BA13E574243476FA005244AD /* OnboardingViewController.swift */,
+				BA13E575243476FA005244AD /* OnboardingViewController.xib */,
+				BA13E57A24347716005244AD /* OnboardingContentViewController.swift */,
+				BA13E57B24347716005244AD /* OnboardingContentViewController.xib */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -2034,6 +2050,7 @@
 				BAA0105022CB66D0007C1541 /* TimelineEmptyTimeEntryCell.xib in Resources */,
 				BAF50DE521A29FED0090BA95 /* Images.xcassets in Resources */,
 				BA00E9F5234C848A0011A703 /* TimeEntryScrubberItem.xib in Resources */,
+				BA13E57E24347716005244AD /* OnboardingContentViewController.xib in Resources */,
 				BA34F10122439C3000C27A15 /* EditorViewController.xib in Resources */,
 				74E857BC194F8854007A88B9 /* cacert.pem in Resources */,
 				BAB818EB228D5AA8008C2367 /* DescriptionContentCellView.xib in Resources */,
@@ -2075,6 +2092,7 @@
 				3C50BCAC1C1F0574004BAE9E /* (null) in Resources */,
 				BA0140482257080F000E5B91 /* TagCellView.xib in Resources */,
 				BA9C2DFA224C7E77002AD2A1 /* ProjectCreationView.xib in Resources */,
+				BA13E578243476FA005244AD /* OnboardingViewController.xib in Resources */,
 				BA75FF2822BCC1FC00D3F08C /* TimelineTimeEntryCell.xib in Resources */,
 				BA412C29224E196D003CA17A /* NoClientCellView.xib in Resources */,
 				BA75FF2C22BCC20D00D3F08C /* TimelineActivityCell.xib in Resources */,
@@ -2107,6 +2125,7 @@
 				BA37ACD723D8900C0013EE26 /* TimelineEmptyTimeEntryCell.xib in Resources */,
 				BA43B25523F525F30007DD99 /* TimelineLineView.xib in Resources */,
 				BAE64E072368334000244D2B /* DateCellViewItem.xib in Resources */,
+				BA13E57F24347716005244AD /* OnboardingContentViewController.xib in Resources */,
 				BAE64E082368334000244D2B /* ColorViewItem.xib in Resources */,
 				BAE64E092368334000244D2B /* OverlayViewController.xib in Resources */,
 				BAE64E0A2368334000244D2B /* ProjectContentCellView.xib in Resources */,
@@ -2116,6 +2135,7 @@
 				BAE64E0D2368334000244D2B /* TimeHeaderView.xib in Resources */,
 				BAE64E0E2368334000244D2B /* PreferencesWindowController.xib in Resources */,
 				BAE64E0F2368334000244D2B /* InfoPlist.strings in Resources */,
+				BA13E579243476FA005244AD /* OnboardingViewController.xib in Resources */,
 				BAE64E102368334000244D2B /* DayLabel.xib in Resources */,
 				BA37ACD523D8900C0013EE26 /* TimelineTimeEntryCell.xib in Resources */,
 				BAE64E112368334000244D2B /* ColorPickerView.xib in Resources */,
@@ -2424,6 +2444,7 @@
 				BA712EC821BF9F1200A2D8DD /* UndoStack.swift in Sources */,
 				BA75FF2722BCC1FC00D3F08C /* TimelineTimeEntryCell.swift in Sources */,
 				BA00E9ED234C5A6C0011A703 /* TouchBarService+Name.swift in Sources */,
+				BA13E57C24347716005244AD /* OnboardingContentViewController.swift in Sources */,
 				BA13D2172269DE3400EB3833 /* NoVibrantPopoverView.swift in Sources */,
 				3C6B2488203E01D90063FC08 /* AutoCompleteTable.m in Sources */,
 				BA47920022F0479200E24F79 /* NoInteractionView.swift in Sources */,
@@ -2537,6 +2558,7 @@
 				BAA11AC12251F49E007F31D2 /* WorkspaceStorage.swift in Sources */,
 				3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */,
 				BA45AAF623FBEED4000C94C0 /* CornerBoxView.swift in Sources */,
+				BA13E576243476FA005244AD /* OnboardingViewController.swift in Sources */,
 				BA13D2062269B7C400EB3833 /* CalendarViewController.swift in Sources */,
 				BAFBFCC821CD1D3C004B443F /* SystemService.m in Sources */,
 				BAF50DF821A2A18D0090BA95 /* AppIconFactory.m in Sources */,
@@ -2724,6 +2746,7 @@
 				BAE64DA72368334000244D2B /* (null) in Sources */,
 				BAE64DA82368334000244D2B /* DesktopLibraryBridge.m in Sources */,
 				BAE64DA92368334000244D2B /* TimeEntryDatasource.swift in Sources */,
+				BA13E577243476FA005244AD /* OnboardingViewController.swift in Sources */,
 				BAE64DAA2368334000244D2B /* SystemMessageView.swift in Sources */,
 				BA37ACBC23D890050013EE26 /* TimelineActivityRecorderViewController.swift in Sources */,
 				BAE64DAB2368334000244D2B /* HoverTableCellView.swift in Sources */,
@@ -2792,6 +2815,7 @@
 				BAE64DDF2368334000244D2B /* HSBGen.swift in Sources */,
 				BAE64DE02368334000244D2B /* GoogleAuthenticationServer.swift in Sources */,
 				BAE64DE12368334000244D2B /* WorkspaceCellView.swift in Sources */,
+				BA13E57D24347716005244AD /* OnboardingContentViewController.swift in Sources */,
 				BA37ACD823D8900C0013EE26 /* TimelineActivityCell.swift in Sources */,
 				BAE64DE32368334000244D2B /* idler.c in Sources */,
 				BAE64DE42368334000244D2B /* ProjectCreationView.swift in Sources */,


### PR DESCRIPTION
### 📒 Description
This PR would introduce a basic hint popover (not full-feature), models and UI preparation for the 
library ticket. It's not ready to merge into the master.

Design: https://toggl.invisionapp.com/d/main#/console/19683071/411619440/inspect

### Not done yet (implement on different tickets)
- Corner Radius on Highlight area
- Support all hints
- Support Circle Highlight area
- Blue Color like the design
- ...

### 🕶️ Types of change
 **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Add some model to present the Popover depend on the hint type
- Logic to present/dismiss the Popover
- Grey Background + highlight area logic

### 👫 Relationships
Related #3951 #3953 but not close 
### 🔎 Review hints
1. Switch to Light theme (Dark theme color is not ready from the designer)
2. Launch the app, after 3 seconds, the app will show the hint on Timeline Button (hardcode for testing). Verify that:
- The basic feature is done
- Able to click on the background to dismiss
- Draw the mask correctly
- Resize the window will re-draw the background + mask layer

GIF: https://www.dropbox.com/s/bc2fk9v5tv6edsx/2020-04-03%2016.49.03.gif?dl=0

