### PR TITLE
Use /me/flags to determine which syncing strategy to use

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -126,4 +126,8 @@
 #define kGoogleAccessToken "google_access_token"
 #define kAppleAccessToken "apple_token"
 
+// there was a typo in the initial set of flags, use both variants
+#define kSyncStrategyLegacy1 "dekstop_sync_client"
+#define kSyncStrategyLegacy2 "desktop_sync_client"
+
 #endif  // SRC_CONST_H_

--- a/src/context.cc
+++ b/src/context.cc
@@ -4877,7 +4877,8 @@ void Context::syncerActivityWrapper() {
             legacySyncerActivity();
             break;
         case BATCHED:
-            // TODO
+            // TODO, legacy fallback for now
+            legacySyncerActivity();
             break;
         }
     }

--- a/src/context.h
+++ b/src/context.h
@@ -563,7 +563,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void uiUpdaterActivity();
     void checkReminders();
     void reminderActivity();
-    void syncerActivity();
+    void syncerActivityWrapper();
+    void legacySyncerActivity();
 
  private:
     static const std::string installerPlatform();


### PR DESCRIPTION
### 📒 Description
For the upcoming sync changes, we need to be able to switch between both protocols if things go haywire. This change makes the desktop app consume the flag from the API and then select which syncing strategy to use. If the server doesn't respond 200 or the flag is missing, we fallback to the legacy sync protocol.

You can now also use the following C++ compiler defines to force the syncing strategy of your choice on compile time:
```
TOGGL_SYNC_FORCE_BATCHED
TOGGL_SYNC_FORCE_LEGACY
```

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- /api/v9/me/flags is now consumed on syncer bootup

### 🔎 Review hints
Everything should work as usual, except the syncer will start syncing after 1+ seconds later (depending on how long does the server take to respond).

