### PR TITLE
Rename local  db name to toggldesktop.db

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1234,11 +1234,19 @@ const NSString *appName = @"osx_native_app";
 	[Bugsnag configuration].releaseStage = self.environment;
 
 	self.app_path = [Utils applicationSupportDirectory:self.environment];
-	self.db_path = [self.app_path stringByAppendingPathComponent:@"kopsik.db"];
+	self.db_path = [self.app_path stringByAppendingPathComponent:@"toggldesktop.db"];
 	self.log_path = [self.app_path stringByAppendingPathComponent:@"toggl_desktop.log"];
 	self.log_level = @"debug";
 	self.systemService = [[SystemService alloc] init];
 	self.isAddedTouchBar = NO;
+
+    // Check if kopsik.db exists and rename it
+    NSString *oldDbPath = [self.app_path stringByAppendingPathComponent:@"kopsik.db"];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if ([fileManager fileExistsAtPath:oldDbPath]){
+        NSError *error = nil;
+        [fileManager moveItemAtPath:oldDbPath toPath:self.db_path error:&error];
+    }
 
 	[self parseCommandLineArguments];
 


### PR DESCRIPTION
### 📒 Description
Currently the local db name on mac was `kopsik.db` for some reason this pr unifies it to be toggldesktop.db as on other platforms.

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #3978

### 🔎 Review hints
- Open `~/Library/Application Support/Kopsik/development`
- See that there is `kopsik.db`
- Start app see that it changes to `toggldesktop.db` and continue using that db file.


We can probably remove the renaming functionality at some point.

