### PR TITLE
Fix the installer to not create a faulty shortcut during auto-update

### DIFF
--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -182,14 +182,15 @@ Section
   File $%TEMP%\Uninstall.exe
 !endif
 
-  ;Create Desktop shortcut only when shortcut is present or at first install
-  IfFileExists $DESKTOP\TogglDesktop.lnk 0 ShortcutDoesntExist
+  ;Create Desktop shortcut at first install
+  ${If} $isOldUpdater == 0
+  ${AndIf} $isNewUpdater == 0
     CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
-    ShortcutDoesntExist:
-    ${If} $isOldUpdater == 0
-    ${AndIf} $isNewUpdater == 0
-      CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
-    ${EndIf}
+  ${Else}
+    ; Overwrite the possibly faulty shortcut (#4005)
+    IfFileExists $DESKTOP\TogglDesktop.lnk 0
+      CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$LOCALAPPDATA\TogglDesktop\TogglDesktop.exe" ""
+  ${EndIf}
 
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -189,6 +189,7 @@ Section
   ${Else}
     ; Overwrite the possibly faulty shortcut (#4005)
     IfFileExists $DESKTOP\TogglDesktop.lnk 0
+      SetOutPath "$LOCALAPPDATA\TogglDesktop"
       CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$LOCALAPPDATA\TogglDesktop\TogglDesktop.exe" ""
   ${EndIf}
 

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -188,6 +188,7 @@ Section
   ${Else}
     ; Overwrite the possibly faulty shortcut (#4005)
     IfFileExists $DESKTOP\TogglDesktop.lnk 0
+      SetOutPath "$LOCALAPPDATA\TogglDesktop"
       CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$LOCALAPPDATA\TogglDesktop\TogglDesktop.exe" ""
   ${EndIf}
 

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -181,14 +181,15 @@ Section
   File $%TEMP%\Uninstall.exe
 !endif
 
-  ;Create Desktop shortcut only when shortcut is not present or at first install
-  IfFileExists $DESKTOP\TogglDesktop.lnk 0 ShortcutDoesntExist
+  ;Create Desktop shortcut at first install
+  ${If} $isOldUpdater == 0
+  ${AndIf} $isNewUpdater == 0
     CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
-    ShortcutDoesntExist:
-    ${If} $isOldUpdater == 0
-    ${AndIf} $isNewUpdater == 0
-      CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
-    ${EndIf}
+  ${Else}
+    ; Overwrite the possibly faulty shortcut (#4005)
+    IfFileExists $DESKTOP\TogglDesktop.lnk 0
+      CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$LOCALAPPDATA\TogglDesktop\TogglDesktop.exe" ""
+  ${EndIf}
 
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0


### PR DESCRIPTION
### 📒 Description
Fix the installer to not create a faulty shortcut during auto-update and to replace the faulty shortcut with the correct one.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Do not create a faulty shortcut during auto-update
- [x] Replace the shortcut with a correct one

### 👫 Relationships
Closes #4005

### 🔎 Review hints

Scenario 1, using pre-built installers with hardcoded update path:
- Download and install the pre-built installer (which is based on the current `master`) with the update path hardcoded to v7.5.110 (which is based on this branch and contains the fix). https://github.com/skel35/toggldesktop/releases/download/v7.5.109/TogglDesktopInstaller-x64-v7.5.109.exe
- Wait until the update is downloaded (check the progress in the About view)
- Quit the app
- Run the app from the desktop shortcut -> the app runs normally

Scenario 2, more realistic and comprehensive, but possible only after the merge to master
- Install 7.5.92 and run the app
- Switch to the beta channel and wait until the update is downloaded (check the progress in the About view)
- Quit the app
- Verify that the desktop shortcut points to the incorrect directory and running it doesn't launch the app
- Run the app from the correct directory `%LOCALAPPDATA%/TogglDesktop/TogglDesktop.exe`. Verify that the desktop shortcut still points to the incorrect directory (but do not try to launch it).
- Switch to the dev channel and wait until the update is downloaded
- Quit the app
- Run the app from the desktop shortcut -> the app runs normally

Scenario 3 - same as Scenario 2, but start from installing the latest stable 7.5.46