### PR TITLE
Remove focus from app after closing with global shortcut (mac), #1824

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -238,6 +238,8 @@ void *ctx;
 		 if ([[NSApplication sharedApplication] isActive] && [strongSelf.mainWindowController.window isVisible])
 		 {
 			 [self.mainWindowController.window close];
+             [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
+             [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 		 }
 		 else
 		 {


### PR DESCRIPTION
### 📒 Description
Fixes issue where the Toggl Desktop menubar would stay after closing app with global shortcut.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
Solution is very simple.

This will block the app from showing menubar and will then trigger showing menubar of the next app in focus.
```
[NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
```

This will put back the usual logic so when the app is shown again there will be menubar visible again
```
[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
```

### 👫 Relationships
Closes #1824 

### 🔎 Review hints
- Open app
- Setup "show/hide" global shortcut
- Hide the app with global shortcut and see that the menubar shows items from the next app that is in focus.

