### PR TITLE
Support multiple-time Undo/Redo for deleting TimeEntry

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2870,7 +2870,11 @@ TimeEntry *Context::Start(
 
     OpenTimeEntryList();
 
-    if (!prevent_on_app && settings_.focus_on_shortcut) {
+    // Don't need to focus on Timer if we create a TimeEntry without running
+    // Avoid glitch
+    // For instance, after undoing the TimeEntry Deletion, we creat an TE
+    // It trigger the DisplayApp() and focus on the Timer -> It prevents the user to do Redo until they click on the Time Entry List
+    if (!prevent_on_app && settings_.focus_on_shortcut && !stop_current_running) {
         // Show app
         UI()->DisplayApp();
     }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -154,6 +154,7 @@ void *ctx;
 - (void)deleteTimeEntryItem:(TimeEntryViewItem *)item undoManager:(NSUndoManager *) undoManager
 {
     self.undoManager = undoManager;
+    self.undoManager.levelsOfUndo = 10;
 
 	// If description is empty and duration is less than 15 seconds delete without confirmation
 	if ([item confirmlessDelete])
@@ -187,7 +188,13 @@ void *ctx;
 - (void) registerUndoDeleteItem:(TimeEntryViewItem *)item
 {
     [self.undoManager registerUndoWithTarget:self selector:@selector(createNewTimeEntryWithOldTimeEntry:) object:item];
-    [self.undoManager setActionName:@"Undo Delete Time Entry"];
+    [self.undoManager setActionName:@"Delete item"];
+}
+
+- (void) registerUndoAddItem:(TimeEntryViewItem *)item
+{
+    [self.undoManager registerUndoWithTarget:self selector:@selector(deleteItem:) object:item];
+    [self.undoManager setActionName:@"Delete Item"];
 }
 
 - (void)updateDescriptionForTimeEntry:(TimeEntryViewItem *)timeEntry autocomplete:(AutocompleteItem *)autocomplete
@@ -361,8 +368,12 @@ void *ctx;
     if (guid != nil) {
         NSString *GUID = [NSString stringWithUTF8String:guid];
         free(guid);
-        // Don't support redo
-        [self.undoManager removeAllActions];
+
+        // Update new GUI for redo
+        // As the GUI is changed
+        item.GUID = GUID;
+        [self registerUndoAddItem:item];
+
         return GUID;
     }
     return nil;

--- a/src/ui/osx/TogglDesktop/Feature/Undo/UndoManager.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Undo/UndoManager.swift
@@ -31,7 +31,7 @@ import Foundation
     }()
 
     // MARK: - Init
-    init(levelOfUndo: Int = 2) {
+    init(levelOfUndo: Int = 10) {
         self.levelOfUndo = levelOfUndo
     }
 

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -134,10 +134,6 @@ extern void *ctx;
 												 name:kDeselectAllTimeEntryList
 											   object:nil];
 	[[NSNotificationCenter defaultCenter] addObserver:self
-											 selector:@selector(windowDidBecomeKeyNotification:)
-												 name:NSWindowDidBecomeKeyNotification
-											   object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(touchBarSettingChangedNotification:)
 												 name:kTouchBarSettingChanged
 											   object:nil];
@@ -637,23 +633,6 @@ extern void *ctx;
 - (void)deselectAllTimeEntryNotification
 {
 	[self.collectionView deselectAll:self];
-}
-
-- (void)windowDidBecomeKeyNotification:(NSNotification *)notification
-{
-    // Don't focus on Timer Bar if the Editor is presented
-    if (self.timeEntrypopover.isShown)
-    {
-        return;
-    }
-
-    // Only focus if the window is main
-    // Otherwise, shouldn't override the firstResponder
-    if (notification.object != self.view.window)
-    {
-        return;
-    }
-    [self.delegate shouldFocusTimer];
 }
 
 - (void)loadMoreIfNeedAtDate:(NSDate *)date;


### PR DESCRIPTION
### 📒 Description
This PR attempts to support
- Undo / Redo on TE deletion
- Multiple levels of undo/redo

### 🕶️ Types of changes
**Improvement** (non-breaking change which adds functionality

### 🤯 List of changes
- Avoid a focus on Timer after creating a no-running TE in the library
- Support multiple levels of undo/redo
- Support Undo/Redo for deletion
- Remove duplicated code

### 👫 Relationships
Closes #4058

### 🔎 Review hints
1. Delete many Time Entries
Verify that
- CMD+Z will undo the deletion.
- Able to undo multiple times
- Able to CMD+SHIFT+Z for redo the action
- Able to redo multiple times

![2020-05-15 14 50 58](https://user-images.githubusercontent.com/5878421/82026166-8eade300-96bc-11ea-8f26-31bf16513164.gif)

