### PR TITLE
Fix crash during autocomplete

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Media;
+using System.Windows.Media.Media3D;
 using System.Windows.Threading;
 using Control = System.Windows.Controls.Control;
 using Panel = System.Windows.Controls.Panel;
@@ -146,13 +147,32 @@ static class UIExtensions
     {
         if (element == null) return null;
 
-        var parent = VisualTreeHelper.GetParent(element);
+        var parent = VisualTreeHelper.GetParent(element.FindVisualTreeRoot());
         while (parent != null && !(parent is T))
         {
             parent = VisualTreeHelper.GetParent(parent);
         }
 
         return parent as T;
+    }
+
+    private static DependencyObject FindVisualTreeRoot(this DependencyObject d)
+    {
+        var current = d;
+        var result = d;
+
+        while (current != null)
+        {
+            result = current;
+            if (current is Visual || current is Visual3D)
+            {
+                break;
+            }
+
+            current = LogicalTreeHelper.GetParent(current);
+        }
+
+        return result;
     }
 }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
@@ -445,17 +445,13 @@ namespace TogglDesktop
 
         private void listBox_PreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
-            DependencyObject dep = (DependencyObject)e.OriginalSource;
-            while ((dep != null) && !(dep is System.Windows.Controls.ListBoxItem))
-            {
-                if (dep is Button) return;
-
-                dep = System.Windows.Media.VisualTreeHelper.GetParent(dep);
-            }
+            var dep = (DependencyObject)e.OriginalSource;
+            dep = dep.FindParent<ListBoxItem>();
 
             if (dep == null)
                 return;
-            int index = listBox.ItemContainerGenerator.IndexFromContainer(dep);
+
+            var index = listBox.ItemContainerGenerator.IndexFromContainer(dep);
 
             e.Handled = true;
             listBox.SelectedIndex = index;


### PR DESCRIPTION
### 📒 Description
Fixes the crash during autocomplete.
It is possible that the original source of `PreviewMouseDown` event is a non-visual object like `System.Windows.Documents.Run`. The solution is to find a visual tree object before starting to look for a visual parent.

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Fix crash during autocomplete
- [x] Do not ignore buttons in the ListBox as our ListBox doesn't have buttons (action button is separate from the ListBox).

### 👫 Relationships
Closes #4007.

### 🔎 Review hints
No steps to reproduce, so just smoke test the autocomplete list functionality (mouse clicks, keyboard navigation and selection, action button (e.g. Create project)).