### PR TITLE
Fixed send feedback menu item tag

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -292,7 +292,7 @@
                                     <action selector="onHelpMenuItem:" target="494" id="Yuo-YB-F1l"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Send Feedback" tag="8" id="tQk-RP-c2H">
+                            <menuItem title="Send Feedback" tag="13" id="tQk-RP-c2H">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="onSendFeedbackMainMenuItem:" target="494" id="Ezo-qQ-7mP"/>


### PR DESCRIPTION
### 📒 Description
Fixes the issue with feedback item being active when user is logged out 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships

Closes #4088 

### 🔎 Review hints
- Open app
- Log out
- Check out that the "Send Feedback" item in the menubar "help" menu is disabled

