### PR TITLE
Delete old updates only if there are no pending updates

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1165,14 +1165,14 @@ public static partial class Toggl
     // (updates are disabled in Debug configuration to allow for proper debugging)
     private static void installPendingUpdates()
     {
-        DeleteOldUpdates();
-
         var aboutWindowViewModel = mainWindow.GetWindow<AboutWindow>().ViewModel;
         if (aboutWindowViewModel.InstallPendingUpdate())
         {
             // quit, updater will restart the app
             Environment.Exit(0);
         }
+
+        DeleteOldUpdates();
     }
 
     private static void DeleteOldUpdates()


### PR DESCRIPTION
### 📒 Description
Delete old updates only if there are no pending updates.
Fixes "App doesn't auto-update via app restart".

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Delete old updates only if there are no pending updates

### 👫 Relationships
Closes #4056

### 🔎 Review hints

Installer 1: containing this PR's changes and hardcoded to auto-update to another installer (v7.5.135) which contains this PR's changes:
https://github.com/skel35/toggldesktop/releases/download/v7.5.134/TogglDesktopInstaller-x64-v7.5.134.exe

Installer 2: not containing this PR's changes but hardcoded to auto-update to an installer (v7.5.135) which contains this PR's changes.
https://github.com/skel35/toggldesktop/releases/download/v7.5.133/TogglDesktopInstaller-x64-v7.5.133.exe


Scenario 1.
Install "Installer 1". Auto-update using About view.
Scenario 2.
Install "Installer 1". Auto-update by quitting the app and then starting it again.
Scenario 3.
Install "Installer 2". Auto-update using About view.

Unfortunately, due to #4056 the scenario with auto-updating from "Installer 2" using app restart won't work.

Please also help me find more scenarios that I could miss.