### PR TITLE
Use server sent error message in case of required fields error

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -5383,6 +5383,10 @@ error Context::pushEntries(
                 trigger_sync_ = false;
             }
 
+            if (kBadRequestError == resp.err) {
+                error_message = resp.body;
+            }
+
             continue;
         }
 


### PR DESCRIPTION
### 📒 Description
In case of the error caused by the required fields, the server returns the exact message detailing what is wrong. We'll show the user this message instead of the vague message about wrong data format.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4027

### 🔎 Review hints
- Jump into Premium Workspace
- Turn on "required fields" setting
- Create an invalid entry in the desktop app (you have to stop the entry for the error to appear)
- The unsynced entry had the exclamation mark in listing and the user gets an error message that describes the field that is required.

