### PR TITLE
Fix possible crashes during auto-update

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1195,16 +1195,19 @@ public static partial class Toggl
             Path.Combine(
                 Environment.GetFolderPath(
                     Environment.SpecialFolder.LocalApplicationData), "Onova", "TogglDesktop"));
-        foreach (var file in updatesDir.GetFiles("*.exe", SearchOption.TopDirectoryOnly))
+        if (updatesDir.Exists)
         {
-            try
+            foreach (var file in updatesDir.GetFiles("*.exe", SearchOption.TopDirectoryOnly))
             {
-                Utils.DeleteFile(file.FullName);
-            }
-            catch (Exception e)
-            {
-                BugsnagService.NotifyBugsnag(e);
-                Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
+                try
+                {
+                    Utils.DeleteFile(file.FullName);
+                }
+                catch (Exception e)
+                {
+                    BugsnagService.NotifyBugsnag(e);
+                    Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
+                }
             }
         }
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1165,6 +1165,18 @@ public static partial class Toggl
     // (updates are disabled in Debug configuration to allow for proper debugging)
     private static void installPendingUpdates()
     {
+        DeleteOldUpdates();
+
+        var aboutWindowViewModel = mainWindow.GetWindow<AboutWindow>().ViewModel;
+        if (aboutWindowViewModel.InstallPendingUpdate())
+        {
+            // quit, updater will restart the app
+            Environment.Exit(0);
+        }
+    }
+
+    private static void DeleteOldUpdates()
+    {
         Directory.CreateDirectory(UpdatesPath); // make sure the directory exists
         var di = new DirectoryInfo(UpdatesPath);
         foreach (var file in di.GetFiles("TogglDesktopInstaller*.exe", SearchOption.TopDirectoryOnly))
@@ -1179,12 +1191,21 @@ public static partial class Toggl
                 Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
             }
         }
-
-        var aboutWindowViewModel = mainWindow.GetWindow<AboutWindow>().ViewModel;
-        if (aboutWindowViewModel.InstallPendingUpdate())
+        var updatesDir = new DirectoryInfo(
+            Path.Combine(
+                Environment.GetFolderPath(
+                    Environment.SpecialFolder.LocalApplicationData), "Onova", "TogglDesktop"));
+        foreach (var file in updatesDir.GetFiles("*.exe", SearchOption.TopDirectoryOnly))
         {
-            // quit, updater will restart the app
-            Environment.Exit(0);
+            try
+            {
+                Utils.DeleteFile(file.FullName);
+            }
+            catch (Exception e)
+            {
+                BugsnagService.NotifyBugsnag(e);
+                Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
+            }
         }
     }
 


### PR DESCRIPTION
### 📒 Description
Fix possible crashes during auto-update

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Try renaming the installer to .exe before running it
- [x] Handle the expected exceptions from launching the auto-update process

### 👫 Relationships
Closes #4009

### 🔎 Review hints

I'm not sure how to reproduce the bugs in #4009, so you can just test the basic auto-update scenario:

Install the following pre-built installer which contains the changes in this PR:
https://github.com/skel35/toggldesktop/releases/download/v7.5.112/TogglDesktopInstaller-x64-v7.5.112.exe

Switch to dev channel, wait until the update downloads, restart the app.
Verify that the application was updated successfully.