### PR TITLE
Don't spam the flags endpoint if the HTTP status is not 200 (lib)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4910,6 +4910,11 @@ void Context::syncerActivityWrapper() {
                     }
                 }
             }
+            // it is a HTTP error in disguise which means the server is alive, fallback to LEGACY
+            else if (resp.err == HTTPClient::StatusCodeToError(resp.status_code)) {
+                logger.log("Syncer - Server didn't respond 200 to /me/flags, fallback to LEGACY");
+                state = LEGACY;
+            }
             break;
         }
         case LEGACY:

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -185,7 +185,7 @@ bool HTTPClient::isRedirect(const Poco::Int64 status_code) const {
     return (status_code >= 300 && status_code < 400);
 }
 
-error HTTPClient::statusCodeToError(const Poco::Int64 status_code) const {
+error HTTPClient::StatusCodeToError(const Poco::Int64 status_code) {
     switch (status_code) {
     case 200:
     case 201:
@@ -225,7 +225,7 @@ error HTTPClient::statusCodeToError(const Poco::Int64 status_code) const {
         return kBackendIsDownError;
     }
 
-    logger().error("Unexpected HTTP status code: ", status_code);
+    Logger("HTTPClient").error("Unexpected HTTP status code: ", status_code);
 
     return kCannotConnectError;
 }
@@ -478,7 +478,7 @@ HTTPResponse HTTPClient::makeHttpRequest(
                            ". So we cannot make new requests until ", Formatter::Format8601(ts));
         }
 
-        resp.err = statusCodeToError(resp.status_code);
+        resp.err = StatusCodeToError(resp.status_code);
 
         if (resp.status_code == 401 || resp.status_code == 403) {
             if (response.has("X-Remaining-Login-Attempts")) {

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -167,6 +167,8 @@ class TOGGL_INTERNAL_EXPORT HTTPClient {
     void SetCACertPath(std::string path);
     void SetIgnoreCert(bool ignore);
 
+    static error StatusCodeToError(const Poco::Int64 status_code);
+
  protected:
     virtual HTTPResponse request(
         HTTPRequest req) const;
@@ -178,8 +180,6 @@ class TOGGL_INTERNAL_EXPORT HTTPClient {
 
     // We only make requests if this timestamp lies in the past.
     static std::map<std::string, Poco::Timestamp> banned_until_;
-
-    error statusCodeToError(const Poco::Int64 status_code) const;
 
     error accountLockingError(int remainingLogins) const;
 


### PR DESCRIPTION
### 📒 Description
Makes `HTTPClient::StatusCodeToError` a public static method. It is then used in the flags endpoint handler to reverse-determine if the returned `error` is a translated HTTP status. If it is, revert to legacy syncing strategy instead of asking the same server over and over.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4113

### 🔎 Review hints
Shouldn't spam the beta flag server anymore if the HTTP status is not 200.

