### PR TITLE
Disable "Disable Library Validation"

### DIFF
--- a/src/ui/osx/TogglDesktop/TogglDesktop/TogglDesktop-AppStore.entitlements
+++ b/src/ui/osx/TogglDesktop/TogglDesktop/TogglDesktop-AppStore.entitlements
@@ -8,8 +8,6 @@
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/src/ui/osx/TogglDesktop/TogglDesktop/TogglDesktop.entitlements
+++ b/src/ui/osx/TogglDesktop/TogglDesktop/TogglDesktop.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
-</dict>
+<dict/>
 </plist>


### PR DESCRIPTION
### 📒 Description
Disable "Disable Library Validation" to prevent library vulnerability

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Uncheck "Disable Library Validation"

### 👫 Relationships
Closes #3999

### 🔎 Review hints
Verify that:
- We're able to run and archive the app
- App runs normally
- Archive and Export the app -> Drag to Application folder -> Download DHS (https://bitbucket.org/objective-see/deploy/downloads/DHS_1.4.1.zip) and scan -> Verify no warning from TogglDesktop

