### PR TITLE
Rename 'Kopsik' to Toggl in Application Support 

### DIFF
--- a/src/ui/osx/TogglDesktop/Utils.m
+++ b/src/ui/osx/TogglDesktop/Utils.m
@@ -98,15 +98,25 @@ extern void *ctx;
 
 + (NSString *)applicationSupportDirectory:(NSString *)environment
 {
-	NSString *path;
-	NSError *error;
+    NSString *oldPath;
+    NSString *path;
+    NSError *error;
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
 
 	if ([paths count] == 0)
 	{
 		NSLog(@"Unable to access application support directory!");
 	}
-	path = [paths[0] stringByAppendingPathComponent:@"Kopsik"];
+
+    oldPath = [paths[0] stringByAppendingPathComponent:@"Kopsik"];
+    path = [paths[0] stringByAppendingPathComponent:@"Toggl"];
+
+    // Check if Kopsik dir exists and rename it
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if ([fileManager fileExistsAtPath:oldPath]){
+        NSError *error = nil;
+        [fileManager moveItemAtPath:oldPath toPath:path error:&error];
+    }
 
 	// Append environment name to path. So we can have
 	// production and development running side by side.


### PR DESCRIPTION
### 📒 Description
Changes the directory name in Application Support to Toggl



### 👫 Relationships
Closes #4022

### 🔎 Review hints
- Open '~/Library/Application Support`
- See that there is a directory called `Kopsik`
- Start the app, this folder is renamed to Toggl and all future local data is saved to this directory.
- One other part to test is if the log file sending still works ok when you send feedback from the app.

