### PR TITLE
Scroll to top of the visible Timeline TimeEntry (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -190,7 +190,7 @@ final class TimelineDatasource: NSObject {
             }
             guard let section = visibleSection else { return }
             collectionView.scrollToItems(at: Set<IndexPath>(arrayLiteral: IndexPath(item: 0, section: section.rawValue)),
-                                         scrollPosition: [.centeredHorizontally, .centeredVertically])
+                                         scrollPosition: [.centeredHorizontally, .top])
         }
     }
 


### PR DESCRIPTION
### 📒 Description
A minor change to make sure that Timeline view will scroll to top of the TE

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Scroll to Top

### 👫 Relationships
Closes #3903

### 🔎 Review hints
1. Create a large TE (A) and set it as a yesterday (Don't use today because Timeline prefers scrolling to the Current Moment line if it's Today)
2. Create a small TE (B) and set it as a tomorrow
3. Switch to Yesterday from Calendar -> Verify if the TimeEntry A is visible at the top and able to see the Timeline Information
4. Switch to tomorrow day from Calendar -> Verify if the TimeEntry B is visible at the top and able to see the Timeline Information

