### PR TITLE
Reset LoginViewController after login/signup

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2464,13 +2464,13 @@ error Context::Login(
             //
             // Discussion: https://toggl.slack.com/archives/CSE5U3ZUN/p1586418153111700
             //
-            #if defined(__APPLE__)
+#if defined(__APPLE__)
             if ((password.compare(kAppleAccessToken) == 0 || password.compare(kGoogleAccessToken) == 0) // Applied for Google and Apple Sign In
-                && IsAuthenticationError(err)) {
+                    && IsAuthenticationError(err)) {
                 UI()->DisplayOnContinueSignIn();
                 return err;
             }
-            #endif
+#endif
 
             if (!IsNetworkingError(err)) {
                 return displayError(err);

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -91,12 +91,20 @@ class TOGGL_INTERNAL_EXPORT HTTPClientConfig {
         return ss.str();
     }
 
-    bool IgnoreCert() { return ignoreCert; };
-    std::string CACertPath() { return caCertPath; };
-    void SetCACertPath(std::string path) { caCertPath = path; }
-    void SetIgnoreCert(bool ignore) { ignoreCert = ignore; }
+    bool IgnoreCert() {
+        return ignoreCert;
+    };
+    std::string CACertPath() {
+        return caCertPath;
+    };
+    void SetCACertPath(std::string path) {
+        caCertPath = path;
+    }
+    void SetIgnoreCert(bool ignore) {
+        ignoreCert = ignore;
+    }
 
-private:
+ private:
     bool ignoreCert;
     std::string caCertPath;
 };
@@ -158,7 +166,7 @@ class TOGGL_INTERNAL_EXPORT HTTPClient {
 
     void SetCACertPath(std::string path);
     void SetIgnoreCert(bool ignore);
-    
+
  protected:
     virtual HTTPResponse request(
         HTTPRequest req) const;
@@ -191,7 +199,7 @@ class TOGGL_INTERNAL_EXPORT SyncStateMonitor {
 };
 
 class TOGGL_INTERNAL_EXPORT TogglClient : public HTTPClient {
-public:
+ public:
     static ServerStatus TogglStatus;
     static TogglClient& GetInstance() {
         static TogglClient instance; // static is thread-safe in C++11.
@@ -214,11 +222,11 @@ public:
     HTTPResponse silentPut(
         HTTPRequest req) const;
 
-protected:
+ protected:
     virtual HTTPResponse request(HTTPRequest req) const override;
     virtual Logger logger() const override;
 
-private:
+ private:
     TogglClient() {};
     SyncStateMonitor *monitor_;
 };

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -16,8 +16,8 @@
 
 typedef NS_ENUM (NSUInteger, TabViewType)
 {
-	TabViewTypeLogin,
-	TabViewTypeSingup,
+    TabViewTypeLogin,
+    TabViewTypeSingup,
     TabViewTypeContinueSignin
 };
 
@@ -28,10 +28,10 @@ static NSString *const tosAgreeError = @"You must agree to the terms of service 
 
 typedef NS_ENUM (NSUInteger, UserAction)
 {
-	UserActionAccountLogin,
-	UserActionAccountSignup,
-	UserActionGoogleLogin,
-	UserActionGoogleSignup,
+    UserActionAccountLogin,
+    UserActionAccountSignup,
+    UserActionGoogleLogin,
+    UserActionGoogleSignup,
     UserActionAppleLogin,
     UserActionAppleSignup,
 };
@@ -95,23 +95,23 @@ extern void *ctx;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-	self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-	if (self)
-	{
-		self.countryAutocompleteDataSource = [[AutocompleteDataSource alloc] initWithNotificationName:kDisplayCountries];
-	}
-	return self;
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self)
+    {
+        self.countryAutocompleteDataSource = [[AutocompleteDataSource alloc] initWithNotificationName:kDisplayCountries];
+    }
+    return self;
 }
 
 - (void)viewDidLoad
 {
-	[super viewDidLoad];
+    [super viewDidLoad];
 
-	[self initCommon];
-	[self initCountryAutocomplete];
+    [self initCommon];
+    [self initCountryAutocomplete];
 
-	// Default
-	[self changeTabView:TabViewTypeLogin];
+    // Default
+    [self changeTabView:TabViewTypeLogin];
 
     // Load countries in signup view
     toggl_get_countries_async(ctx);
@@ -119,32 +119,32 @@ extern void *ctx;
 
 - (void)initCommon
 {
-	self.signUpLink.delegate = self;
-	self.countrySelect.delegate = self;
-	self.email.delegate = self;
-	self.password.delegate = self;
+    self.signUpLink.delegate = self;
+    self.countrySelect.delegate = self;
+    self.email.delegate = self;
+    self.password.delegate = self;
 
-	self.forgotPasswordTextField.titleUnderline = YES;
-	self.signUpLink.titleUnderline = YES;
-	self.tosLink.titleUnderline = YES;
-	self.privacyLink.titleUnderline = YES;
+    self.forgotPasswordTextField.titleUnderline = YES;
+    self.signUpLink.titleUnderline = YES;
+    self.tosLink.titleUnderline = YES;
+    self.privacyLink.titleUnderline = YES;
     self.tosContinueLink.titleUnderline = YES;
     self.privacyContinueLink.titleUnderline = YES;
     self.tosContinueLink.delegate = self;
     self.privacyContinueLink.delegate = self;
 
-	self.boxView.wantsLayer = YES;
-	self.boxView.layer.masksToBounds = NO;
-	self.boxView.shadow = [[NSShadow alloc] init];
-	self.boxView.layer.shadowColor = [NSColor colorWithWhite:0 alpha:0.1].CGColor;
-	self.boxView.layer.shadowOpacity = 1.0;
-	self.boxView.layer.shadowOffset = CGSizeMake(0, -2);
-	self.boxView.layer.shadowRadius = 6;
+    self.boxView.wantsLayer = YES;
+    self.boxView.layer.masksToBounds = NO;
+    self.boxView.shadow = [[NSShadow alloc] init];
+    self.boxView.layer.shadowColor = [NSColor colorWithWhite:0 alpha:0.1].CGColor;
+    self.boxView.layer.shadowOpacity = 1.0;
+    self.boxView.layer.shadowOffset = CGSizeMake(0, -2);
+    self.boxView.layer.shadowRadius = 6;
 
-	self.view.wantsLayer = YES;
-	self.view.layer.backgroundColor = [NSColor colorWithPatternImage:[NSImage imageNamed:@"background-pattern"]].CGColor;
+    self.view.wantsLayer = YES;
+    self.view.layer.backgroundColor = [NSColor colorWithPatternImage:[NSImage imageNamed:@"background-pattern"]].CGColor;
 
-	self.userAction = UserActionAccountLogin;
+    self.userAction = UserActionAccountLogin;
 
     if (@available(macOS 10.12.2, *))
     {
@@ -152,7 +152,7 @@ extern void *ctx;
         self.loginTouchBar.delegate = self;
     }
 
-    #ifdef APP_STORE
+#ifdef APP_STORE
     if (@available(macOS 10.15, *))
     {
         [AppleAuthenticationService shared].delegate = self;
@@ -160,43 +160,43 @@ extern void *ctx;
     } else {
         self.appleBtn.hidden = YES;
     }
-    #else
-        self.appleBtn.hidden = YES;
-    #endif
+#else
+    self.appleBtn.hidden = YES;
+#endif
 
     self.passwordStrengthView = [[PasswordStrengthView alloc] initWithNibName:@"PasswordStrengthView" bundle:nil];
 }
 
 - (void)initCountryAutocomplete {
-	self.countryAutocompleteDataSource.combobox = self.countrySelect;
-	self.countryAutocompleteDataSource.combobox.dataSource = self.countryAutocompleteDataSource;
-	[self.countryAutocompleteDataSource setFilter:@""];
-	self.selectedCountryID = -1;
+    self.countryAutocompleteDataSource.combobox = self.countrySelect;
+    self.countryAutocompleteDataSource.combobox.dataSource = self.countryAutocompleteDataSource;
+    [self.countryAutocompleteDataSource setFilter:@""];
+    self.selectedCountryID = -1;
 }
 
 - (void)viewDidAppear
 {
-	[super viewDidAppear];
+    [super viewDidAppear];
 
-	// As we change the cursor's color to white
-	// so, we have to reset cursor color
-	[self.email resetCursorColor];
-	[self.password resetCursorColor];
+    // As we change the cursor's color to white
+    // so, we have to reset cursor color
+    [self.email resetCursorColor];
+    [self.password resetCursorColor];
 
-	[self.email.window makeFirstResponder:self.email];
-	[self changeTabView:TabViewTypeLogin];
+    [self.email.window makeFirstResponder:self.email];
+    [self changeTabView:TabViewTypeLogin];
 }
 
 - (void)textFieldClicked:(id)sender
 {
-	if (sender == self.forgotPasswordTextField)
-	{
-		toggl_password_forgot(ctx);
-		return;
-	}
+    if (sender == self.forgotPasswordTextField)
+    {
+        toggl_password_forgot(ctx);
+        return;
+    }
 
-	if (sender == self.signUpLink)
-	{
+    if (sender == self.signUpLink)
+    {
         switch (self.currentTab) {
             case TabViewTypeLogin:
                 [self changeTabView:TabViewTypeSingup];
@@ -208,20 +208,20 @@ extern void *ctx;
                 [self changeTabView:TabViewTypeLogin];
                 break;
         }
-		return;
-	}
+        return;
+    }
 
     if (sender == self.tosLink || sender == self.tosContinueLink)
-	{
-		toggl_tos(ctx);
-		return;
-	}
+    {
+        toggl_tos(ctx);
+        return;
+    }
 
     if (sender == self.privacyLink || sender == self.privacyContinueLink)
-	{
-		toggl_privacy_policy(ctx);
-		return;
-	}
+    {
+        toggl_privacy_policy(ctx);
+        return;
+    }
 }
 
 - (void)changeTabView:(TabViewType)type
@@ -327,143 +327,143 @@ extern void *ctx;
 
 - (void)startGoogleAuthentication
 {
-	__weak typeof(self) weakSelf = self;
-	[GoogleAuthenticationServerHelper authorize:^(NSString *token, NSError *error) {
-		 typeof(self) strongSelf = weakSelf;
-		 if (error != nil)
-		 {
-			 [strongSelf handleGoogleError:error];
-		 }
-		 else if (token != nil)
-		 {
-			 [strongSelf handleGoogleToken:token];
-		 }
-	 }];
-	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kHideDisplayError
-																object:nil];
+    __weak typeof(self) weakSelf = self;
+    [GoogleAuthenticationServerHelper authorize:^(NSString *token, NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (error != nil)
+        {
+            [strongSelf handleGoogleError:error];
+        }
+        else if (token != nil)
+        {
+            [strongSelf handleGoogleToken:token];
+        }
+    }];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kHideDisplayError
+                                                                object:nil];
 }
 
 - (void)handleGoogleError:(NSError *)error
 {
-	NSString *errorStr = [error localizedDescription];
+    NSString *errorStr = [error localizedDescription];
 
-	NSLog(@"Login error: %@", errorStr);
+    NSLog(@"Login error: %@", errorStr);
 
-	if ([errorStr isEqualToString:@"access_denied"])
-	{
-		errorStr = @"Google login access was denied to app.";
-	} else if ([errorStr isEqualToString:@"The operation couldn’t be completed. (com.google.GTMOAuth2 error -1000.)"])
-	{
-		errorStr = @"Window was closed before login completed.";
+    if ([errorStr isEqualToString:@"access_denied"])
+    {
+        errorStr = @"Google login access was denied to app.";
+    } else if ([errorStr isEqualToString:@"The operation couldn’t be completed. (com.google.GTMOAuth2 error -1000.)"])
+    {
+        errorStr = @"Window was closed before login completed.";
     } else if (error.code == -1009) {
         errorStr = @"The Internet connection appears to be offline.";
     } else {
         errorStr = [NSString stringWithFormat:@"Google Authorization Failed. Code %ld", (long)error.code];
     }
 
-	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
-																object:errorStr];
+    [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+                                                                object:errorStr];
 }
 
 - (void)handleGoogleToken:(NSString *)token
 {
-	[self showLoaderView:YES];
+    [self showLoaderView:YES];
     self.token = token;
 
-	switch (self.userAction)
-	{
-		case UserActionGoogleSignup :
-			toggl_google_signup_async(ctx, [token UTF8String], self.selectedCountryID);
-			break;
-		case UserActionGoogleLogin :
-			toggl_google_login_async(ctx, [token UTF8String]);
-			break;
-		default :
-			break;
-	}
+    switch (self.userAction)
+    {
+        case UserActionGoogleSignup :
+            toggl_google_signup_async(ctx, [token UTF8String], self.selectedCountryID);
+            break;
+        case UserActionGoogleLogin :
+            toggl_google_login_async(ctx, [token UTF8String]);
+            break;
+        default :
+            break;
+    }
 }
 
 - (BOOL)validateFormForAction:(UserAction)action
 {
-	switch (action)
-	{
-		case UserActionAccountLogin :
-			if (![self isEmalValid])
-			{
-				return NO;
-			}
-			if (![self isPasswordValid])
-			{
-				return NO;
-			}
-			return YES;
+    switch (action)
+    {
+        case UserActionAccountLogin :
+            if (![self isEmalValid])
+            {
+                return NO;
+            }
+            if (![self isPasswordValid])
+            {
+                return NO;
+            }
+            return YES;
 
-		case UserActionAccountSignup :
-			if (![self isEmalValid])
-			{
-				return NO;
-			}
-			if (![self isPasswordValid])
-			{
-				return NO;
-			}
-			if (![self isCountryValid])
-			{
-				return NO;
-			}
-			if (![self isTOSValid])
-			{
-				return NO;
-			}
-			return YES;
+        case UserActionAccountSignup :
+            if (![self isEmalValid])
+            {
+                return NO;
+            }
+            if (![self isPasswordValid])
+            {
+                return NO;
+            }
+            if (![self isCountryValid])
+            {
+                return NO;
+            }
+            if (![self isTOSValid])
+            {
+                return NO;
+            }
+            return YES;
 
-		case UserActionGoogleLogin :
+        case UserActionGoogleLogin :
         case UserActionAppleLogin :
-			return YES;
+            return YES;
 
-		case UserActionGoogleSignup :
+        case UserActionGoogleSignup :
         case UserActionAppleSignup :
-			if (![self isCountryValid])
-			{
-				return NO;
-			}
-			if (![self isTOSValid])
-			{
-				return NO;
-			}
-			return YES;
+            if (![self isCountryValid])
+            {
+                return NO;
+            }
+            if (![self isTOSValid])
+            {
+                return NO;
+            }
+            return YES;
 
-		default :
-			break;
-	}
+        default :
+            break;
+    }
 
-	return NO;
+    return NO;
 }
 
 - (void)controlTextDidChange:(NSNotification *)aNotification
 {
-	if ([[aNotification object] isKindOfClass:[NSCustomComboBox class]])
-	{
-		NSCustomComboBox *box = [aNotification object];
-		NSString *filter = [box stringValue];
+    if ([[aNotification object] isKindOfClass:[NSCustomComboBox class]])
+    {
+        NSCustomComboBox *box = [aNotification object];
+        NSString *filter = [box stringValue];
 
-		[self.countryAutocompleteDataSource setFilter:filter];
+        [self.countryAutocompleteDataSource setFilter:filter];
 
-		// Hide dropdown if filter is empty or nothing was found
-		if (!filter || ![filter length] || !self.countryAutocompleteDataSource.count)
-		{
-			if ([box isExpanded] == YES)
-			{
-				[box setExpanded:NO];
-			}
-			return;
-		}
+        // Hide dropdown if filter is empty or nothing was found
+        if (!filter || ![filter length] || !self.countryAutocompleteDataSource.count)
+        {
+            if ([box isExpanded] == YES)
+            {
+                [box setExpanded:NO];
+            }
+            return;
+        }
 
-		if ([box isExpanded] == NO)
-		{
-			[box setExpanded:YES];
-		}
-	}
+        if ([box isExpanded] == NO)
+        {
+            [box setExpanded:YES];
+        }
+    }
 
     if (aNotification.object == self.password && self.currentTab == TabViewTypeSingup) {
         [self validatePasswordStrength];
@@ -471,38 +471,38 @@ extern void *ctx;
 }
 
 - (BOOL)control:(NSControl *)control textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector {
-	if (control == self.email || control == self.password)
-	{
-		if (commandSelector == @selector(insertNewline:))
-		{
+    if (control == self.email || control == self.password)
+    {
+        if (commandSelector == @selector(insertNewline:))
+        {
             [self userActionButtonOnClick:control];
-		}
-	}
-	return NO;
+        }
+    }
+    return NO;
 }
 
 - (void)setUserSignUp:(BOOL)isSignUp
 {
-	[[NSUserDefaults standardUserDefaults] setBool:isSignUp forKey:kUserHasBeenSignup];
-	[[NSUserDefaults standardUserDefaults] synchronize];
+    [[NSUserDefaults standardUserDefaults] setBool:isSignUp forKey:kUserHasBeenSignup];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (void)showLoaderView:(BOOL)show
 {
-	self.loginLoaderView.hidden = !show;
-	if (show)
-	{
-		[self.loginLoaderView startAnimation:self];
-	}
-	else
-	{
-		[self.loginLoaderView stopAnimation:self];
-	}
+    self.loginLoaderView.hidden = !show;
+    if (show)
+    {
+        [self.loginLoaderView startAnimation:self];
+    }
+    else
+    {
+        [self.loginLoaderView stopAnimation:self];
+    }
 
-	self.email.enabled = !show;
-	self.password.enabled = !show;
-	self.userActionBtn.enabled = !show;
-	self.signUpLink.enabled = !show;
+    self.email.enabled = !show;
+    self.password.enabled = !show;
+    self.userActionBtn.enabled = !show;
+    self.signUpLink.enabled = !show;
     self.forgotPasswordTextField.enabled = !show;
     self.appleBtn.enabled = !show;
     self.googleBtn.enabled = !show;
@@ -510,33 +510,33 @@ extern void *ctx;
 
 - (void)resetLoader
 {
-	[self showLoaderView:NO];
+    [self showLoaderView:NO];
 }
 
 - (BOOL)isEmalValid
 {
-	NSString *email = [self.email stringValue];
+    NSString *email = [self.email stringValue];
 
-	if (email == nil || !email.length)
-	{
-		[self.email.window makeFirstResponder:self.email];
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
-																	object:emailMissingError];
-		return NO;
-	}
-	return YES;
+    if (email == nil || !email.length)
+    {
+        [self.email.window makeFirstResponder:self.email];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+                                                                    object:emailMissingError];
+        return NO;
+    }
+    return YES;
 }
 
 - (BOOL)isPasswordValid
 {
-	NSString *pass = [self.password stringValue];
+    NSString *pass = [self.password stringValue];
 
-	if (pass == nil || !pass.length)
-	{
-		[self.password.window makeFirstResponder:self.password];
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
-																	object:passwordMissingError];
-		return NO;
+    if (pass == nil || !pass.length)
+    {
+        [self.password.window makeFirstResponder:self.password];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+                                                                    object:passwordMissingError];
+        return NO;
     } else if (self.currentTab == TabViewTypeSingup && ![self.passwordStrengthView isMeetAllRequirements]) {
         [self.password.window makeFirstResponder:self.password];
         [self displayPasswordStrengthView:YES];
@@ -544,33 +544,33 @@ extern void *ctx;
         return NO;
     }
 
-	return YES;
+    return YES;
 }
 
 - (BOOL)isCountryValid
 {
-	if (self.selectedCountryID == -1 || self.countrySelect.stringValue.length == 0)
-	{
-		[self.countrySelect.window makeFirstResponder:self.countrySelect];
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
-																	object:countryNotSelectedError];
-		return NO;
-	}
-	return YES;
+    if (self.selectedCountryID == -1 || self.countrySelect.stringValue.length == 0)
+    {
+        [self.countrySelect.window makeFirstResponder:self.countrySelect];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+                                                                    object:countryNotSelectedError];
+        return NO;
+    }
+    return YES;
 }
 
 - (BOOL)isTOSValid
 {
-	BOOL tosChecked = [Utils stateToBool:[self.tosCheckbox state]];
+    BOOL tosChecked = [Utils stateToBool:[self.tosCheckbox state]];
 
-	if (!tosChecked)
-	{
-		[self.tosCheckbox.window makeFirstResponder:self.tosCheckbox];
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
-																	object:tosAgreeError];
-		return NO;
-	}
-	return YES;
+    if (!tosChecked)
+    {
+        [self.tosCheckbox.window makeFirstResponder:self.tosCheckbox];
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+                                                                    object:tosAgreeError];
+        return NO;
+    }
+    return YES;
 }
 
 - (NSTouchBar *)makeTouchBar
@@ -592,28 +592,28 @@ extern void *ctx;
 
 - (void)loginSignupTouchBarOn:(enum LoginSignupAction)action
 {
-	switch (action)
-	{
-		case LoginSignupActionLogin :
-			[self clickLoginButton:self];
-			break;
-		case LoginSignupActionLoginGoogle :
-			[self loginGoogleOnTap:self];
-			break;
-		case LoginSignupActionSignUp :
-			[self clickSignupButton:self];
-			break;
-		case LoginSignupActionSignUpGoogle :
-			[self signupGoogleBtnOnTap:self];
-			break;
+    switch (action)
+    {
+        case LoginSignupActionLogin :
+            [self clickLoginButton:self];
+            break;
+        case LoginSignupActionLoginGoogle :
+            [self loginGoogleOnTap:self];
+            break;
+        case LoginSignupActionSignUp :
+            [self clickSignupButton:self];
+            break;
+        case LoginSignupActionSignUpGoogle :
+            [self signupGoogleBtnOnTap:self];
+            break;
         case LoginSignupActionLoginApple:
             [self loginAppleBtnOnTap:self];
             break;
         case LoginSignupActionSignUpApple:
             [self signupAppleBtnOnTap:self];
-		default :
-			break;
-	}
+        default :
+            break;
+    }
 }
 
 #pragma mark - User action
@@ -742,7 +742,7 @@ extern void *ctx;
 
 - (void)signupAppleBtnOnTap:(id)sender
 {
-    #ifdef APP_STORE
+#ifdef APP_STORE
     if (@available(macOS 10.15, *))
     {
         // Validate all values inserted
@@ -756,12 +756,12 @@ extern void *ctx;
         [self showLoaderView:YES];
         [[AppleAuthenticationService shared] requestAuth];
     }
-    #endif
+#endif
 }
 
 - (void)loginAppleBtnOnTap:(id)sender
 {
-    #ifdef APP_STORE
+#ifdef APP_STORE
     if (@available(macOS 10.15, *))
     {
         self.userAction = UserActionAppleLogin;
@@ -769,7 +769,7 @@ extern void *ctx;
         [self showLoaderView:YES];
         [[AppleAuthenticationService shared] requestAuth];
     }
-    #endif
+#endif
 }
 
 #pragma mark - AppleAuthenticationServiceDelegate

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -35,45 +35,45 @@ extern void *ctx;
 
 - (id)initWithWindow:(NSWindow *)window
 {
-	self = [super initWithWindow:window];
-	if (self)
-	{
-		self.loginViewController = [[LoginViewController alloc] initWithNibName:@"LoginViewController" bundle:nil];
-		self.mainDashboardViewController = [[MainDashboardViewController alloc] initWithNibName:@"MainDashboardViewController" bundle:nil];
-		self.overlayViewController = [[OverlayViewController alloc] initWithNibName:@"OverlayViewController" bundle:nil];
+    self = [super initWithWindow:window];
+    if (self)
+    {
+        self.loginViewController = [[LoginViewController alloc] initWithNibName:@"LoginViewController" bundle:nil];
+        self.mainDashboardViewController = [[MainDashboardViewController alloc] initWithNibName:@"MainDashboardViewController" bundle:nil];
+        self.overlayViewController = [[OverlayViewController alloc] initWithNibName:@"OverlayViewController" bundle:nil];
 
-		[self.loginViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-		[self.mainDashboardViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-		[self.overlayViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+        [self.loginViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+        [self.mainDashboardViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+        [self.overlayViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
 
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayLogin:)
-													 name:kDisplayLogin
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayTimeEntryList:)
-													 name:kDisplayTimeEntryList
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayOverlay:)
-													 name:kDisplayOverlay
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayError:)
-													 name:kDisplayError
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(stopDisplayError:)
-													 name:kHideDisplayError
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayOnlineState:)
-													 name:kDisplayOnlineState
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayTimeline:)
-													 name:kDisplayTimeline
-												   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(startDisplayLogin:)
+                                                     name:kDisplayLogin
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(startDisplayTimeEntryList:)
+                                                     name:kDisplayTimeEntryList
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(startDisplayOverlay:)
+                                                     name:kDisplayOverlay
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(startDisplayError:)
+                                                     name:kDisplayError
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(stopDisplayError:)
+                                                     name:kHideDisplayError
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(startDisplayOnlineState:)
+                                                     name:kDisplayOnlineState
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(startDisplayTimeline:)
+                                                     name:kDisplayTimeline
+                                                   object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(startDisplayInAppMessage:)
                                                      name:kStartDisplayInAppMessage
@@ -86,24 +86,24 @@ extern void *ctx;
 												selector:@selector(handleContinueSignInNotification:)
                                                      name:kContinueSignIn
                                                    object:nil];
-	}
-	return self;
+    }
+    return self;
 }
 
 - (void)windowDidLoad
 {
-	[super windowDidLoad];
+    [super windowDidLoad];
     self.window.delegate = self;
 
-	// Tracking the size of window after loaded
-	[self trackWindowSize];
+    // Tracking the size of window after loaded
+    [self trackWindowSize];
 
-	// Error View
-	[self initErrorView];
-	[self setInitialWindowSizeIfNeed];
+    // Error View
+    [self initErrorView];
+    [self setInitialWindowSizeIfNeed];
 
-	// Touch bar
-	[self initTouchBar];
+    // Touch bar
+    [self initTouchBar];
 }
 
 - (void)initTouchBar
@@ -114,24 +114,24 @@ extern void *ctx;
 }
 
 - (void)initErrorView {
-	self.messageView = [SystemMessageView initFromXib];
-	self.messageView.translatesAutoresizingMaskIntoConstraints = NO;
-	[self.contentView addSubview:self.messageView];
+    self.messageView = [SystemMessageView initFromXib];
+    self.messageView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.contentView addSubview:self.messageView];
 
-	[self.messageView addConstraint:[NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:270.0]];
-	NSLayoutConstraint *height = [NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:38.0];
-	// Message View should be expandable depend on the length of text
-	height.priority = NSLayoutPriorityDefaultLow;
-	[self.messageView addConstraint:height];
-	[self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0]];
-	[self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0]];
+    [self.messageView addConstraint:[NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:270.0]];
+    NSLayoutConstraint *height = [NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:38.0];
+    // Message View should be expandable depend on the length of text
+    height.priority = NSLayoutPriorityDefaultLow;
+    [self.messageView addConstraint:height];
+    [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0]];
+    [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0]];
     [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationGreaterThanOrEqual toItem:self.contentView attribute:NSLayoutAttributeTop multiplier:1 constant:16]];
 
-	// Hidden by default
-	self.messageView.hidden = YES;
+    // Hidden by default
+    self.messageView.hidden = YES;
 
-	// Register
-	[self.messageView registerToSystemMessage];
+    // Register
+    [self.messageView registerToSystemMessage];
 }
 
 - (void) initInAppMessageView
@@ -142,144 +142,144 @@ extern void *ctx;
 
 - (void)startDisplayLogin:(NSNotification *)notification
 {
-	[self displayLogin:notification.object];
+    [self displayLogin:notification.object];
 }
 
 - (void)displayLogin:(DisplayCommand *)cmd
 {
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	if (cmd.open)
-	{
+    NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
+    if (cmd.open)
+    {
         [self displayLoginViewController:YES];
 
-		[self.mainDashboardViewController.view removeFromSuperview];
-		[self.overlayViewController.view removeFromSuperview];
+        [self.mainDashboardViewController.view removeFromSuperview];
+        [self.overlayViewController.view removeFromSuperview];
 
-		// Reset
-        if (@available(macOS 10.12.2, *)) 
-		{
+        // Reset
+        if (@available(macOS 10.12.2, *))
+        {
             [[TouchBarService shared] resetContent];
         }
 
         // Reset the apple state
-        #ifdef APP_STORE
+#ifdef APP_STORE
         if (@available(macOS 10.15, *)) {
             [[AppleAuthenticationService shared] reset];
         }
-        #endif
-	}
+#endif
+    }
 }
 
 - (void)startDisplayTimeEntryList:(NSNotification *)notification
 {
-	[self displayTimeEntryList:notification.object];
+    [self displayTimeEntryList:notification.object];
 }
 
 - (void)displayTimeEntryList:(DisplayCommand *)cmd
 {
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	if (cmd.open)
-	{
-		if ([self.loginViewController.view superview] != nil
-			|| [self.mainDashboardViewController.view superview] == nil)
-		{
-			// Close error when loging in
-			[self closeError];
+    NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
+    if (cmd.open)
+    {
+        if ([self.loginViewController.view superview] != nil
+            || [self.mainDashboardViewController.view superview] == nil)
+        {
+            // Close error when loging in
+            [self closeError];
 
             // Add Main View
-			[self.contentView addSubview:self.mainDashboardViewController.view];
-			[self.mainDashboardViewController.view setFrame:self.contentView.bounds];
+            [self.contentView addSubview:self.mainDashboardViewController.view];
+            [self.mainDashboardViewController.view setFrame:self.contentView.bounds];
 
             // Dismiss Login
             [self displayLoginViewController:NO];
-			[self.overlayViewController.view removeFromSuperview];
+            [self.overlayViewController.view removeFromSuperview];
 
-			[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
-																		object:nil];
+            [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
+                                                                        object:nil];
 
-			// Prepare the Touch bar
+            // Prepare the Touch bar
             if (@available(macOS 10.12.2, *)) {
                 [[TouchBarService shared] prepareContent];
             }
-		}
-	}
+        }
+    }
 }
 
 - (void)startDisplayTimeline:(NSNotification *)notification
 {
-	[self displayTimeline:notification.object];
+    [self displayTimeline:notification.object];
 }
 
 - (void)displayTimeline:(TimelineDisplayCommand *)cmd
 {
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	if (cmd.open)
-	{
-		[self.mainDashboardViewController timelineBtnOnTap:self];
-	}
+    NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
+    if (cmd.open)
+    {
+        [self.mainDashboardViewController timelineBtnOnTap:self];
+    }
 }
 
 - (void)startDisplayOverlay:(NSNotification *)notification
 {
-	[self displayOverlay:notification.object];
+    [self displayOverlay:notification.object];
 }
 
 - (void)displayOverlay:(NSNumber *)type
 {
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
+    NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 
-	// Setup overlay content
+    // Setup overlay content
 
-	[self.overlayViewController setType:[type intValue]];
+    [self.overlayViewController setType:[type intValue]];
 
-	[self.contentView addSubview:self.overlayViewController.view];
-	[self.overlayViewController.view setFrame:self.contentView.bounds];
+    [self.contentView addSubview:self.overlayViewController.view];
+    [self.overlayViewController.view setFrame:self.contentView.bounds];
 
     [self displayLoginViewController:NO];
-	[self.mainDashboardViewController.view removeFromSuperview];
+    [self.mainDashboardViewController.view removeFromSuperview];
 }
 
 - (void)startDisplayError:(NSNotification *)notification
 {
-	[self displayError:notification.object];
+    [self displayError:notification.object];
 }
 
 - (void)displayError:(NSString *)msg
 {
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
+    NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 
-	NSString *errorMessage = msg == nil ? @"Error" : msg;
-	[[SystemMessage shared] presentError:errorMessage subTitle:nil];
+    NSString *errorMessage = msg == nil ? @"Error" : msg;
+    [[SystemMessage shared] presentError:errorMessage subTitle:nil];
 
-	// Reset loader if there is error
-	// Have to check if login is present
-	if (self.loginViewController.view.superview != nil)
-	{
-		[self.loginViewController resetLoader];
-	}
+    // Reset loader if there is error
+    // Have to check if login is present
+    if (self.loginViewController.view.superview != nil)
+    {
+        [self.loginViewController resetLoader];
+    }
 }
 
 - (void)startDisplayOnlineState:(NSNotification *)notification
 {
-	[self displayOnlineState:notification.object];
+    [self displayOnlineState:notification.object];
 }
 
 - (void)displayOnlineState:(NSNumber *)status
 {
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
+    NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 
-	switch ([status intValue])
-	{
-		case 1 :
-			[[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, no network"];
-			break;
-		case 2 :
-			[[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, Toggl not responding"];
-			break;
-		default :
-			[self closeError];
-			break;
-	}
+    switch ([status intValue])
+    {
+        case 1 :
+            [[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, no network"];
+            break;
+        case 2 :
+            [[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, Toggl not responding"];
+            break;
+        default :
+            [self closeError];
+            break;
+    }
 
     // Have to check if login is present
     if (self.loginViewController.view.superview != nil)
@@ -290,73 +290,73 @@ extern void *ctx;
 
 - (void)stopDisplayError:(NSNotification *)notification
 {
-	[self closeError];
+    [self closeError];
 }
 
 - (void)closeError
 {
-	self.messageView.hidden = YES;
+    self.messageView.hidden = YES;
 }
 
 - (void)keyUp:(NSEvent *)event
 {
-	if ([event keyCode] == kVK_DownArrow && ([event modifierFlags] & NSShiftKeyMask))
-	{
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusListing
-																	object:nil];
-	}
-	else
-	{
-		[super keyUp:event];
-	}
+    if ([event keyCode] == kVK_DownArrow && ([event modifierFlags] & NSShiftKeyMask))
+    {
+        [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusListing
+                                                                    object:nil];
+    }
+    else
+    {
+        [super keyUp:event];
+    }
 }
 
 - (BOOL)isEditOpened
 {
-	return self.mainDashboardViewController.timeEntryController.isEditorOpen;
+    return self.mainDashboardViewController.timeEntryController.isEditorOpen;
 }
 
 - (void)trackWindowSize
 {
-	if (self.window == nil)
-	{
-		return;
-	}
-	[[TrackingService sharedInstance] trackWindowSize:self.window.frame.size];
+    if (self.window == nil)
+    {
+        return;
+    }
+    [[TrackingService sharedInstance] trackWindowSize:self.window.frame.size];
 }
 
 - (void)setWindowMode:(WindowMode)mode
 {
-	switch (mode)
-	{
-		case WindowModeAlwaysOnTop :
-			[self.window setLevel:NSFloatingWindowLevel];
-			self.window.collectionBehavior = NSWindowCollectionBehaviorManaged;
-			break;
-		case WindowModeDefault :
-			[self.window setLevel:NSNormalWindowLevel];
-			break;
-	}
+    switch (mode)
+    {
+        case WindowModeAlwaysOnTop :
+            [self.window setLevel:NSFloatingWindowLevel];
+            self.window.collectionBehavior = NSWindowCollectionBehaviorManaged;
+            break;
+        case WindowModeDefault :
+            [self.window setLevel:NSNormalWindowLevel];
+            break;
+    }
 }
 
 - (void)setInitialWindowSizeIfNeed
 {
-	if (self.contentView == nil || self.mainDashboardViewController.timerController == nil)
-	{
-		return;
-	}
+    if (self.contentView == nil || self.mainDashboardViewController.timerController == nil)
+    {
+        return;
+    }
 
-	if (self.contentView.frame.size.height - 2 <= self.mainDashboardViewController.timerController.view.frame.size.height)
-	{
-		[self.window setContentSize:CGSizeMake(400, 600)];
-	}
+    if (self.contentView.frame.size.height - 2 <= self.mainDashboardViewController.timerController.view.frame.size.height)
+    {
+        [self.window setContentSize:CGSizeMake(400, 600)];
+    }
 }
 
 #pragma mark - Touch Bar
 
 - (void)touchBarServiceStartTimeEntryOnTap
 {
-	[self.mainDashboardViewController.timerController startButtonClicked:self];
+    [self.mainDashboardViewController.timerController startButtonClicked:self];
 }
 
 #pragma mark - Timeline Menu

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -150,7 +150,7 @@ extern void *ctx;
     NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
     if (cmd.open)
     {
-        [self displayLoginViewController:YES];
+        [self displayLoginViewController];
 
         [self.mainDashboardViewController.view removeFromSuperview];
         [self.overlayViewController.view removeFromSuperview];
@@ -191,7 +191,7 @@ extern void *ctx;
             [self.mainDashboardViewController.view setFrame:self.contentView.bounds];
 
             // Dismiss Login
-            [self displayLoginViewController:NO];
+            [self dismissLoginViewController];
             [self.overlayViewController.view removeFromSuperview];
 
             [[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
@@ -235,7 +235,7 @@ extern void *ctx;
     [self.contentView addSubview:self.overlayViewController.view];
     [self.overlayViewController.view setFrame:self.contentView.bounds];
 
-    [self displayLoginViewController:NO];
+    [self dismissLoginViewController];
     [self.mainDashboardViewController.view removeFromSuperview];
 }
 
@@ -475,21 +475,19 @@ extern void *ctx;
     }
 }
 
--(void) displayLoginViewController:(BOOL) display
+-(void) displayLoginViewController
 {
-    if (display)
-    {
-        if (self.loginViewController == nil) {
-            self.loginViewController = [[LoginViewController alloc] initWithNibName:@"LoginViewController" bundle:nil];
-            [self.loginViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-        }
-        [self.contentView addSubview:self.loginViewController.view];
-        [self.loginViewController.view setFrame:self.contentView.bounds];
+    if (self.loginViewController == nil) {
+        self.loginViewController = [[LoginViewController alloc] initWithNibName:@"LoginViewController" bundle:nil];
+        [self.loginViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     }
-    else
-    {
-        [self.loginViewController.view removeFromSuperview];
-        self.loginViewController = nil;
-    }
+    [self.contentView addSubview:self.loginViewController.view];
+    [self.loginViewController.view setFrame:self.contentView.bounds];
+}
+
+-(void) dismissLoginViewController
+{
+    [self.loginViewController.view removeFromSuperview];
+    self.loginViewController = nil;
 }
 @end

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -150,9 +150,7 @@ extern void *ctx;
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 	if (cmd.open)
 	{
-		[self.contentView addSubview:self.loginViewController.view];
-		[self.loginViewController.view setFrame:self.contentView.bounds];
-		self.loginViewController.view.hidden = NO;
+        [self displayLoginViewController:YES];
 
 		[self.mainDashboardViewController.view removeFromSuperview];
 		[self.overlayViewController.view removeFromSuperview];
@@ -187,13 +185,13 @@ extern void *ctx;
 		{
 			// Close error when loging in
 			[self closeError];
-			[self.loginViewController resetLoader];
 
-			self.loginViewController.view.hidden = YES;
+            // Add Main View
 			[self.contentView addSubview:self.mainDashboardViewController.view];
 			[self.mainDashboardViewController.view setFrame:self.contentView.bounds];
 
-			[self.loginViewController.view removeFromSuperview];
+            // Dismiss Login
+            [self displayLoginViewController:NO];
 			[self.overlayViewController.view removeFromSuperview];
 
 			[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
@@ -237,7 +235,7 @@ extern void *ctx;
 	[self.contentView addSubview:self.overlayViewController.view];
 	[self.overlayViewController.view setFrame:self.contentView.bounds];
 
-	[self.loginViewController.view removeFromSuperview];
+    [self displayLoginViewController:NO];
 	[self.mainDashboardViewController.view removeFromSuperview];
 }
 
@@ -474,6 +472,24 @@ extern void *ctx;
     if (self.loginViewController.view.superview != nil)
     {
         [self.loginViewController continueSignIn];
+    }
+}
+
+-(void) displayLoginViewController:(BOOL) display
+{
+    if (display)
+    {
+        if (self.loginViewController == nil) {
+            self.loginViewController = [[LoginViewController alloc] initWithNibName:@"LoginViewController" bundle:nil];
+            [self.loginViewController.view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+        }
+        [self.contentView addSubview:self.loginViewController.view];
+        [self.loginViewController.view setFrame:self.contentView.bounds];
+    }
+    else
+    {
+        [self.loginViewController.view removeFromSuperview];
+        self.loginViewController = nil;
     }
 }
 @end

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -255,13 +255,9 @@
 		BA5B0E502330EA92008D1DED /* GoogleAuthenticationServer+Objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B0E4F2330EA92008D1DED /* GoogleAuthenticationServer+Objc.swift */; };
 		BA5BDC2C2464079800FF3C28 /* PasswordStrengthValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC2B2464079800FF3C28 /* PasswordStrengthValidation.swift */; };
 		BA5BDC2F24640D8A00FF3C28 /* PasswordStrengthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC2D24640D8A00FF3C28 /* PasswordStrengthView.swift */; };
-		BA5BDC3024640D8A00FF3C28 /* PasswordStrengthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC2D24640D8A00FF3C28 /* PasswordStrengthView.swift */; };
 		BA5BDC3124640D8A00FF3C28 /* PasswordStrengthView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA5BDC2E24640D8A00FF3C28 /* PasswordStrengthView.xib */; };
-		BA5BDC3224640D8A00FF3C28 /* PasswordStrengthView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA5BDC2E24640D8A00FF3C28 /* PasswordStrengthView.xib */; };
 		BA5BDC342464112100FF3C28 /* PasswordRuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC332464112100FF3C28 /* PasswordRuleView.swift */; };
-		BA5BDC352464112100FF3C28 /* PasswordRuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC332464112100FF3C28 /* PasswordRuleView.swift */; };
 		BA5BDC372464112D00FF3C28 /* PasswordRuleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA5BDC362464112D00FF3C28 /* PasswordRuleView.xib */; };
-		BA5BDC382464112D00FF3C28 /* PasswordRuleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA5BDC362464112D00FF3C28 /* PasswordRuleView.xib */; };
 		BA5E988923BF496E0089A2C7 /* HoverImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5E988823BF496E0089A2C7 /* HoverImageView.swift */; };
 		BA5E988D23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5E988B23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.swift */; };
 		BA5E988F23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA5E988C23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.xib */; };
@@ -390,6 +386,11 @@
 		BAD15FFC223A52D600A8CCC9 /* TimeEntryEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD15FFB223A52D600A8CCC9 /* TimeEntryEmptyView.swift */; };
 		BAD15FFE223A530600A8CCC9 /* TimeEntryEmptyView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BAD15FFD223A530600A8CCC9 /* TimeEntryEmptyView.xib */; };
 		BAD307D3229C1BD000C727DB /* KeyboardDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD307D2229C1BD000C727DB /* KeyboardDatePicker.swift */; };
+		BAD4F9C4246D392C0032F0C7 /* PasswordStrengthValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC2B2464079800FF3C28 /* PasswordStrengthValidation.swift */; };
+		BAD4F9C5246D392C0032F0C7 /* PasswordStrengthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC2D24640D8A00FF3C28 /* PasswordStrengthView.swift */; };
+		BAD4F9C6246D392C0032F0C7 /* PasswordStrengthView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA5BDC2E24640D8A00FF3C28 /* PasswordStrengthView.xib */; };
+		BAD4F9C7246D392C0032F0C7 /* PasswordRuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5BDC332464112100FF3C28 /* PasswordRuleView.swift */; };
+		BAD4F9C8246D392C0032F0C7 /* PasswordRuleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA5BDC362464112D00FF3C28 /* PasswordRuleView.xib */; };
 		BAD858CC228EAE7C00226C71 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = BAD858CB228EAE7C00226C71 /* libz.tbd */; };
 		BAE007DE21FAF00D00404379 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAE007DD21FAF00D00404379 /* Media.xcassets */; };
 		BAE6379A22B225C70024DD08 /* AddTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE6379922B225C70024DD08 /* AddTagButton.swift */; };
@@ -2198,7 +2199,7 @@
 				BA37ACBD23D890050013EE26 /* TimelineActivityRecorderViewController.xib in Resources */,
 				BAE64E1F2368334000244D2B /* FloatingErrorView.xib in Resources */,
 				BAE64E202368334000244D2B /* TimeEntryListViewController.xib in Resources */,
-				BA5BDC382464112D00FF3C28 /* PasswordRuleView.xib in Resources */,
+				BAD4F9C8246D392C0032F0C7 /* PasswordRuleView.xib in Resources */,
 				BAE64E212368334000244D2B /* (null) in Resources */,
 				BAE64E222368334000244D2B /* TagCellView.xib in Resources */,
 				BAE64E232368334000244D2B /* ProjectCreationView.xib in Resources */,
@@ -2212,7 +2213,7 @@
 				BA37ACB723D890050013EE26 /* MainDashboardViewController.xib in Resources */,
 				BA37ACDE23D8900C0013EE26 /* TimelineTimeEntryHoverViewController.xib in Resources */,
 				BA37ACB523D890050013EE26 /* TimelineDashboardViewController.xib in Resources */,
-				BA5BDC3224640D8A00FF3C28 /* PasswordStrengthView.xib in Resources */,
+				BAD4F9C6246D392C0032F0C7 /* PasswordStrengthView.xib in Resources */,
 				BAE64E282368334000244D2B /* TimerEditViewController.xib in Resources */,
 				BAE64E292368334000244D2B /* dsa_pub.pem in Resources */,
 			);
@@ -2792,11 +2793,11 @@
 				BAE64DA32368334000244D2B /* ProjectColor.swift in Sources */,
 				BAE64DA42368334000244D2B /* TagCellView.swift in Sources */,
 				BAE64DA52368334000244D2B /* AutoCompleteView.swift in Sources */,
+				BAD4F9C7246D392C0032F0C7 /* PasswordRuleView.swift in Sources */,
 				BABB85AA23882D7C0084DEAC /* SystemPermissionManager.swift in Sources */,
 				BAE64DA62368334000244D2B /* (null) in Sources */,
 				BAE64DA72368334000244D2B /* (null) in Sources */,
 				BAE64DA82368334000244D2B /* DesktopLibraryBridge.m in Sources */,
-				BA5BDC3024640D8A00FF3C28 /* PasswordStrengthView.swift in Sources */,
 				BAE64DA92368334000244D2B /* TimeEntryDatasource.swift in Sources */,
 				BA13E577243476FA005244AD /* OnboardingViewController.swift in Sources */,
 				BAE64DAA2368334000244D2B /* SystemMessageView.swift in Sources */,
@@ -2852,7 +2853,6 @@
 				BA37ACD223D8900C0013EE26 /* TimelineTimeLabelCell.swift in Sources */,
 				BA63ABEF238284DB004C70CF /* LoginSignupTouchBar.swift in Sources */,
 				BAE64DD12368334000244D2B /* UnsupportedNotice.m in Sources */,
-				BA5BDC352464112100FF3C28 /* PasswordRuleView.swift in Sources */,
 				BAE64DD22368334000244D2B /* NSTextFieldWithBackground.m in Sources */,
 				BAE64DD32368334000244D2B /* Array+ByGroup.swift in Sources */,
 				BAE64DD42368334000244D2B /* TogglApplication.m in Sources */,
@@ -2871,9 +2871,11 @@
 				BAE64DE12368334000244D2B /* WorkspaceCellView.swift in Sources */,
 				BA13E57D24347716005244AD /* OnboardingContentViewController.swift in Sources */,
 				BA37ACD823D8900C0013EE26 /* TimelineActivityCell.swift in Sources */,
+				BAD4F9C4246D392C0032F0C7 /* PasswordStrengthValidation.swift in Sources */,
 				BAE64DE32368334000244D2B /* idler.c in Sources */,
 				BAE64DE42368334000244D2B /* ProjectCreationView.swift in Sources */,
 				BAE64DE52368334000244D2B /* ClientStorage.swift in Sources */,
+				BAD4F9C5246D392C0032F0C7 /* PasswordStrengthView.swift in Sources */,
 				BA37ACD423D8900C0013EE26 /* TimelineTimeEntryCell.swift in Sources */,
 				BA37ACE023D8900C0013EE26 /* TimelineActivityHoverController.swift in Sources */,
 				BAE64DE62368334000244D2B /* String+Optional.swift in Sources */,


### PR DESCRIPTION
### 📒 Description
This PR attempt to clear out the Login View Controller and reset its state after login/signup

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Don't keep reference LoginViewController anymore. Just remove it and assemble later
- Update `make fmt` for fixing intends

### 👫 Relationships
Closes #4063

### 🔎 Review hints
#### Email/Pass
1. Try to Sign up a new account by email (Select Country, check the TOS)
2. Go to the main view and logout. Verify:
- The login screen appears again
- The previous states are reset (No Country, No Email and No TOS)
3. Log in with this account and repeat with the 1st steps. Verify:
- Everything is okay 

### Social login
1. Try to login/signup by Apple or Google
2. Verify that everything is okay