### PR TITLE
[WIP] Clear Cache on Logout

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2738,7 +2738,12 @@ error Context::SetLoggedInUserFromJSON(
     return noError;
 }
 
-error Context::Logout() {
+error Context::LogoutAndClearCache() {
+    // ClearCache will trigger the logout action too
+    return ClearCache();
+}
+
+error Context::logout() {
     try {
         if (!user_) {
             logger.warning("User is logged out, cannot logout again");
@@ -2791,7 +2796,7 @@ error Context::ClearCache() {
             return displayError(err);
         }
 
-        return Logout();
+        return logout();
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {

--- a/src/context.h
+++ b/src/context.h
@@ -332,7 +332,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error AppleLogin(const std::string &access_token);
     error AsyncAppleLogin(const std::string &access_token);
 
-    error Logout();
+    error LogoutAndClearCache();
 
     error SetLoggedInUserFromJSON(
         const std::string &json,
@@ -823,6 +823,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error updateTimeEntryDescription(
         TimeEntry *te,
         const std::string &value);
+
+    error logout();
 };
 
 void on_websocket_message(

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -517,7 +517,7 @@ bool_t toggl_logout(
 
     logger().debug("toggl_logout");
 
-    return toggl::noError == app(context)->Logout();
+    return toggl::noError == app(context)->LogoutAndClearCache();
 }
 
 bool_t toggl_clear_cache(

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -224,7 +224,6 @@ void MainWindowController::enableMenuActions() {
     ui->actionStop->setEnabled(loggedIn && tracking);
     ui->actionSync->setEnabled(loggedIn);
     ui->actionLogout->setEnabled(loggedIn);
-    ui->actionClear_Cache->setEnabled(loggedIn);
     ui->actionSend_Feedback->setEnabled(loggedIn);
     ui->actionReports->setEnabled(loggedIn);
     ui->actionEmail->setText(TogglApi::instance->userEmail());
@@ -394,7 +393,6 @@ void MainWindowController::connectMenuActions() {
     connect(ui->actionStop,  &QAction::triggered, this, &MainWindowController::onActionStop);
     connect(ui->actionSync,  &QAction::triggered, this, &MainWindowController::onActionSync);
     connect(ui->actionLogout,  &QAction::triggered, this, &MainWindowController::onActionLogout);
-    connect(ui->actionClear_Cache,  &QAction::triggered, this, &MainWindowController::onActionClear_Cache);
     connect(ui->actionSend_Feedback,  &QAction::triggered, this, &MainWindowController::onActionSend_Feedback);
     connect(ui->actionReports,  &QAction::triggered, this, &MainWindowController::onActionReports);
     connect(ui->actionShow,  &QAction::triggered, this, &MainWindowController::onActionShow);
@@ -459,16 +457,6 @@ void MainWindowController::quitApp() {
     TogglApi::instance->shutdown = true;
     TogglApi::instance->clear();
     qApp->exit(0);
-}
-
-void MainWindowController::onActionClear_Cache() {
-    if (QMessageBox::Ok == QMessageBox(
-        QMessageBox::Question,
-        "Clear Cache?",
-        "Clearing cache will delete any unsaved time entries and log you out.",
-        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
-        TogglApi::instance->clearCache();
-    }
 }
 
 void MainWindowController::onActionHelp() {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -87,7 +87,6 @@ class MainWindowController : public QMainWindow {
     void onActionSend_Feedback();
     void onActionLogout();
     void onActionQuit();
-    void onActionClear_Cache();
     void onActionHelp();
 
     void updateShowHideShortcut();

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.ui
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.ui
@@ -91,7 +91,6 @@
     <addaction name="actionSend_Feedback"/>
     <addaction name="actionHelp"/>
     <addaction name="actionLogout"/>
-    <addaction name="actionClear_Cache"/>
     <addaction name="actionQuit"/>
    </widget>
    <addaction name="menuToggl_Desktop"/>
@@ -156,11 +155,6 @@
   <action name="actionQuit">
    <property name="text">
     <string>&amp;Quit</string>
-   </property>
-  </action>
-  <action name="actionClear_Cache">
-   <property name="text">
-    <string>Clear Cache</string>
    </property>
   </action>
   <action name="actionHelp">

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -585,10 +585,6 @@ void TogglApi::openInBrowser() {
     toggl_open_in_browser(ctx);
 }
 
-bool TogglApi::clearCache() {
-    return toggl_clear_cache(ctx);
-}
-
 void TogglApi::getSupport() {
     toggl_get_support(ctx, 2);
 }

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -78,8 +78,6 @@ class TogglApi : public QObject {
 
     void sync();
 
-    bool clearCache();
-
     void getSupport();
 
     void logout();

--- a/src/ui/osx/TogglDesktop/MenuItemTags.h
+++ b/src/ui/osx/TogglDesktop/MenuItemTags.h
@@ -12,7 +12,6 @@ static NSInteger const kMenuItemTagLogout = 2;
 static NSInteger const kMenuItemTagNew = 3;
 static NSInteger const kMenuItemTagContinue = 4;
 static NSInteger const kMenuItemTagStop = 5;
-static NSInteger const kMenuItemTagClearCache = 6;
 static NSInteger const kMenuItemTagOpenBrowser = 9;
 static NSInteger const kMenuItemTagEdit = 10;
 static NSInteger const kMenuItemTagMode = 12;

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.h
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.h
@@ -22,7 +22,6 @@
 - (IBAction)onSyncMenuItem:(id)sender;
 - (IBAction)onShowMenuItem:(id)sender;
 - (IBAction)onEditMenuItem:(id)sender;
-- (IBAction)onClearCacheMenuItem:(id)sender;
 - (IBAction)onLogoutMenuItem:(id)sender;
 - (IBAction)onHelpMenuItem:(id)sender;
 - (IBAction)onNewMenuItem:(id)sender;

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1078,22 +1078,6 @@ void *ctx;
 	toggl_logout(ctx);
 }
 
-- (IBAction)onClearCacheMenuItem:(id)sender
-{
-	NSAlert *alert = [[NSAlert alloc] init];
-
-	[alert addButtonWithTitle:@"OK"];
-	[alert addButtonWithTitle:@"Cancel"];
-	[alert setMessageText:@"Clear local data and log out?"];
-	[alert setInformativeText:@"Deleted unsynced time entries cannot be restored."];
-	[alert setAlertStyle:NSWarningAlertStyle];
-	if ([alert runModal] != NSAlertFirstButtonReturn)
-	{
-		return;
-	}
-	toggl_clear_cache(ctx);
-}
-
 - (IBAction)onAboutMenuItem:(id)sender
 {
 	[self.aboutWindowController showWindowAndFocus];
@@ -1412,7 +1396,6 @@ const NSString *appName = @"osx_native_app";
 		case kMenuItemTagMode :
 		case kMenuItemTagSync :
 		case kMenuItemTagLogout :
-		case kMenuItemTagClearCache :
 		case kMenuItemTagOpenBrowser :
 		case kMenuItemTagNew :
 		case kMenuItemTagSendFeedBack :

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -163,13 +163,6 @@
                             <menuItem title="Sync" tag="1" keyEquivalent="r" id="qrV-uu-7qU">
                                 <connections>
                                     <action selector="onSyncMenuItem:" target="494" id="u4k-n1-pLG"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="wuv-bR-uz5"/>
-                            <menuItem title="Clear cache" tag="6" id="OCn-tS-va2">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="onClearCacheMenuItem:" target="494" id="kgh-DN-75s"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="ocd-ur-e1h"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryFixture.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryFixture.cs
@@ -29,7 +29,6 @@ namespace TogglDesktop.Tests
                 IsRunning = false;
             };
             Assert.True(Toggl.StartUI("0.0.0", new ulong[0]));
-            Toggl.ClearCache();
             Toggl.SetManualMode(false);
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryIntegrationTests.cs
@@ -307,25 +307,6 @@ namespace TogglDesktop.Tests
         }
 
         [Fact]
-        public void ClearCacheShouldLogTheUserOut()
-        {
-            var assertionExecuted = false;
-            Toggl.OnLogin += Assertion;
-
-            Assert.True(Toggl.Logout());
-
-            void Assertion(bool open, ulong userId)
-            {
-                Assert.True(open);
-                Assert.Equal(0ul, userId);
-                assertionExecuted = true;
-            }
-            Assert.True(assertionExecuted);
-
-            Toggl.OnLogin -= Assertion;
-        }
-
-        [Fact]
         public void AddProjectShouldCreateNewProjectAndAssignItToTimeEntry()
         {
             var projectId = Toggl.AddProject(_firstTimeEntryGuid, 123456789, 0, null,

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -504,12 +504,7 @@ public static partial class Toggl
     {
         return toggl_logout(ctx);
     }
-
-    public static bool ClearCache()
-    {
-        return toggl_clear_cache(ctx);
-    }
-
+    
     public static bool SetLoggedInUser(string json) {
         return testing_set_logged_in_user(ctx, json);
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -48,7 +48,6 @@ namespace TogglDesktop.ViewModels
                 onNext => (open, userId) => { onNext(userId != 0); },
                 x => Toggl.OnLogin += x,
                 x => Toggl.OnLogin -= x);
-            ClearCacheCommand = ReactiveCommand.Create(ClearCache, isLoggedIn.ObserveOnDispatcher());
 
             this.WhenAnyValue(x => x.ShowHideToggl)
                 .Buffer(2, 1)
@@ -66,8 +65,6 @@ namespace TogglDesktop.ViewModels
                 hotKey => IsHotKeyValid(hotKey, ContinueStopTimerDescription),
                 hotKey => $"This shortcut is already taken by {_knownShortcuts[hotKey]}");
         }
-
-        public ICommand ClearCacheCommand { get; }
 
         [Reactive]
         public HotKey ShowHideToggl { get; set; }
@@ -126,20 +123,6 @@ namespace TogglDesktop.ViewModels
         {
             var key = getKey();
             return new HotKey(key, key == Key.None ? ModifierKeys.None : getModifiers());
-        }
-
-        private void ClearCache()
-        {
-            var result = _showMessageBox(
-                "This will remove your Toggl user data from this PC and log you out of the Toggl Desktop app. " +
-                "Any unsynced data will be lost.\n\nDo you want to continue?", "Clear Cache",
-                MessageBoxButton.OKCancel, "Clear cache");
-
-            if (result == MessageBoxResult.OK)
-            {
-                Toggl.ClearCache();
-                _closePreferencesWindow();
-            }
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -246,15 +246,6 @@
                                          Content="end time"
                                          Name="keepDurationFixedCheckbox" x:FieldModifier="private" />
                         </StackPanel>
-                        <TextBlock Style="{StaticResource Toggl.TitleText}" Margin="0 32 0 0"
-                                   Text="Clear cache" />
-                        <TextBlock Style="{StaticResource Toggl.CaptionText}" Margin="0 4 0 0"
-                                   Text="This will clear all Toggl local data and log you out. To avoid losing any time entries, please make sure they are successfully synced."/>
-                        <Button Style="{StaticResource Toggl.PrimaryButton}" Margin="0 8 0 0"
-                                Width="136"
-                                HorizontalAlignment="Left"
-                                Content="Clear cache"
-                                Command="{Binding ClearCacheCommand}"/>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>


### PR DESCRIPTION
### 📒 Description
This PR will change the behavior of the Logout.

Logout will clear all cache by default and it's affecting all platforms

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change) 

### 🤯 List of changes
- [x] Logout will trigger the Clear Cache
- [x] Remove Clear Cache menu on macOS
- [ ] Remove Clear Cache menu on Window / Linux (not done yet)

### 👫 Relationships
Closes #3897
### 🔎 Review hints
1. Login to any account and open the local database
2. Play around by creating new TimeEntry, Project, ....
3. Logout from Menu
4. Verify that this user information in the local database is gone
5. Try to login in the same account: Verify that the data is still there (after sync successfully)

