### PR TITLE
Display first day of the week in Reminders depending on the user settings

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -1399,6 +1399,14 @@ std::string Context::UserEmail() {
     return user_->Email();
 }
 
+Poco::UInt8 Context::UserBeginningOfWeek() {
+    Poco::Mutex::ScopedLock lock(user_m_);
+    if (!user_) {
+        return 1;
+    }
+    return user_->BeginningOfWeek();
+}
+
 void Context::executeUpdateCheck() {
     logger.debug("executeUpdateCheck");
 

--- a/src/context.h
+++ b/src/context.h
@@ -529,8 +529,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const Poco::Int64 id);
 
     std::string UserFullName();
-
     std::string UserEmail();
+    Poco::UInt8 UserBeginningOfWeek();
 
     // Timeline datasource
     error StartAutotrackerEvent(const TimelineEvent &event) override;

--- a/src/database.cc
+++ b/src/database.cc
@@ -1197,13 +1197,14 @@ error Database::LoadUserByID(
         std::string offline_data("");
         Poco::UInt64 default_pid(0);
         Poco::UInt64 default_tid(0);
+        Poco::UInt8 beginning_of_week(1);
         bool collapse_entries(false);
         *session_ <<
                   "select local_id, id, default_wid, since, "
                   "fullname, "
                   "email, record_timeline, store_start_and_stop_time, "
                   "timeofday_format, duration_format, offline_data, "
-                  "default_pid, default_tid, collapse_entries "
+                  "default_pid, default_tid, collapse_entries, beginning_of_week "
                   "from users where id = :id limit 1",
                   into(local_id),
                   into(id),
@@ -1219,6 +1220,7 @@ error Database::LoadUserByID(
                   into(default_pid),
                   into(default_tid),
                   into(collapse_entries),
+                  into(beginning_of_week),
                   useRef(UID),
                   limit(1),
                   now;
@@ -1247,6 +1249,7 @@ error Database::LoadUserByID(
         user->SetDefaultPID(default_pid);
         user->SetDefaultTID(default_tid);
         user->SetCollapseEntries(collapse_entries);
+        user->SetBeginningOfWeek(beginning_of_week);
     } catch(const Poco::Exception& exc) {
         return exc.displayText();
     } catch(const std::exception& ex) {
@@ -3272,7 +3275,8 @@ error Database::SaveUser(
                           "offline_data = :offline_data, "
                           "default_pid = :default_pid, "
                           "default_tid = :default_tid, "
-                          "collapse_entries = :collapse_entries "
+                          "collapse_entries = :collapse_entries, "
+                          "beginning_of_week = :beginning_of_week "
                           "where local_id = :local_id",
                           useRef(user->DefaultWID()),
                           useRef(user->Since()),
@@ -3287,6 +3291,7 @@ error Database::SaveUser(
                           useRef(user->DefaultPID()),
                           useRef(user->DefaultTID()),
                           useRef(user->CollapseEntries()),
+                          useRef(user->BeginningOfWeek()),
                           useRef(user->LocalID()),
                           now;
                 error err = last_error("SaveUser");
@@ -3303,13 +3308,13 @@ error Database::SaveUser(
                           "id, default_wid, since, fullname, email, "
                           "record_timeline, store_start_and_stop_time, "
                           "timeofday_format, duration_format, offline_data, "
-                          "default_pid, default_tid"
+                          "default_pid, default_tid, beginning_of_week"
                           ") values("
                           ":id, :default_wid, :since, :fullname, "
                           ":email, "
                           ":record_timeline, :store_start_and_stop_time, "
                           ":timeofday_format, :duration_format, :offline_data, "
-                          ":default_pid, :default_tid"
+                          ":default_pid, :default_tid, :beginning_of_week"
                           ")",
                           useRef(user->ID()),
                           useRef(user->DefaultWID()),
@@ -3323,6 +3328,7 @@ error Database::SaveUser(
                           useRef(user->OfflineData()),
                           useRef(user->DefaultPID()),
                           useRef(user->DefaultTID()),
+                          useRef(user->BeginningOfWeek()),
                           now;
                 error err = last_error("SaveUser");
                 if (err != noError) {

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -665,6 +665,14 @@ error Migrations::migrateUsers() {
         return err;
     }
 
+    err = db_->Migrate(
+        "users.beginning_of_week",
+        "alter table users"
+        " add column beginning_of_week integer not null default 1;");
+    if (err != noError) {
+        return err;
+    }
+
     return err;
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1063,6 +1063,11 @@ char_t *toggl_get_user_email(
     return copy_string(app(context)->UserEmail());
 }
 
+uint8_t toggl_get_user_beginning_of_week(
+    void *context) {
+    return app(context)->UserBeginningOfWeek();
+}
+
 int64_t toggl_parse_duration_string_into_seconds(
     const char_t *duration_string) {
     if (!duration_string) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1012,6 +1012,9 @@ extern "C" {
     TOGGL_EXPORT char_t *toggl_get_user_fullname(
         void *context);
 
+    TOGGL_EXPORT uint8_t toggl_get_user_beginning_of_week(
+        void *context);
+
     // You must free() the result
     TOGGL_EXPORT char_t *toggl_get_user_email(
         void *context);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -586,6 +586,11 @@ public static partial class Toggl
         return toggl_get_user_email(ctx);
     }
 
+    public static DayOfWeek UserBeginningOfWeek()
+    {
+        return (DayOfWeek) toggl_get_user_beginning_of_week(ctx);
+    }
+
     public static void FullSync()
     {
         toggl_fullsync(ctx);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -1550,6 +1550,10 @@ public static partial class Toggl
     private static extern string toggl_get_user_fullname(
         IntPtr context);
 
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern byte toggl_get_user_beginning_of_week(
+        IntPtr context);
+
     // You must free() the result
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern string toggl_get_user_email(

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -336,6 +336,7 @@
     <Compile Include="ui\windows\MiniTimerWindow.xaml.cs">
       <DependentUpon>MiniTimerWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="utilities\DayOfWeekExtensions.cs" />
     <Compile Include="utilities\LinqExtensions.cs" />
     <Compile Include="utilities\StaticObjectPool.cs" />
     <Compile Include="TogglApi.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -317,19 +317,19 @@
                         </StackPanel>
 
                         <StackPanel Grid.Row="2" Grid.Column="1">
-                            <CheckBox Name="remindOnMondayTextBox" x:FieldModifier="private"
+                            <CheckBox Name="remindDay1CheckBox" x:FieldModifier="private"
                                       >Monday</CheckBox>
-                            <CheckBox Name="remindOnTuesdayTextBox" x:FieldModifier="private"
+                            <CheckBox Name="remindDay2CheckBox" x:FieldModifier="private"
                                       Margin="0 12 0 0">Tuesday</CheckBox>
-                            <CheckBox Name="remindOnWednesdayTextBox" x:FieldModifier="private"
+                            <CheckBox Name="remindDay3CheckBox" x:FieldModifier="private"
                                       Margin="0 12 0 0">Wednesday</CheckBox>
-                            <CheckBox Name="remindOnThursdayTextBox" x:FieldModifier="private"
+                            <CheckBox Name="remindDay4CheckBox" x:FieldModifier="private"
                                       Margin="0 12 0 0">Thursday</CheckBox>
-                            <CheckBox Name="remindOnFridayTextBox" x:FieldModifier="private"
+                            <CheckBox Name="remindDay5CheckBox" x:FieldModifier="private"
                                       Margin="0 12 0 0">Friday</CheckBox>
-                            <CheckBox Name="remindOnSaturdayTextBox" x:FieldModifier="private"
+                            <CheckBox Name="remindDay6CheckBox" x:FieldModifier="private"
                                       Margin="0 12 0 0">Saturday</CheckBox>
-                            <CheckBox Name="remindOnSundayTextBox" x:FieldModifier="private"
+                            <CheckBox Name="remindDay7CheckBox" x:FieldModifier="private"
                                       Margin="0 12 0 0">Sunday</CheckBox>
                         </StackPanel>
                     </Grid>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TogglDesktop
+{
+    public static class DayOfWeekExtensions
+    {
+        public static IEnumerable<DayOfWeek> DaysOfWeek() => Enum.GetValues(typeof(DayOfWeek)).Cast<DayOfWeek>();
+
+        public static int PositionRelativeTo(this DayOfWeek day, DayOfWeek beginningOfWeek) =>
+            (day - beginningOfWeek + 7) % 7;
+    }
+}

--- a/src/user.cc
+++ b/src/user.cc
@@ -409,6 +409,13 @@ void User::SetCollapseEntries(const bool value) {
     }
 }
 
+void User::SetBeginningOfWeek(const Poco::UInt8 value) {
+    if (beginning_of_week_ != value) {
+        beginning_of_week_ = value;
+        SetDirty();
+    }
+}
+
 // Stop a time entry, mark it as dirty.
 // Note that there may be multiple TE-s running. If there are,
 // all of them are stopped (multi-tracking is not supported by Toggl).
@@ -800,6 +807,7 @@ void User::loadUserAndRelatedDataFromJSON(
     SetStoreStartAndStopTime(data["store_start_and_stop_time"].asBool());
     SetTimeOfDayFormat(data["timeofday_format"].asString());
     SetDurationFormat(data["duration_format"].asString());
+    SetBeginningOfWeek(data["beginning_of_week"].asUInt());
 
     {
         std::set<Poco::UInt64> alive;

--- a/src/user.h
+++ b/src/user.h
@@ -36,6 +36,7 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     , offline_data_("")
     , default_pid_(0)
     , default_tid_(0)
+    , beginning_of_week_(1)
     , has_loaded_more_(false)
     , collapse_entries_(false) {}
 
@@ -168,6 +169,11 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         return collapse_entries_;
     }
     void SetCollapseEntries(const bool value);
+
+    const Poco::UInt8 &BeginningOfWeek() const {
+        return beginning_of_week_;
+    }
+    void SetBeginningOfWeek(const Poco::UInt8 value);
 
     RelatedData related;
 
@@ -335,9 +341,9 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     std::string offline_data_;
     Poco::UInt64 default_pid_;
     Poco::UInt64 default_tid_;
-
     bool has_loaded_more_;
     bool collapse_entries_;
+    Poco::UInt8 beginning_of_week_;
 
     Poco::Mutex loadTimeEntries_m_;
 };


### PR DESCRIPTION
### 📒 Description
Display first day of the week in Reminders depending on the user settings (Windows)

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add `beginning_of_week` to `User` class and users database table
- [x] Get `beginning_of_week` value from the `/me` response
- [x] Add `toggl_get_user_beginning_of_week` API method for clients
- [x] Implement the Windows part

### 👫 Relationships
Closes #3922

### 🔎 Review hints
- Run the Toggl Desktop Windows app
- Open web app (staging if Windows app is running in Debug mode) -> Profile settings -> change "First day of the week"
- Open Preferences -> Reminder, verify that the first day of the week is correct
- Uncheck a few days of the week
- Change "First day of the week" in the web app again
- Open Preferences -> Reminder again
- Verify that the first day of the week is correct
- Verify that the unchecked days were remembered correctly