### PR TITLE
Account locking error messages

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -95,6 +95,9 @@
 #define kMissingWS "You no longer have access to your last workspace"
 #define kOutOfDatePleaseUpgrade "Your version of Toggl Desktop is out of date, please upgrade!"
 #define kThisEntryCantBeSavedPleaseAdd "This entry can't be saved - please add"
+#define kOneLoginAttemptLeft "Incorrect email or password. One more try before account gets locked for 5 minutes."
+#define kAccountIsLocked "Incorrect email or password. Account is locked for 5 minutes. Account owner has been notified."
+#define kIncorrectEmailOrPassword "Incorrect email or password. Please try again."
 
 #define kModelAutotrackerRule "autotracker_rule"
 #define kModelClient "client"

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -173,6 +173,8 @@ class TOGGL_INTERNAL_EXPORT HTTPClient {
 
     error statusCodeToError(const Poco::Int64 status_code) const;
 
+    error accountLockingError(int remainingLogins) const;
+
     bool isRedirect(const Poco::Int64 status_code) const;
 
     virtual HTTPResponse makeHttpRequest(

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/LoginViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/LoginViewModel.cs
@@ -97,7 +97,7 @@ namespace TogglDesktop.ViewModels
         public bool IsTosChecked { get; set; }
 
         [Reactive]
-        public bool ShowLoginError { get; private set; }
+        public bool ShowLoginError { get; set; }
 
         public string ConfirmButtonText { [ObservableAsProperty] get; }
         public string GoogleLoginButtonText { [ObservableAsProperty] get; }
@@ -191,7 +191,6 @@ namespace TogglDesktop.ViewModels
                     throw new ArgumentOutOfRangeException();
             }
 
-            ShowLoginError = !success;
             return success;
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/IMainView.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/IMainView.cs
@@ -6,7 +6,7 @@ namespace TogglDesktop
     {
         void Activate(bool allowAnimation);
         void Deactivate(bool allowAnimation);
-        bool HandlesError(string errorMessage);
+        bool TryShowErrorInsideView(string errorMessage);
 
         double MinWidth { get; }
         double MinHeight { get; }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml.cs
@@ -146,9 +146,15 @@ namespace TogglDesktop
             this.IsEnabled = false;
         }
 
-        public bool HandlesError(string errorMessage)
+        public bool TryShowErrorInsideView(string errorMessage)
         {
-            return errorMessage == "Invalid e-mail or password!" && ViewModel.SelectedConfirmAction == ConfirmAction.LogIn;
+            if (errorMessage == "Invalid e-mail or password!" && ViewModel.SelectedConfirmAction == ConfirmAction.LogIn)
+            {
+                ViewModel.ShowLoginError = true;
+                return true;
+            }
+
+            return false;
         }
 
         public Brush TitleBarBrush => this.Background;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/OverlayView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/OverlayView.xaml.cs
@@ -113,7 +113,7 @@ namespace TogglDesktop
             this.IsEnabled = false;
         }
 
-        public bool HandlesError(string errorMessage)
+        public bool TryShowErrorInsideView(string errorMessage)
         {
             return false;
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
@@ -178,7 +178,7 @@ namespace TogglDesktop
             this.IsEnabled = false;
         }
 
-        public bool HandlesError(string errorMessage)
+        public bool TryShowErrorInsideView(string errorMessage)
         {
             return false;
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -412,7 +412,7 @@ namespace TogglDesktop
             if (this.TryBeginInvoke(this.onError, errmsg, userError))
                 return;
 
-            if (this.activeView?.HandlesError(errmsg) != true)
+            if (this.activeView?.TryShowErrorInsideView(errmsg) != true)
             {
                 this.errorBar.ShowError(errmsg);
             }


### PR DESCRIPTION
### 📒 Description
Password Security project. Account locking part.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Show proper error message when account is locked or about to get locked
- [x] Make sure Login view on Windows shows only one type of error at a time

### 👫 Relationships
Closes #4074 

### 🔎 Review hints

Method 1
- Ask someone from BE in #project-security-features to deploy account locking to Staging.

Method 2
- Manipulate the HTTP response via some debugging proxy tool so that the response contains the necessary header

Method 3
- Manipulate the code to force the response to contain the necessary header