### PR TITLE
Hide autocomplete on timer start

### DIFF
--- a/src/ui/linux/TogglDesktop/TimerView.qml
+++ b/src/ui/linux/TogglDesktop/TimerView.qml
@@ -77,6 +77,7 @@ Rectangle {
                     else {
                         if (acceptableInput) {
                             start()
+                            autocomplete.visible = false
                         }
                     }
                 }


### PR DESCRIPTION
### 📒 Description
Close the autosuggest dialog after return was pressed even if no item from it was selected.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3955

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

