### PR TITLE
Show suggestion also when there is a running entry

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4672,13 +4672,26 @@ error Context::StartAutotrackerEvent(const TimelineEvent &event) {
         return noError;
     }
 
-    // Notify user to track using autotracker rules:
-    if (user_ && user_->RunningTimeEntry()) {
-        return noError;
+    TimeEntry* runningEntry = user_->RunningTimeEntry();
+    if (runningEntry) {
+        // on Windows show suggestion also where there is a running entry (#3917)
+        if (POCO_OS_WINDOWS_NT != POCO_OS) {
+            return noError;
+        }
     }
+
     AutotrackerRule *rule = user_->related.FindAutotrackerRule(event);
     if (!rule) {
         return noError;
+    }
+
+    if (runningEntry) {
+        bool isRunningEntryMatchingAutotrackerRuleProject = 
+            rule->PID() == runningEntry->PID() && (!rule->TID() || rule->TID() == runningEntry->TID());
+
+        if (isRunningEntryMatchingAutotrackerRuleProject) {
+            return noError;
+        }
     }
 
     Project *p = nullptr;


### PR DESCRIPTION
### 📒 Description
Show suggestion also when there is a running entry (on Windows only)

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3917

### 🔎 Review hints

Set up some autotracker rules and test whether the suggestions from these rules are shown while a time entry is running.

1. Autotracker - Project1, running time entry - Project1 -> no suggestion ❌  
2. Autotracker - Project1 Task1, running time entry - Project1 -> suggestion ✔️ 
3. Autotracker - Project1 Task1, running time entry - Project1 Task2 -> suggestion ✔️ 
4. Autotracker - Project1, running time entry - Project1 Task1 -> no suggestion ❌ 
5. Autotracker - Project1, running time entry - Project2 -> suggestion ✔️ 
6. Autotracker - Project1, running time entry - no project -> suggestion ✔️ 

Note: I came up with these test cases, so let me know if you think it should behave differently.

⚠️ This is only for Windows. On other platforms, the behavior remains the same.