### PR TITLE
Basic push against the sync server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(TogglDesktop)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # Set up automatic resource generation to make Qt development easier
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/const.h
+++ b/src/const.h
@@ -126,4 +126,8 @@
 #define kGoogleAccessToken "google_access_token"
 #define kAppleAccessToken "apple_token"
 
+// there was a typo in the initial set of flags, use both variants
+#define kSyncStrategyLegacy1 "dekstop_sync_client"
+#define kSyncStrategyLegacy2 "desktop_sync_client"
+
 #endif  // SRC_CONST_H_

--- a/src/context.cc
+++ b/src/context.cc
@@ -1523,7 +1523,7 @@ error Context::downloadUpdate() {
                     kDownloadStatusStarted);
             }
 
-            std::auto_ptr<std::istream> stream(
+            std::unique_ptr<std::istream> stream(
                 Poco::URIStreamOpener::defaultOpener().open(uri));
             Poco::FileOutputStream fos(file, std::ios::binary);
             Poco::StreamCopier::copyStream(*stream.get(), fos);

--- a/src/context.h
+++ b/src/context.h
@@ -563,8 +563,10 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void uiUpdaterActivity();
     void checkReminders();
     void reminderActivity();
+
     void syncerActivityWrapper();
     void legacySyncerActivity();
+    void batchedSyncerActivity();
 
  private:
     static const std::string installerPlatform();
@@ -666,6 +668,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pullChanges();
     error pullUserPreferences();
 
+    error pushBatchedChanges(
+        bool *had_something_to_push);
     error pushChanges(
         bool *had_something_to_push);
     error pushClients(
@@ -682,6 +686,9 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error updateEntryProjects(
         const std::vector<Project *> &projects,
         const std::vector<TimeEntry *> &time_entries);
+    error updateProjectClients(
+        const std::vector<Client *> &clients,
+        const std::vector<Project *> &projects);
     error signup(
         const std::string &email,
         const std::string &password,

--- a/src/context.h
+++ b/src/context.h
@@ -563,7 +563,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void uiUpdaterActivity();
     void checkReminders();
     void reminderActivity();
-    void syncerActivity();
+    void syncerActivityWrapper();
+    void legacySyncerActivity();
 
  private:
     static const std::string installerPlatform();

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <sstream>
 #include <memory>
+#include <iostream>
 
 #include "util/formatter.h"
 #include "netconf.h"
@@ -368,7 +369,7 @@ HTTPResponse HTTPClient::makeHttpRequest(
         // Request gzip unless downloading files
         poco_req.set("Accept-Encoding", "gzip");
 
-        if (!req.form) {
+        if (!req.form && req.compress) {
             std::istringstream requestStream(req.payload);
 
             Poco::DeflatingInputStream gzipRequest(
@@ -387,6 +388,9 @@ HTTPResponse HTTPClient::makeHttpRequest(
             }
 
             session->sendRequest(poco_req) << pBuff << std::flush;
+        } else if (!req.form) {
+            poco_req.setContentLength(req.payload.size());
+            session->sendRequest(poco_req) << req.payload << std::flush;
         } else {
             req.form->prepareSubmit(poco_req);
             std::ostream& send = session->sendRequest(poco_req);

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -122,6 +122,7 @@ class TOGGL_INTERNAL_EXPORT HTTPRequest {
     std::string basic_auth_password;
     Poco::Net::HTMLForm *form;
     Poco::Int64 timeout_seconds;
+    bool compress { true };
 };
 
 class TOGGL_INTERNAL_EXPORT HTTPResponse {

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -645,7 +645,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -709,7 +709,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -764,7 +764,7 @@
 		C55DA5AA17F06A3B00B42178 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
@@ -804,7 +804,7 @@
 		C55DA5AB17F06A3B00B42178 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -129,7 +129,7 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual std::string ModelURL() const = 0;
 
     virtual void LoadFromJSON(Json::Value value) {}
-    virtual Json::Value SaveToJSON() const {
+    virtual Json::Value SaveToJSON(int apiVersion = 8) const {
         return 0;
     }
 

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -51,7 +51,7 @@ void Client::LoadFromJSON(Json::Value data) {
     SetWID(data["wid"].asUInt64());
 }
 
-Json::Value Client::SaveToJSON() const {
+Json::Value Client::SaveToJSON(int apiVersion) const {
     Json::Value n;
     if (ID()) {
         n["id"] = Json::UInt64(ID());

--- a/src/model/client.h
+++ b/src/model/client.h
@@ -37,7 +37,7 @@ class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
     std::string ModelName() const override;
     std::string ModelURL() const override;
     void LoadFromJSON(Json::Value value) override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
     bool ResolveError(const toggl::error &err) override;
     bool ResourceCannotBeCreated(const toggl::error &err) const override;
 

--- a/src/model/obm_action.cc
+++ b/src/model/obm_action.cc
@@ -47,7 +47,7 @@ std::string ObmAction::ModelURL() const {
     return "/api/v9/obm/actions";
 }
 
-Json::Value ObmAction::SaveToJSON() const {
+Json::Value ObmAction::SaveToJSON(int apiVersion) const {
     Json::Value n;
     n["experiment_id"] = Json::UInt64(ExperimentID());
     n["key"] = Formatter::EscapeJSONString(Key());

--- a/src/model/obm_action.h
+++ b/src/model/obm_action.h
@@ -40,7 +40,7 @@ class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
 
  private:
     Poco::UInt64 experiment_id_;

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -140,7 +140,7 @@ void Project::LoadFromJSON(Json::Value data) {
     SetBillable(data["billable"].asBool());
 }
 
-Json::Value Project::SaveToJSON() const {
+Json::Value Project::SaveToJSON(int apiVersion) const {
     Json::Value n;
     if (ID()) {
         n["id"] = Json::UInt64(ID());

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -82,7 +82,7 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
     std::string ModelName() const override;
     std::string ModelURL() const override;
     void LoadFromJSON(Json::Value value) override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
     bool DuplicateResource(const toggl::error &err) const override;
     bool ResourceCannotBeCreated(const toggl::error &err) const override;
     bool ResolveError(const toggl::error &err) override;

--- a/src/model/settings.cc
+++ b/src/model/settings.cc
@@ -6,7 +6,7 @@
 
 namespace toggl {
 
-Json::Value Settings::SaveToJSON() const {
+Json::Value Settings::SaveToJSON(int apiVersion) const {
     Json::Value json;
     json["use_idle_detection"] = use_idle_detection;
     json["menubar_timer"] = menubar_timer;

--- a/src/model/settings.h
+++ b/src/model/settings.h
@@ -90,7 +90,7 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
 };
 
 }  // namespace toggl

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -458,7 +458,7 @@ void TimeEntry::LoadFromJSON(Json::Value data) {
     ClearUnsynced();
 }
 
-Json::Value TimeEntry::SaveToJSON() const {
+Json::Value TimeEntry::SaveToJSON(int apiVersion) const {
     Json::Value n;
     if (ID()) {
         n["id"] = Json::UInt64(ID());
@@ -469,32 +469,47 @@ Json::Value TimeEntry::SaveToJSON() const {
     // NULL is not 0
     if (WID()) {
         n["wid"] = Json::UInt64(WID());
+        n["workspace_id"] = Json::UInt64(WID());
     }
-    n["guid"] = GUID();
+    if (apiVersion == 8)
+        n["guid"] = GUID();
     if (!PID() && !ProjectGUID().empty()) {
-        n["pid"] = ProjectGUID();
+        if (apiVersion == 8)
+            n["pid"] = ProjectGUID();
+        else
+            n["project_id"] = ProjectGUID();
     } else {
-        n["pid"] = Json::UInt64(PID());
+        if (apiVersion == 8)
+            n["pid"] = Json::UInt64(PID());
     }
 
     if (PID()) {
-        n["pid"] = Json::UInt64(PID());
+        if (apiVersion == 8)
+            n["pid"] = Json::UInt64(PID());
+        else
+            n["project_id"] = Json::UInt64(PID());
     } else {
-        n["pid"] = Json::nullValue;
+        if (apiVersion == 8)
+            n["pid"] = Json::nullValue;
     }
 
     if (TID()) {
-        n["tid"] = Json::UInt64(TID());
+        if (apiVersion == 8)
+            n["tid"] = Json::UInt64(TID());
+        else
+            n["task_id"] = Json::UInt64(TID());
     } else {
-        n["tid"] = Json::nullValue;
+        if (apiVersion == 8)
+            n["tid"] = Json::nullValue;
     }
 
     n["start"] = StartString();
-    if (Stop()) {
+    if (Stop() && apiVersion == 8) {
         n["stop"] = StopString();
     }
     n["duration"] = Json::Int64(DurationInSeconds());
-    n["billable"] = Billable();
+    if (apiVersion == 8)
+        n["billable"] = Billable();
     n["duronly"] = DurOnly();
     n["ui_modified_at"] = Json::UInt64(UIModifiedAt());
     n["created_with"] = Formatter::EscapeJSONString(CreatedWith());

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -129,7 +129,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string String() const override;
     virtual bool ResolveError(const error &err) override;
     void LoadFromJSON(Json::Value value) override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
 
     // Implement TimedEvent
 

--- a/src/model/timeline_event.cc
+++ b/src/model/timeline_event.cc
@@ -79,7 +79,7 @@ void TimelineEvent::SetUploaded(const bool value) {
     }
 }
 
-Json::Value TimelineEvent::SaveToJSON() const {
+Json::Value TimelineEvent::SaveToJSON(int apiVersion) const {
     Json::Value n;
     n["guid"] = GUID();
     n["filename"] = Filename();

--- a/src/model/timeline_event.h
+++ b/src/model/timeline_event.h
@@ -76,7 +76,7 @@ class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent 
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
 
  private:
     std::string title_;

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -1069,33 +1069,6 @@ void User::loadUserProjectFromJSON(
     model->LoadFromJSON(data);
 }
 
-bool User::SetTimeEntryID(
-    Poco::UInt64 id,
-    TimeEntry* timeEntry) {
-
-    poco_check_ptr(timeEntry);
-
-    {
-        Poco::Mutex::ScopedLock lock(loadTimeEntries_m_);
-        auto otherTimeEntry = related.TimeEntryByID(id);
-        if (otherTimeEntry) {
-            // this means that somehow we already have a time entry with the ID
-            // that was just returned from a response to time entry creation request
-            logger().error("There is already a newer version of this entry");
-
-            // clearing the GUID to make sure there's no GUID conflict
-            timeEntry->SetGUID("");
-
-            // deleting the duplicate entry
-            // this entry has no ID so the corresponding server entry will not be deleted
-            timeEntry->Delete();
-            return false;
-        }
-        timeEntry->SetID(id);
-        return true;
-    }
-}
-
 void User::loadUserTimeEntryFromJSON(
     Json::Value data,
     std::set<Poco::UInt64> *alive) {

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -52,6 +52,7 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
 
     void Clear();
 
+    template <class T> T *ModelByID(Poco::UInt64 id);
     Task *TaskByID(const Poco::UInt64 id) const;
     Client *ClientByID(const Poco::UInt64 id) const;
     Project *ProjectByID(const Poco::UInt64 id) const;
@@ -133,8 +134,12 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
 
     void mergeGroupedAutocompleteItems(
         std::vector<view::Autocomplete> *result,
-        std::map<std::string, std::vector<view::Autocomplete> > *items) const;
+            std::map<std::string, std::vector<view::Autocomplete> > *items) const;
 };
+
+template<> inline TimeEntry *RelatedData::ModelByID<TimeEntry>(Poco::UInt64 id) { return TimeEntryByID(id); }
+template<> inline Project *RelatedData::ModelByID<Project>(Poco::UInt64 id) { return ProjectByID(id); }
+template<> inline Client *RelatedData::ModelByID<Client>(Poco::UInt64 id) { return ClientByID(id); }
 
 template<typename T>
 void clearList(std::vector<T *> *list);

--- a/src/urls.cc
+++ b/src/urls.cc
@@ -63,6 +63,10 @@ void SetRequestsAllowed(const bool value) {
     requests_allowed_ = value;
 }
 
+std::string SyncAPI() {
+    return "http://localhost:8080";
+}
+
 
 }  // namespace urls
 

--- a/src/urls.h
+++ b/src/urls.h
@@ -13,6 +13,7 @@ std::string Main();
 std::string API();
 std::string TimelineUpload();
 std::string WebSocket();
+std::string SyncAPI();
 
 void SetUseStagingAsBackend(const bool value);
 


### PR DESCRIPTION
### 📒 Description
This PR implements the simplest subset of pushing to the sync server, currently located on a temporary host.

It also requires C++17 support (which may need to be enabled on platforms other than Linux, let's wait if GitHub Actions builds fail).

SaveToJSON methods now take an argument to generate a v9 JSON (some properties have different names and some have to be missing completely instead of sending `null`).

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Sync initiative: basic push

### 👫 Relationships
Requires #4066 merged first.

### 🔎 Review hints
For testing, an up-to-date version of the sync server has to be installed on localhost. See https://github.com/toggl/sync-api . Also, it's a bit easier to test with using the `TOGGL_SYNC_FORCE_BATCHED` compile-time flag.
The URL in urls.cc is subject to change in the future.

Since per-property updates (see docs) were introduced while this PR was in progress, it works basically just for creating new entities. Updates will get fixed in another PR.

This branch of code will be disabled until the beta flag is flipped, so it should be safe to merge into master.