### PR TITLE
Days of week selector component

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
@@ -8,10 +8,11 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TogglDesktop.LibraryInteropTests</RootNamespace>
+    <RootNamespace>TogglDesktop.Tests</RootNamespace>
     <AssemblyName>TogglDesktop.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\x86\Debug\</OutputPath>
@@ -44,6 +45,7 @@
     <Compile Include="LibraryIntegrationTests.cs" />
     <Compile Include="LibraryUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UIUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\lib\windows\TogglDesktopDLL\TogglDesktopDLL.vcxproj">

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/UIUnitTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/UIUnitTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace TogglDesktop.Tests
+{
+    public class UIUnitTests
+    {
+        [Theory]
+        [InlineData(new[] { false, true,  false, false, false, false, false}, DayOfWeek.Monday, "on Monday")]
+        [InlineData(new[] { false, true,  true,  false, false, false, false}, DayOfWeek.Monday, "on Monday, Tuesday")]
+        [InlineData(new[] { true,  false, false, false, false, false, true},  DayOfWeek.Monday, "on weekend")]
+        [InlineData(new[] { false, true,  true,  true,  false, false, false}, DayOfWeek.Monday, "on Monday, Tuesday, Wednesday")]
+        [InlineData(new[] { false, true,  true,  true,  false, false, true},  DayOfWeek.Monday, "on Monday, Tuesday, Wednesday, Saturday")]
+        [InlineData(new[] { false, true,  true,  true,  true,  false, false}, DayOfWeek.Monday, "on weekdays except Friday")]
+        [InlineData(new[] { false, true,  true,  true,  true,  false, true},  DayOfWeek.Monday, "every day except Friday, Sunday")]
+        [InlineData(new[] { false, true,  true,  true,  true,  true,  false}, DayOfWeek.Monday, "on weekdays")]
+        [InlineData(new[] { true,  true,  true,  true,  true,  false, true},  DayOfWeek.Monday, "every day except Friday")]
+        [InlineData(new[] { true,  true,  true,  true,  true,  true,  false}, DayOfWeek.Monday, "on weekdays and Sunday")]
+        [InlineData(new[] { true,  true,  true,  true,  true,  true,  true},  DayOfWeek.Monday, "every day")]
+        [InlineData(new[] { true,  true,  false, false, false, false, false}, DayOfWeek.Monday, "on Monday, Sunday")]
+        [InlineData(new[] { true,  true,  false, false, false, false, false}, DayOfWeek.Sunday, "on Sunday, Monday")]
+        public void TestSelectedDaysOfWeekText(bool[] daysChecked, DayOfWeek beginningOfWeek, string expectedText)
+        {
+            var isDayChecked = daysChecked.WithIndex()
+                .ToDictionary(x => (DayOfWeek) x.index, x => x.item);
+            var text = DayOfWeekExtensions.GetText(isDayChecked, beginningOfWeek);
+            Assert.Equal(expectedText, text);
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -208,6 +208,9 @@
     <Compile Include="ui\Behaviors\NumericInputTextBoxBehavior.cs" />
     <Compile Include="ui\Behaviors\RepositionPopupWithParentWindowBehavior.cs" />
     <Compile Include="ui\Behaviors\TextBoxHelper.cs" />
+    <Compile Include="ui\controls\DaysOfWeekSelector.xaml.cs">
+      <DependentUpon>DaysOfWeekSelector.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ui\controls\InAppNotification.xaml.cs">
       <DependentUpon>InAppNotification.xaml</DependentUpon>
     </Compile>
@@ -482,6 +485,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="ui\controls\DaysOfWeekSelector.xaml" />
     <Page Include="ui\controls\ErrorBar.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml
@@ -16,7 +16,8 @@
         </TextBlock>
         <Popup x:Name="popup" x:FieldModifier="private"
                AllowsTransparency="True"
-               StaysOpen="False">
+               StaysOpen="False"
+               HorizontalOffset="-4">
             <Grid Background="Transparent">
                 <Border Margin="4"
                         BorderBrush="{DynamicResource Toggl.LightGrayBrush}"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml
@@ -1,0 +1,49 @@
+<UserControl x:Class="TogglDesktop.DaysOfWeekSelector"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300"
+             DataContext="{Binding RelativeSource={RelativeSource Self}}">
+    <Grid>
+        <TextBlock>
+            <Hyperlink Style="{StaticResource Toggl.AccentHyperlink}"
+                       Click="TogglePopup"
+                       TextDecorations="None">
+                <Run Text="{Binding Text}" />
+            </Hyperlink>
+        </TextBlock>
+        <Popup x:Name="popup" x:FieldModifier="private"
+               AllowsTransparency="True"
+               StaysOpen="False">
+            <Grid Background="Transparent">
+                <Border Margin="4"
+                        BorderBrush="{DynamicResource Toggl.LightGrayBrush}"
+                        BorderThickness="1"
+                        Background="{DynamicResource Toggl.CardBackground}">
+                    <Border.Effect>
+                        <DropShadowEffect ShadowDepth="1" BlurRadius="4" Direction="270" Opacity="0.1" Color="Black" />
+                    </Border.Effect>
+
+                    <StackPanel Margin="16 16 24 16">
+                        <CheckBox Name="remindDay1CheckBox" x:FieldModifier="private"
+                        >Monday</CheckBox>
+                        <CheckBox Name="remindDay2CheckBox" x:FieldModifier="private"
+                                  Margin="0 12 0 0">Tuesday</CheckBox>
+                        <CheckBox Name="remindDay3CheckBox" x:FieldModifier="private"
+                                  Margin="0 12 0 0">Wednesday</CheckBox>
+                        <CheckBox Name="remindDay4CheckBox" x:FieldModifier="private"
+                                  Margin="0 12 0 0">Thursday</CheckBox>
+                        <CheckBox Name="remindDay5CheckBox" x:FieldModifier="private"
+                                  Margin="0 12 0 0">Friday</CheckBox>
+                        <CheckBox Name="remindDay6CheckBox" x:FieldModifier="private"
+                                  Margin="0 12 0 0">Saturday</CheckBox>
+                        <CheckBox Name="remindDay7CheckBox" x:FieldModifier="private"
+                                  Margin="0 12 0 0">Sunday</CheckBox>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Popup>
+    </Grid>
+</UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
@@ -73,34 +73,6 @@ namespace TogglDesktop
                 .ToArray();
         }
 
-        private string GetText(Dictionary<DayOfWeek, bool> isDayChecked)
-        {
-            var checkedCount = isDayChecked.Count(kvp => kvp.Value);
-            return isDayChecked switch
-            {
-                _ when checkedCount == 7
-                => "every day",
-                var x when checkedCount == 5 && !x[DayOfWeek.Sunday] && !x[DayOfWeek.Saturday]
-                => "on weekdays",
-                var x when checkedCount == 6 && (!x[DayOfWeek.Sunday] || !x[DayOfWeek.Saturday])
-                => "on weekdays and " + (x[DayOfWeek.Sunday] ? "Sunday" : "Saturday"),
-                var x when checkedCount >= 5
-                => "every day except " + string.Join(", ",
-                    x.Where(kvp => !kvp.Value)
-                        .OrderBy(kvp => kvp.Key.DaysSince(lastBeginningOfWeek))
-                        .Select(kvp => Enum.GetName(typeof(DayOfWeek), kvp.Key))),
-                var x when checkedCount == 4 && !x[DayOfWeek.Sunday] && !x[DayOfWeek.Saturday]
-                => "on weekdays except " +
-                   Enum.GetName(typeof(DayOfWeek), x.First(kvp => kvp.Key.IsWeekday() && !kvp.Value).Key),
-                var x when checkedCount == 2 && x[DayOfWeek.Sunday] && x[DayOfWeek.Saturday]
-                => "on weekend",
-                var x => "on " + string.Join(", ",
-                    x.Where(kvp => kvp.Value)
-                        .OrderBy(kvp => kvp.Key.DaysSince(lastBeginningOfWeek))
-                        .Select(kvp => Enum.GetName(typeof(DayOfWeek), kvp.Key)))
-            };
-        }
-
         private static bool isChecked(ToggleButton checkBox)
         {
             return checkBox.IsChecked ?? false;
@@ -132,7 +104,7 @@ namespace TogglDesktop
             var isDayChecked = GetDaysOfWeekCheckboxes()
                 .WithIndex()
                 .ToDictionary(x => lastBeginningOfWeek.Add(x.index), x => isChecked(x.item));
-            Text = GetText(isDayChecked);
+            Text = DayOfWeekExtensions.GetText(isDayChecked, lastBeginningOfWeek);
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace TogglDesktop
+{
+    public partial class DaysOfWeekSelector : UserControl
+    {
+        private DayOfWeek lastBeginningOfWeek = DayOfWeek.Monday;
+        public DaysOfWeekSelector()
+        {
+            InitializeComponent();
+            Text = "every day";
+            GetDaysOfWeekCheckboxes().ForEach(checkBox =>
+            {
+                checkBox.Checked += OnCheckBoxIsCheckedChanged;
+                checkBox.Unchecked += OnCheckBoxIsCheckedChanged;
+            });
+        }
+
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+            "Text", typeof(string), typeof(DaysOfWeekSelector), new PropertyMetadata(default(string)));
+
+        public string Text
+        {
+            get => (string) GetValue(TextProperty);
+            private set => SetValue(TextProperty, value);
+        }
+
+        public void SetBeginningOfWeek(DayOfWeek beginningOfWeek)
+        {
+            if (lastBeginningOfWeek == beginningOfWeek)
+            {
+                return;
+            }
+
+            var daysOfWeekCheckboxes = GetDaysOfWeekCheckboxes();
+            var isDayOfWeekChecked = daysOfWeekCheckboxes.Select(c => c.IsChecked).ToArray();
+
+            foreach (var dayOfWeek in DayOfWeekExtensions.DaysOfWeek())
+            {
+                var newDayPosition = dayOfWeek.PositionRelativeTo(beginningOfWeek);
+                var oldDayPosition = dayOfWeek.PositionRelativeTo(lastBeginningOfWeek);
+                daysOfWeekCheckboxes[newDayPosition].IsChecked = isDayOfWeekChecked[oldDayPosition];
+
+                daysOfWeekCheckboxes[newDayPosition].Content = Enum.GetName(typeof(DayOfWeek), dayOfWeek);
+            }
+
+            lastBeginningOfWeek = beginningOfWeek;
+        }
+
+        public void Reset(bool mon, bool tue, bool wed, bool thu, bool fri, bool sat, bool sun)
+        {
+            lastBeginningOfWeek = DayOfWeek.Monday;
+            remindDay1CheckBox.IsChecked = mon;
+            remindDay2CheckBox.IsChecked = tue;
+            remindDay3CheckBox.IsChecked = wed;
+            remindDay4CheckBox.IsChecked = thu;
+            remindDay5CheckBox.IsChecked = fri;
+            remindDay6CheckBox.IsChecked = sat;
+            remindDay7CheckBox.IsChecked = sun;
+        }
+
+        public bool[] GetSelection()
+        {
+            var checkBoxes = GetDaysOfWeekCheckboxes();
+
+            return DayOfWeekExtensions.DaysOfWeek()
+                .Select(day => isChecked(checkBoxes[day.PositionRelativeTo(lastBeginningOfWeek)]))
+                .ToArray();
+        }
+
+        private static string GetText(bool[] daysOfWeek)
+        {
+            // TODO: use beginning of week for correct order of days
+            var checkedCount = daysOfWeek.Count(x => x);
+            return daysOfWeek switch
+            {
+                _ when checkedCount == 7
+                    => "every day",
+                var x when checkedCount == 5 && !x[0] && !x[6]
+                    => "on weekdays",
+                var x when checkedCount == 6 && (!x[0] || !x[6])
+                    => "on weekdays and " + (x[0] ? "Sunday" : "Saturday"),
+                _ when checkedCount >= 5
+                    => "every day except " + string.Join(", ",
+                    daysOfWeek.WithIndex()
+                        .Where(x => !x.item)
+                        .Select(x => Enum.GetName(typeof(DayOfWeek), (DayOfWeek)x.index))),
+                var x when checkedCount == 4 && !x[0] && !x[6]
+                    => "on weekdays except " + Enum.GetName(typeof(DayOfWeek), (DayOfWeek)(daysOfWeek.WithIndex().Skip(1).First(d => !d.item).index)),
+                var x when checkedCount == 2 && x[0] && x[6]
+                    => "on weekend",
+                _ => "on " + string.Join(", ",
+                    daysOfWeek.WithIndex()
+                    .Where(x => x.item)
+                    .Select(x => Enum.GetName(typeof(DayOfWeek), (DayOfWeek)x.index)))
+            };
+        }
+
+        private static bool isChecked(ToggleButton checkBox)
+        {
+            return checkBox.IsChecked ?? false;
+        }
+
+        private void TogglePopup(object sender, RoutedEventArgs e)
+        {
+            popup.IsOpen = !popup.IsOpen;
+        }
+
+        private CheckBox[] GetDaysOfWeekCheckboxes() => new[]
+        {
+            remindDay1CheckBox,
+            remindDay2CheckBox,
+            remindDay3CheckBox,
+            remindDay4CheckBox,
+            remindDay5CheckBox,
+            remindDay6CheckBox,
+            remindDay7CheckBox,
+        };
+
+        private void OnCheckBoxIsCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            var isCheckBoxChecked = GetDaysOfWeekCheckboxes().Select(isChecked).ToArray();
+            Text = GetText(isCheckBoxChecked.Skip(6).Concat(isCheckBoxChecked.Take(6)).ToArray());
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
@@ -73,9 +73,8 @@ namespace TogglDesktop
                 .ToArray();
         }
 
-        private static string GetText(Dictionary<DayOfWeek, bool> isDayChecked)
+        private string GetText(Dictionary<DayOfWeek, bool> isDayChecked)
         {
-            // TODO: use beginning of week for correct order of days
             var checkedCount = isDayChecked.Count(kvp => kvp.Value);
             return isDayChecked switch
             {
@@ -88,14 +87,16 @@ namespace TogglDesktop
                 var x when checkedCount >= 5
                 => "every day except " + string.Join(", ",
                     x.Where(kvp => !kvp.Value)
+                        .OrderBy(kvp => kvp.Key.DaysSince(lastBeginningOfWeek))
                         .Select(kvp => Enum.GetName(typeof(DayOfWeek), kvp.Key))),
                 var x when checkedCount == 4 && !x[DayOfWeek.Sunday] && !x[DayOfWeek.Saturday]
                 => "on weekdays except " +
-                   Enum.GetName(typeof(DayOfWeek), x.Where(kvp => kvp.Key.IsWeekday() && !kvp.Value)),
+                   Enum.GetName(typeof(DayOfWeek), x.First(kvp => kvp.Key.IsWeekday() && !kvp.Value).Key),
                 var x when checkedCount == 2 && x[DayOfWeek.Sunday] && x[DayOfWeek.Saturday]
                 => "on weekend",
                 var x => "on " + string.Join(", ",
                     x.Where(kvp => kvp.Value)
+                        .OrderBy(kvp => kvp.Key.DaysSince(lastBeginningOfWeek))
                         .Select(kvp => Enum.GetName(typeof(DayOfWeek), kvp.Key)))
             };
         }
@@ -130,7 +131,7 @@ namespace TogglDesktop
         {
             var isDayChecked = GetDaysOfWeekCheckboxes()
                 .WithIndex()
-                .ToDictionary(x => lastBeginningOfWeek.AddDays(x.index), x => isChecked(x.item));
+                .ToDictionary(x => lastBeginningOfWeek.Add(x.index), x => isChecked(x.item));
             Text = GetText(isDayChecked);
         }
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -316,22 +316,8 @@
                                      HorizontalContentAlignment="Right" />
                         </StackPanel>
 
-                        <StackPanel Grid.Row="2" Grid.Column="1">
-                            <CheckBox Name="remindDay1CheckBox" x:FieldModifier="private"
-                                      >Monday</CheckBox>
-                            <CheckBox Name="remindDay2CheckBox" x:FieldModifier="private"
-                                      Margin="0 12 0 0">Tuesday</CheckBox>
-                            <CheckBox Name="remindDay3CheckBox" x:FieldModifier="private"
-                                      Margin="0 12 0 0">Wednesday</CheckBox>
-                            <CheckBox Name="remindDay4CheckBox" x:FieldModifier="private"
-                                      Margin="0 12 0 0">Thursday</CheckBox>
-                            <CheckBox Name="remindDay5CheckBox" x:FieldModifier="private"
-                                      Margin="0 12 0 0">Friday</CheckBox>
-                            <CheckBox Name="remindDay6CheckBox" x:FieldModifier="private"
-                                      Margin="0 12 0 0">Saturday</CheckBox>
-                            <CheckBox Name="remindDay7CheckBox" x:FieldModifier="private"
-                                      Margin="0 12 0 0">Sunday</CheckBox>
-                        </StackPanel>
+                        <toggl:DaysOfWeekSelector x:Name="daysOfWeekSelector" x:FieldModifier="private"
+                                                  Grid.Row="2" Grid.Column="1" />
                     </Grid>
                 </StackPanel>
             </TabItem>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -32,7 +32,6 @@ namespace TogglDesktop
 
         private Toggl.TogglAutocompleteView selectedDefaultProject;
         private List<Toggl.TogglAutocompleteView> knownProjects;
-        private DayOfWeek lastBeginningOfWeek = DayOfWeek.Monday;
 
         public PreferencesWindow()
         {
@@ -136,15 +135,16 @@ namespace TogglDesktop
             this.reminderStartTimeTextBox.Text = settings.RemindStarts;
             this.reminderEndTimeTextBox.Text = settings.RemindEnds;
 
-            this.remindDay1CheckBox.IsChecked = settings.RemindMon;
-            this.remindDay2CheckBox.IsChecked = settings.RemindTue;
-            this.remindDay3CheckBox.IsChecked = settings.RemindWed;
-            this.remindDay4CheckBox.IsChecked = settings.RemindThu;
-            this.remindDay5CheckBox.IsChecked = settings.RemindFri;
-            this.remindDay6CheckBox.IsChecked = settings.RemindSat;
-            this.remindDay7CheckBox.IsChecked = settings.RemindSun;
+            this.daysOfWeekSelector.Reset(
+                settings.RemindMon,
+                settings.RemindTue,
+                settings.RemindWed,
+                settings.RemindThu,
+                settings.RemindFri,
+                settings.RemindSat,
+                settings.RemindSun);
 
-            this.SetBeginningOfWeek(Toggl.UserBeginningOfWeek());
+            this.daysOfWeekSelector.SetBeginningOfWeek(Toggl.UserBeginningOfWeek());
 
             #endregion
 
@@ -254,7 +254,7 @@ namespace TogglDesktop
 
         private Settings createSettingsFromUI()
         {
-            var isRemindDayChecked = GetDaysOfWeekCheckboxes().Select(isChecked).ToArray();
+            var isRemindDayChecked = daysOfWeekSelector.GetSelection();
 
             var settings = new Toggl.TogglSettingsView
             {
@@ -302,13 +302,13 @@ namespace TogglDesktop
                 RemindStarts = this.reminderStartTimeTextBox.Text,
                 RemindEnds = this.reminderEndTimeTextBox.Text,
 
-                RemindMon = isRemindDayChecked[DayOfWeek.Monday.PositionRelativeTo(lastBeginningOfWeek)],
-                RemindTue = isRemindDayChecked[DayOfWeek.Tuesday.PositionRelativeTo(lastBeginningOfWeek)],
-                RemindWed = isRemindDayChecked[DayOfWeek.Wednesday.PositionRelativeTo(lastBeginningOfWeek)],
-                RemindThu = isRemindDayChecked[DayOfWeek.Thursday.PositionRelativeTo(lastBeginningOfWeek)],
-                RemindFri = isRemindDayChecked[DayOfWeek.Friday.PositionRelativeTo(lastBeginningOfWeek)],
-                RemindSat = isRemindDayChecked[DayOfWeek.Saturday.PositionRelativeTo(lastBeginningOfWeek)],
-                RemindSun = isRemindDayChecked[DayOfWeek.Sunday.PositionRelativeTo(lastBeginningOfWeek)],
+                RemindMon = isRemindDayChecked[(int)DayOfWeek.Monday],
+                RemindTue = isRemindDayChecked[(int)DayOfWeek.Tuesday],
+                RemindWed = isRemindDayChecked[(int)DayOfWeek.Wednesday],
+                RemindThu = isRemindDayChecked[(int)DayOfWeek.Thursday],
+                RemindFri = isRemindDayChecked[(int)DayOfWeek.Friday],
+                RemindSat = isRemindDayChecked[(int)DayOfWeek.Saturday],
+                RemindSun = isRemindDayChecked[(int)DayOfWeek.Sunday],
 
                 #endregion
             };
@@ -403,33 +403,5 @@ namespace TogglDesktop
         }
 
         #endregion
-
-        private void SetBeginningOfWeek(DayOfWeek beginningOfWeek)
-        {
-            var daysOfWeekCheckboxes = GetDaysOfWeekCheckboxes();
-            var isDayOfWeekChecked = daysOfWeekCheckboxes.Select(c => c.IsChecked).ToArray();
-
-            foreach (var dayOfWeek in DayOfWeekExtensions.DaysOfWeek())
-            {
-                var newDayPosition = dayOfWeek.PositionRelativeTo(beginningOfWeek);
-                var oldDayPosition = dayOfWeek.PositionRelativeTo(DayOfWeek.Monday);
-                daysOfWeekCheckboxes[newDayPosition].IsChecked = isDayOfWeekChecked[oldDayPosition];
-
-                daysOfWeekCheckboxes[newDayPosition].Content = Enum.GetName(typeof(DayOfWeek), dayOfWeek);
-            }
-
-            lastBeginningOfWeek = beginningOfWeek;
-        }
-
-        private CheckBox[] GetDaysOfWeekCheckboxes() => new[]
-        {
-            remindDay1CheckBox,
-            remindDay2CheckBox,
-            remindDay3CheckBox,
-            remindDay4CheckBox,
-            remindDay5CheckBox,
-            remindDay6CheckBox,
-            remindDay7CheckBox,
-        };
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -302,13 +302,13 @@ namespace TogglDesktop
                 RemindStarts = this.reminderStartTimeTextBox.Text,
                 RemindEnds = this.reminderEndTimeTextBox.Text,
 
-                RemindMon = isRemindDayChecked[(int)DayOfWeek.Monday],
-                RemindTue = isRemindDayChecked[(int)DayOfWeek.Tuesday],
-                RemindWed = isRemindDayChecked[(int)DayOfWeek.Wednesday],
-                RemindThu = isRemindDayChecked[(int)DayOfWeek.Thursday],
-                RemindFri = isRemindDayChecked[(int)DayOfWeek.Friday],
-                RemindSat = isRemindDayChecked[(int)DayOfWeek.Saturday],
-                RemindSun = isRemindDayChecked[(int)DayOfWeek.Sunday],
+                RemindMon = isRemindDayChecked[DayOfWeek.Monday],
+                RemindTue = isRemindDayChecked[DayOfWeek.Tuesday],
+                RemindWed = isRemindDayChecked[DayOfWeek.Wednesday],
+                RemindThu = isRemindDayChecked[DayOfWeek.Thursday],
+                RemindFri = isRemindDayChecked[DayOfWeek.Friday],
+                RemindSat = isRemindDayChecked[DayOfWeek.Saturday],
+                RemindSun = isRemindDayChecked[DayOfWeek.Sunday],
 
                 #endregion
             };

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
@@ -10,5 +10,9 @@ namespace TogglDesktop
 
         public static int PositionRelativeTo(this DayOfWeek day, DayOfWeek beginningOfWeek) =>
             (day - beginningOfWeek + 7) % 7;
+
+        public static bool IsWeekday(this DayOfWeek day) => day >= DayOfWeek.Monday && day <= DayOfWeek.Friday;
+
+        public static DayOfWeek AddDays(this DayOfWeek day, int numberOfDays) => (DayOfWeek) (((int)day + numberOfDays) % 7);
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
@@ -13,6 +13,9 @@ namespace TogglDesktop
 
         public static bool IsWeekday(this DayOfWeek day) => day >= DayOfWeek.Monday && day <= DayOfWeek.Friday;
 
-        public static DayOfWeek AddDays(this DayOfWeek day, int numberOfDays) => (DayOfWeek) (((int)day + numberOfDays) % 7);
+        public static DayOfWeek Add(this DayOfWeek day, int numberOfDays) => (DayOfWeek) (((int)day + numberOfDays) % 7);
+
+        public static int DaysBetween(DayOfWeek dayFrom, DayOfWeek dayUntil) => (dayUntil - dayUntil + 7) % 7;
+        public static int DaysSince(this DayOfWeek day1, DayOfWeek day2) => (day1 - day2 + 7) % 7;
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/DayOfWeekExtensions.cs
@@ -15,7 +15,35 @@ namespace TogglDesktop
 
         public static DayOfWeek Add(this DayOfWeek day, int numberOfDays) => (DayOfWeek) (((int)day + numberOfDays) % 7);
 
-        public static int DaysBetween(DayOfWeek dayFrom, DayOfWeek dayUntil) => (dayUntil - dayUntil + 7) % 7;
         public static int DaysSince(this DayOfWeek day1, DayOfWeek day2) => (day1 - day2 + 7) % 7;
+
+        public static string GetText(Dictionary<DayOfWeek, bool> isDayChecked, DayOfWeek beginningOfWeek)
+        {
+            var checkedCount = isDayChecked.Count(kvp => kvp.Value);
+            return isDayChecked switch
+            {
+                _ when checkedCount == 7
+                => "every day",
+                var x when checkedCount == 5 && !x[DayOfWeek.Sunday] && !x[DayOfWeek.Saturday]
+                => "on weekdays",
+                var x when checkedCount == 6 && (!x[DayOfWeek.Sunday] || !x[DayOfWeek.Saturday])
+                => "on weekdays and " + (x[DayOfWeek.Sunday] ? "Sunday" : "Saturday"),
+                var x when checkedCount >= 5
+                => "every day except " + string.Join(", ",
+                    x.Where(kvp => !kvp.Value)
+                        .OrderBy(kvp => kvp.Key.DaysSince(beginningOfWeek))
+                        .Select(kvp => Enum.GetName(typeof(DayOfWeek), kvp.Key))),
+                var x when checkedCount == 4 && !x[DayOfWeek.Sunday] && !x[DayOfWeek.Saturday]
+                => "on weekdays except " +
+                   Enum.GetName(typeof(DayOfWeek), x.First(kvp => kvp.Key.IsWeekday() && !kvp.Value).Key),
+                var x when checkedCount == 2 && x[DayOfWeek.Sunday] && x[DayOfWeek.Saturday]
+                => "on weekend",
+                var x => "on " + string.Join(", ",
+                    x.Where(kvp => kvp.Value)
+                        .OrderBy(kvp => kvp.Key.DaysSince(beginningOfWeek))
+                        .Select(kvp => Enum.GetName(typeof(DayOfWeek), kvp.Key)))
+            };
+        }
+
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/LinqExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/LinqExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace TogglDesktop
 {
-static class LinqExtensions
+public static class LinqExtensions
 {
     public static IEnumerable<T> Yield<T>(this T subject)
     {


### PR DESCRIPTION
### 📒 Description
Implementation of the Days of week selector component. Here it's added into Reminders tab, replacing plain 7 checkboxes, but it will also be used in the Autotracker tab.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
 - [x] Introduced the Days of week selector component
- [x] Unit tests for the day selection text

### 👫 Relationships
Closes #3921

### 🔎 Review hints

- Open Reminders tab and check out the new days of the week selector. Compare it to the [mockup in InVision](https://toggl.invisionapp.com/d/main#/console/19425238/407511393/preview).

- Test how the UI updates depending on the user's "First day of the week" settings, see Review hints in #3994 on how to test this.