### PR TITLE
Added logic to show notification when update is ready to be installed

### DIFF
--- a/src/ui/osx/TogglDesktop/AboutWindowController.m
+++ b/src/ui/osx/TogglDesktop/AboutWindowController.m
@@ -140,6 +140,9 @@ extern void *ctx;
 
 	[self displayUpdateStatus];
 	[self setDownloadState:DownloadStateRestart];
+
+    // Show notification to quit
+    [[NSNotificationCenter defaultCenter] postNotificationName:kUpdateReady object:nil];
 }
 
 - (void)updater:(SUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)update

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -60,6 +60,7 @@ extern NSString *const kDidAdddManualTimeNotification;
 extern NSString *const kTouchBarSettingChanged;
 extern NSString *const kStartDisplayInAppMessage;
 extern NSString *const kStarTimeEntryWithStartTime;
+extern NSString *const kUpdateReady;
 
 const char *kFocusedFieldNameDuration;
 const char *kFocusedFieldNameDescription;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -54,6 +54,7 @@ NSString *const kUpdateIconTooltip = @"kUpdateIconTooltip";
 NSString *const kUserHasBeenSignup = @"kUserHasBeenSignup";
 NSString *const kTouchBarSettingChanged = @"kTouchBarSettingChanged";
 NSString *const kStartDisplayInAppMessage = @"kStartDisplayInAppMessage";
+NSString *const kUpdateReady = @"kUpdateReady";
 
 NSString *const kDeselectAllTimeEntryList = @"kDeselectAllTimeEntryList";
 NSString *const kDidAdddManualTimeNotification = @"kDidAdddManualTimeNotification";

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -401,6 +401,7 @@ void *ctx;
             [[UserNotificationCenter share] removeAllDeliveredNotificationsWithType:@"update-restart"];
             self.aboutWindowController.restart = YES;
             [[NSApplication sharedApplication] terminate:nil];
+            return;
         }
 
 		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -216,6 +216,10 @@ void *ctx;
                                              selector:@selector(invalidAppleUserCrendentialNotification:)
                                                  name:kInvalidAppleUserCrendential
                                                object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(updateReadyNotification:)
+                                                 name:kUpdateReady
+                                               object:nil];
 
 	if (@available(macOS 10.14, *))
 	{
@@ -378,14 +382,29 @@ void *ctx;
 	// handle user clicking on notification alert
 	if (NSUserNotificationActivationTypeContentsClicked == notification.activationType)
 	{
-		[self onShowMenuItem:self];
+        if (notification.userInfo[@"update-restart"] != nil)
+        {
+            [[UserNotificationCenter share] removeAllDeliveredNotificationsWithType:@"update-restart"];
+            self.aboutWindowController.restart = YES;
+            [[NSApplication sharedApplication] terminate:nil];
+        } else {
+            [self onShowMenuItem:self];
+        }
 		return;
 	}
 
-	// handle autotracker notification
 	if (notification && notification.userInfo)
 	{
+        // handle restart to update notification
+        if (notification.userInfo[@"update-restart"] != nil)
+        {
+            [[UserNotificationCenter share] removeAllDeliveredNotificationsWithType:@"update-restart"];
+            self.aboutWindowController.restart = YES;
+            [[NSApplication sharedApplication] terminate:nil];
+        }
+
 		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            // handle autotracker notification
 			if (notification.userInfo[@"autotracker"] != nil)
 			{
 				NSNumber *project_id = notification.userInfo[@"project_id"];
@@ -1797,5 +1816,10 @@ void on_display_message(const char *title,
     [self onLogoutMenuItem:self];
     [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
                                                                 object:@"Invalid Apple session. Please try login again."];
+}
+
+- (void) updateReadyNotification:(NSNotification *) notification
+{
+    [[UserNotificationCenter share] scheduleUpdateReady];
 }
 @end

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
@@ -22,6 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)scheduleAutoTrackerWithProjectName:(NSString *)projectName projectID:(NSNumber *)projectID taskID:(NSNumber *)taskID;
 
+- (void)scheduleUpdateReady;
+
+- (void)removeAllDeliveredNotificationsWithType:(NSString *)type;
+
 - (BOOL)isDoNotDisturbEnabled;
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
@@ -143,4 +143,19 @@
 	[self scheduleNotification:notification];
 }
 
+- (void)scheduleUpdateReady
+{
+    NSUserNotification *notification = [self defaultUserNotificationWithTitle:@"A new version of Toggl Desktop is ready!"
+                                                              informativeText:@"Click here to restart and install"];
+
+    notification.userInfo = @{ @"update-restart": @"YES" };
+    notification.hasActionButton = YES;
+    notification.actionButtonTitle = @"Restart";
+    notification.otherButtonTitle = @"Close";
+
+    // Delivery
+    [self removeAllDeliveredNotificationsWithType:@"update-restart"];
+    [self scheduleNotification:notification];
+}
+
 @end


### PR DESCRIPTION
### 📒 Description
Show notification when the update has finished downloading in the background. Clicking the notification restarts the app and installs the update.

### 🕶️ Types of changes

**New feature**

### 👫 Relationships
Closes #3988

### 🔎 Review hints
- Switch to Production Scheme (Menubar menu -> Product -> Scheme -> TogglDesktop-Production)
- Start app and wait for the update to download. (you can open the About view to see the progress)

