### PR TITLE
Update new list of Project Colors

### DIFF
--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -14,9 +14,9 @@
 namespace toggl {
 
 static const char *known_colors[] = {
-    "#06aaf5", "#c56bff", "#ea468d", "#fb8b14", "#c7741c",
-    "#4bc800", "#04bb9b", "#e19a86", "#3750b5", "#a01aa5",
-    "#f1c33f", "#205500", "#890000", "#e20505", "#000000"
+    "#0b83d9", "#9e5bd9", "#d94182", "#e36a00", "#bf7000",
+    "#2da608", "#06a893", "#c9806b", "#465bb3", "#990099",
+    "#c7af14", "#566614", "#d92b2b", "#525266"
 };
 
 template<typename T, size_t N> T *end(T (&ra)[N]) {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
@@ -30,7 +30,7 @@ final class ColorPickerView: NSView {
     // MARK: Variables
 
     weak var delegate: ColorPickerViewDelegate?
-    fileprivate lazy var colors: [ProjectColor] = ProjectColor.defaultColors
+    fileprivate lazy var colors: [ProjectColor] = ProjectColorPool.shared.colors
 
     // MARK: View Cycle
 
@@ -131,7 +131,7 @@ extension ColorPickerView: ChangeColorDelegate {
 
     private func notifySelectedColorChange(with color: HSV) {
         let hex = color.toNSColor().hexString.lowercased()
-        let color = ProjectColor(colorHex: hex)
+        let color = ProjectColor(hex: hex)
         delegate?.colorPickerDidSelectColor(color)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorViewItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorViewItem.swift
@@ -26,7 +26,7 @@ final class ColorViewItem: NSCollectionViewItem {
     // MARK: Public
 
     func render(_ color: ProjectColor) {
-        boxView.fillColor = ConvertHexColor.hexCode(toNSColor: color.colorHex)!
+        boxView.fillColor = ConvertHexColor.hexCode(toNSColor: color.hex)!
     }
 
     override var isSelected: Bool {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectColor.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectColor.swift
@@ -10,21 +10,21 @@ import Foundation
 
 struct ProjectColor: Equatable {
 
-    static let `default` = ProjectColor(colorHex: "#c56bff")
-    static let defaultColors: [ProjectColor] = [ProjectColor(colorHex: "#06aaf5"),
-                                                ProjectColor(colorHex: "#c56bff"),
-                                                ProjectColor(colorHex: "#ea468d"),
-                                                ProjectColor(colorHex: "#fb8b14"),
-                                                ProjectColor(colorHex: "#c7741c"),
-                                                ProjectColor(colorHex: "#f1c33f"),
-                                                ProjectColor(colorHex: "#e20505"),
-                                                ProjectColor(colorHex: "#4bc800"),
-                                                ProjectColor(colorHex: "#04bb9b"),
-                                                ProjectColor(colorHex: "#e19a86"),
-                                                ProjectColor(colorHex: "#3750b5"),
-                                                ProjectColor(colorHex: "#a01aa5"),
-                                                ProjectColor(colorHex: "#205500"),
-                                                ProjectColor(colorHex: "#000000")]
+    static let `default` = ProjectColor(colorHex: "#9e5bd9")
+    static let defaultColors: [ProjectColor] = [ProjectColor(colorHex: "#0b83d9"),
+                                                ProjectColor(colorHex: "#9e5bd9"),
+                                                ProjectColor(colorHex: "#d94182"),
+                                                ProjectColor(colorHex: "#e36a00"),
+                                                ProjectColor(colorHex: "#bf7000"),
+                                                ProjectColor(colorHex: "#c7af14"),
+                                                ProjectColor(colorHex: "#d92b2b"),
+                                                ProjectColor(colorHex: "#2da608"),
+                                                ProjectColor(colorHex: "#06a893"),
+                                                ProjectColor(colorHex: "#c9806b"),
+                                                ProjectColor(colorHex: "#465bb3"),
+                                                ProjectColor(colorHex: "#990099"),
+                                                ProjectColor(colorHex: "#566614"),
+                                                ProjectColor(colorHex: "#525266")]
 
     let colorHex: String
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectColor.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectColor.swift
@@ -8,27 +8,38 @@
 
 import Foundation
 
+final class ProjectColorPool {
+
+    static let shared = ProjectColorPool()
+
+    // MARK: Variables
+
+    private(set) var colors: [ProjectColor] = []
+    let defaultColor = ProjectColor(hex: "#9e5bd9")
+
+    // MARK: Public
+
+    func updateDefaultColors(_ colors: [String]) {
+        self.colors = colors.map { ProjectColor(hex: $0) }
+    }
+
+    func random() -> ProjectColor {
+        return colors.randomElement() ?? defaultColor
+    }
+}
+
 struct ProjectColor: Equatable {
+    let hex: String
 
-    static let `default` = ProjectColor(colorHex: "#9e5bd9")
-    static let defaultColors: [ProjectColor] = [ProjectColor(colorHex: "#0b83d9"),
-                                                ProjectColor(colorHex: "#9e5bd9"),
-                                                ProjectColor(colorHex: "#d94182"),
-                                                ProjectColor(colorHex: "#e36a00"),
-                                                ProjectColor(colorHex: "#bf7000"),
-                                                ProjectColor(colorHex: "#c7af14"),
-                                                ProjectColor(colorHex: "#d92b2b"),
-                                                ProjectColor(colorHex: "#2da608"),
-                                                ProjectColor(colorHex: "#06a893"),
-                                                ProjectColor(colorHex: "#c9806b"),
-                                                ProjectColor(colorHex: "#465bb3"),
-                                                ProjectColor(colorHex: "#990099"),
-                                                ProjectColor(colorHex: "#566614"),
-                                                ProjectColor(colorHex: "#525266")]
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.hex == rhs.hex
+    }
+}
 
-    let colorHex: String
+@objcMembers
+final class ProjectColorPoolObjc: NSObject {
 
-    static func random() -> ProjectColor {
-        return defaultColors.randomElement() ?? .default
+    class func updateDefaultColors(_ colors: [String]) {
+        ProjectColorPool.shared.updateDefaultColors(colors)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -79,8 +79,8 @@ final class ProjectCreationView: NSView {
     private lazy var workspaceDatasource = WorkspaceDataSource(items: WorkspaceStorage.shared.workspaces,
                                                                updateNotificationName: .WorkspaceStorageChangedNotification)
     weak var delegate: ProjectCreationViewDelegate?
-    private var originalColor = ProjectColor.default
-    private var selectedColor = ProjectColor.default {
+    private var originalColor = ProjectColorPool.shared.defaultColor
+    private var selectedColor = ProjectColorPool.shared.defaultColor {
         didSet {
             updateSelectColorView()
         }
@@ -159,7 +159,7 @@ final class ProjectCreationView: NSView {
         let clientID = clientData.0
         let clientGUID = clientData.1
         let projectName = projectTextField.stringValue
-        let colorHex = selectedColor.colorHex
+        let colorHex = selectedColor.hex
 
         let projectGUID = DesktopLibraryBridge.shared().createProject(withTimeEntryGUID: timeEntryGUID,
                                                                     workspaceID: workspaceID,
@@ -215,7 +215,7 @@ extension ProjectCreationView {
         addBtn.cursor = .pointingHand
         
         // Default value
-        selectedColor = ProjectColor.default
+        selectedColor = ProjectColorPool.shared.defaultColor
         displayMode = .normal
         publicProjectCheckBox.state = .off
 
@@ -242,7 +242,7 @@ extension ProjectCreationView {
     }
 
     fileprivate func getRandomColor() {
-        let color = ProjectColor.random()
+        let color = ProjectColorPool.shared.random()
         originalColor = color
         selectedColor = color
     }
@@ -262,7 +262,7 @@ extension ProjectCreationView {
     }
 
     fileprivate func updateSelectColorView() {
-        colorBtn.layer?.backgroundColor = ConvertHexColor.hexCode(toNSColor: selectedColor.colorHex)!.cgColor
+        colorBtn.layer?.backgroundColor = ConvertHexColor.hexCode(toNSColor: selectedColor.hex)!.cgColor
         colorPickerView.select(selectedColor)
     }
 

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -50,7 +50,6 @@ extern NSString *const kFocusTimer;
 extern NSString *const kEscapeListing;
 extern NSString *const kToggleManualMode;
 extern NSString *const kToggleTimerMode;
-extern NSString *const kSetProjectColors;
 extern NSString *const kToggleGroup;
 extern NSString *const kDisplayCountries;
 extern NSString *const kUpdateIconTooltip;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -47,7 +47,6 @@ NSString *const kFocusTimer = @"kFocusTimer";
 NSString *const kEscapeListing = @"kEscapeListing";
 NSString *const kToggleManualMode = @"kToggleManualMode";
 NSString *const kToggleTimerMode = @"kToggleTimerMode";
-NSString *const kSetProjectColors = @"kSetProjectColors";
 NSString *const kToggleGroup = @"ToggleGroup";
 NSString *const kDisplayCountries = @"kDisplayCountries";
 NSString *const kUpdateIconTooltip = @"kUpdateIconTooltip";

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1361,6 +1361,8 @@ const NSString *appName = @"osx_native_app";
 		 return theEvent;
 	 }];
 
+    toggl_get_project_colors(ctx);
+
 	NSLog(@"AppDelegate init done");
 
 	return self;

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1752,13 +1752,11 @@ void on_project_colors(
 	const uint64_t count)
 {
 	NSMutableArray *colors = [NSMutableArray array];
-
-	for (int i = 0; i < count; i++)
+	for (NSInteger i = 0; i < count; i++)
 	{
 		[colors addObject:[NSString stringWithUTF8String:list[i]]];
 	}
-	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kSetProjectColors
-																object:colors];
+    [ProjectColorPoolObjc updateDefaultColors:[colors copy]];
 }
 
 void on_countries(TogglCountryView *first)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ProjectColorPicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ProjectColorPicker.xaml
@@ -25,9 +25,7 @@
         <Popup Name="popup" x:FieldModifier="private"
             MaxHeight="300" StaysOpen="True" AllowsTransparency="True"
             PlacementTarget="{Binding ElementName=button}"
-            Placement="Left"
-            HorizontalOffset="{Binding ActualWidth, ElementName=button}"
-            VerticalOffset="{Binding ActualHeight, ElementName=button}"
+            Placement="Bottom"
             PreviewKeyDown="onPopupPreviewKeyDown"
             IsKeyboardFocusWithinChanged="onPopupKeyboardFocusWithinChanged">
 


### PR DESCRIPTION
### 📒 Description
This PR attempts to update a new list project color, which better adapts dark/light theme.
It also changes the number of colors from 15 -> 14 colors in all platforms

Color list: https://www.notion.so/toggl/0f5d3ccf60364fc8b161264c54a434b4?v=b3d281b2065b42358332e8ea6cb69f75

### 🕶️ Types of changes
 **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Update new list color in the library -> Affect on Win + Linux
- Refactor ProjectColor in macOS by using project colors from the library instead of maintaining own version

### 👫 Relationships
Closes  #4045

### 🔎 Review hints
1. Open Project Color Picker view in macOS, Window, and Linux
Verify that the color list is correct

<img width="646" alt="Screen Shot 2020-05-05 at 18 06 56" src="https://user-images.githubusercontent.com/5878421/81060015-d5048480-8efb-11ea-864e-703a5b8f4e8a.png">
<img width="703" alt="Screen Shot 2020-05-05 at 18 01 16" src="https://user-images.githubusercontent.com/5878421/81060026-dafa6580-8efb-11ea-8e5f-dc72413bd3ff.png">

<img width="291" alt="Screen Shot 2020-05-05 at 18 12 39" src="https://user-images.githubusercontent.com/5878421/81060121-067d5000-8efc-11ea-86b4-8c28c8a5c012.png">


