### PR TITLE
Clear default project if it has been archived

### DIFF
--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -1013,6 +1013,12 @@ void User::loadUserProjectFromSyncJSON(
     if (addNew) {
         AddProjectToList(model);
     }
+
+    // Clear default project if it was archived
+    if (model->ID() == DefaultPID()
+        && !model->Active()) {
+        SetDefaultPID(0);
+    }
 }
 
 void User::loadUserProjectFromJSON(


### PR DESCRIPTION
### 📒 Description
Adds functionality that checks if project is archived when an update for project comes in.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4035

### 🔎 Review hints
- Select a default project in preferences
- Close preferences and start timer. See that default project works.
- Go to web app and archive that project
- Start another timer and see that there is no default project set
- Check preferences and see that the default project has been cleared.

