### PR TITLE
Fix Dropdown location for non-default popup alignment

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
@@ -26,6 +26,7 @@
             <converters:StringFormatIfNotEmptyConverter x:Key="StringFormatIfNotEmptyConverter" />
             <converters:EnumEqualToVisibilityConverter x:Key="EnumEqualToVisibilityConverter" />
             <converters:AndConverter x:Key="AndConverter" />
+            <converters:PopupAlignmentAwareConverter x:Key="PopupAlignmentAwareConverter"/>
 
         </ResourceDictionary>
     </Application.Resources>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -242,6 +242,7 @@
     <Compile Include="ui\Converters\CapitalizeConverter.cs" />
     <Compile Include="ui\Converters\EmptyStringToCollapsedConverter.cs" />
     <Compile Include="ui\Converters\IsSelectableItemConverter.cs" />
+    <Compile Include="ui\Converters\PopupAlignmentAwareConverter.cs" />
     <Compile Include="ui\Converters\StringFormatIfNotEmptyConverter.cs" />
     <Compile Include="ui\Converters\StringToUpperConverter.cs" />
     <Compile Include="ui\Converters\BytesToStringConverter.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/PopupAlignmentAwareConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/PopupAlignmentAwareConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace TogglDesktop.Converters
+{
+    public class PopupAlignmentAwareConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(parameter is string str)) return default(double);
+            var input = double.Parse(str);
+            return SystemParameters.MenuDropAlignment ? -input : input;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ComboBox.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/ComboBox.xaml
@@ -1,12 +1,14 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="http://metro.mahapps.com/winfx/xaml/controls"
-                    xmlns:Converters="http://metro.mahapps.com/winfx/xaml/shared">
+                    xmlns:Converters="http://metro.mahapps.com/winfx/xaml/shared"
+                    xmlns:converters="clr-namespace:TogglDesktop.Converters">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ComboBox.xaml" />
         <ResourceDictionary Source="Typography.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
+    <converters:PopupAlignmentAwareConverter x:Key="PopupAlignmentAwareConverter" />
     <Thickness x:Key="ComboBoxPopupBorderThemeThickness">1</Thickness>
     <Thickness x:Key="ComboBoxPopupBorderThemePadding">0,5</Thickness>
 
@@ -273,8 +275,8 @@
                                IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}"
                                Placement="Bottom"
                                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}"
-                               HorizontalOffset="-8">
-                            <Grid Background="Transparent">
+                               HorizontalOffset="{Binding Converter={StaticResource PopupAlignmentAwareConverter}, ConverterParameter=-8}">
+                            <Grid Background="Transparent" UseLayoutRounding="True">
                                 <Border x:Name="PopupBorder"
                                         Height="Auto"
                                         MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}" MaxHeight="{Binding MaxDropDownHeight, RelativeSource={RelativeSource TemplatedParent}}"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePicker.xaml
@@ -2,11 +2,14 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
                     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-                    xmlns:behaviours="http://metro.mahapps.com/winfx/xaml/shared">
+                    xmlns:behaviours="http://metro.mahapps.com/winfx/xaml/shared"
+                    xmlns:converters="clr-namespace:TogglDesktop.Converters">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
         <ResourceDictionary Source="Calendar.xaml" />
     </ResourceDictionary.MergedDictionaries>
+
+    <converters:PopupAlignmentAwareConverter x:Key="PopupAlignmentAwareConverter"/>
 
     <Style TargetType="Button" x:Key="Toggl.DateIconButton">
         <Setter Property="Background" Value="Transparent" />
@@ -147,7 +150,8 @@
                                    Placement="Bottom"
                                    PlacementTarget="{Binding ElementName=PART_Root}"
                                    StaysOpen="False"
-                                   HorizontalOffset="-8"/>
+                                   HorizontalOffset="{Binding Converter={StaticResource PopupAlignmentAwareConverter}, ConverterParameter=-8}">
+                            </Popup>
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml
@@ -222,7 +222,7 @@
     
     <Popup Name="popup" x:FieldModifier="private"
            AllowsTransparency="True"
-           HorizontalOffset="-8"
+           HorizontalOffset="{Binding Converter={StaticResource PopupAlignmentAwareConverter}, ConverterParameter=-8}"
            StaysOpen="False"
            PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
         <Grid Background="Transparent">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -80,15 +80,11 @@
                                AllowsTransparency="True"
                                StaysOpen="False"
                                IsOpen="False"
-                               HorizontalOffset="-8"
+                               HorizontalOffset="{Binding Converter={StaticResource PopupAlignmentAwareConverter}, ConverterParameter=-8}"
                                Placement="Bottom"
                                PlacementTarget="{Binding ElementName=projectDropDownBorder}"
                                Opened="CreateProjectPopup_OnOpened"
                                Closed="CreateProjectPopup_OnClosed">
-                            <!-- <i:Interaction.Behaviors> -->
-                            <!--     <behaviors:RepositionPopupWithParentWindowBehavior /> -->
-                            <!--     <behaviors:ActivateParentWindowOnMouseClick /> -->
-                            <!-- </i:Interaction.Behaviors> -->
                             <Grid Background="Transparent">
                                 <Border Height="Auto"
                                         HorizontalAlignment="Stretch"


### PR DESCRIPTION
### 📒 Description
Fixes Dropdown location for non-default popup alignment

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Set HorizontalOffset depending on SystemParameters.MenuDropAlignment
- [x] Apply UseLayoutRounding="True" for ComboBox dropdown 

### 👫 Relationships
Closes #4016

### 🔎 Review hints

1. run %windir%\explorer.exe shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}
2. Other tab -> Right-handed -> OK
3. Run Toggl Desktop and observe various dropdowns (timer, edit view, light/dark mode selection, etc.)

Also, try different scaling options (Display Settings -> Scale and Layout) and see if the dropdown position is correct.

