### PR TITLE
Implement basic pull against the sync server

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -62,6 +62,7 @@
 #define kCannotConnectError "Cannot connect to Toggl"
 #define kCannotSyncInTestEnv "Cannot sync in test env"
 #define kBackendIsDownError "Backend is down"
+#define kBackendIsSendingInvalidData "Backend is sending invalid data"
 #define kBadRequestError "Data that you are sending is not valid/acceptable"
 #define kRequestIsNotPossible "Request is not possible"
 #define kPaymentRequiredError "Requested action allowed only for Non-Free workspaces. Please upgrade!"  // NOLINT

--- a/src/context.h
+++ b/src/context.h
@@ -571,6 +571,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void reminderActivity();
     void syncerActivityWrapper();
     void legacySyncerActivity();
+    void batchedSyncerActivity();
 
  private:
     static const std::string installerPlatform();
@@ -669,6 +670,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error applySettingsSaveResultToUI(const error &err);
 
     error pullAllUserData();
+    error pullBatchedUserData();
     error pullChanges();
     error pullUserPreferences();
 
@@ -713,6 +715,10 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
                     const std::string &password,
                     std::string *user_data,
                     const Poco::Int64 since);
+    static error syncPull(const std::string &email,
+                         const std::string &password,
+                         std::string *user_data,
+                         const Poco::Int64 since);
 
     bool isTimeEntryLocked(TimeEntry* te);
     bool isTimeLockedInWorkspace(time_t t, Workspace* ws);

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -48,7 +48,10 @@ void Client::SetWID(const Poco::UInt64 value) {
 void Client::LoadFromJSON(Json::Value data) {
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
-    SetWID(data["wid"].asUInt64());
+    if (data.isMember("wid"))
+        SetWID(data["wid"].asUInt64());
+    else
+        SetWID(data["workspace_id"].asUInt64());
 }
 
 Json::Value Client::SaveToJSON() const {

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -134,8 +134,14 @@ void Project::LoadFromJSON(Json::Value data) {
 
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
-    SetWID(data["wid"].asUInt64());
-    SetCID(data["cid"].asUInt64());
+    if (data.isMember("wid"))
+        SetWID(data["wid"].asUInt64());
+    else
+        SetWID(data["workspace_id"].asUInt64());
+    if (data.isMember("cid"))
+        SetCID(data["cid"].asUInt64());
+    else
+        SetCID(data["client_id"].asUInt64());
     SetActive(data["active"].asBool());
     SetBillable(data["billable"].asBool());
 }

--- a/src/model/tag.cc
+++ b/src/model/tag.cc
@@ -35,7 +35,10 @@ void Tag::SetName(const std::string &value) {
 void Tag::LoadFromJSON(Json::Value data) {
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
-    SetWID(data["wid"].asUInt64());
+    if (data.isMember("wid"))
+        SetWID(data["wid"].asUInt64());
+    else
+        SetWID(data["workspace_id"].asUInt64());
 }
 
 std::string Tag::ModelName() const {

--- a/src/model/task.cc
+++ b/src/model/task.cc
@@ -47,8 +47,14 @@ void Task::SetActive(const bool value) {
 void Task::LoadFromJSON(Json::Value data) {
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
-    SetPID(data["pid"].asUInt64());
-    SetWID(data["wid"].asUInt64());
+    if (data.isMember("pid"))
+        SetPID(data["pid"].asUInt64());
+    else
+        SetPID(data["project_id"].asUInt64());
+    if (data.isMember("wid"))
+        SetWID(data["wid"].asUInt64());
+    else
+        SetWID(data["workspace_id"].asUInt64());
     SetActive(data["active"].asBool());
 }
 

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -434,16 +434,22 @@ void TimeEntry::LoadFromJSON(Json::Value data) {
 
     if (data.isMember("wid")) {
         SetWID(data["wid"].asUInt64());
+    } else if (data.isMember("workspace_id")) {
+        SetWID(data["workspace_id"].asUInt64());
     } else {
         SetWID(0);
     }
     if (data.isMember("pid")) {
         SetPID(data["pid"].asUInt64());
+    } else if (data.isMember("project_id")) {
+        SetPID(data["project_id"].asUInt64());
     } else {
         SetPID(0);
     }
     if (data.isMember("tid")) {
         SetTID(data["tid"].asUInt64());
+    } else if (data.isMember("project_id")) {
+        SetTID(data["project_id"].asUInt64());
     } else {
         SetTID(0);
     }

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -265,8 +265,15 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         std::set<Poco::UInt64> *alive = nullptr);
 
     void loadUserAndRelatedDataFromJSON(
-        Json::Value node,
-        const bool &including_related_data);
+        const Json::Value &root,
+        bool including_related_data);
+
+    error loadUserFromJSON(
+        const Json::Value &node);
+
+    error loadRelatedDataFromJSON(
+        const Json::Value &node,
+        bool including_related_data);
 
     void loadUserUpdateFromJSON(
         Json::Value list);

--- a/src/urls.cc
+++ b/src/urls.cc
@@ -19,6 +19,10 @@ void SetUseStagingAsBackend(const bool value) {
     use_staging_as_backend = value;
 }
 
+bool IsUsingStagingAsBackend() {
+    return use_staging_as_backend;
+}
+
 std::string Main() {
     if (use_staging_as_backend) {
         return "https://toggl.space";
@@ -31,6 +35,13 @@ std::string API() {
         return "https://toggl.space";
     }
     return "https://desktop.toggl.com";
+}
+
+std::string SyncAPI() {
+    if (use_staging_as_backend) {
+        // TODO
+    }
+    return "http://localhost:8080";
 }
 
 std::string TimelineUpload() {

--- a/src/urls.h
+++ b/src/urls.h
@@ -11,10 +11,13 @@ namespace urls {
 
 std::string Main();
 std::string API();
+std::string SyncAPI();
 std::string TimelineUpload();
 std::string WebSocket();
 
 void SetUseStagingAsBackend(const bool value);
+
+bool IsUsingStagingAsBackend();
 
 bool RequestsAllowed();
 


### PR DESCRIPTION
### 📒 Description
This change adds basic full entity pull against the sync server in addition to v8.
* Only full pull (without `since`) is implemented in this PR.
* `User::LoadUserAndRelatedDataFromJSON` was split into two methods.
* The library won't care now if v8 returns the sync JSON or vice versa, both are treated equally, depending on if the parser can find the `since` and `data` fields in the JSON (these are only in v8). 
* Short foreign entity names (`cid`, `wid`, `pid`, etc.) can now be parsed along with their long variants (v9: `client_id`, `workspace_id`, `project_id`, etc.).

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Related to the Sync effort

### 🔎 Review hints
You can enable this PR by either setting the `TOGGL_SYNC_FORCE_BATCHED` compile-time flag or by enabling the "`dekstop_sync_client`" (is the typo still there? the app will consume both the wrong and the right variants) beta flag for your account. Even then, it will only connect to a sync server running on `http://localhost:8080` and only if you have a staging TogglDesktop build.

Everything should work exactly the same as before. 
There's also a test to make sure both protocol JSONs are consumed right.

