### PR TITLE
Fix the max size of Preferences window

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -34,6 +34,8 @@ namespace TogglDesktop
         public PreferencesWindow()
         {
             this.InitializeComponent();
+            this.MaxHeight = System.Windows.SystemParameters.WorkArea.Height;
+
             ViewModel = new PreferencesWindowViewModel(MessageBox.Show(this), this.Close);
 
             Toggl.OnSettings += this.onSettings;


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
The Height of Preferences window set to high constant number (760) so it may not fit on the low display resolution, and because the window is not resizable the user can do nothing to access the bottom of the window.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->
Set the Maximum height of the window to be the height of the working area of the screen.
### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
-Set the display resolution to low resolution.
-open Preferences window, the window should fit the screen. 