### PR TITLE
Fix crash with UriFormatException on proxy setup

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/LoginViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/LoginViewModel.cs
@@ -329,12 +329,16 @@ namespace TogglDesktop.ViewModels
             }
             else if (settings.UseProxy)
             {
-                var proxy = new WebProxy(settings.ProxyHost + ":" + settings.ProxyPort, true);
-                if (!string.IsNullOrEmpty(settings.ProxyUsername))
+                if (!Uri.CheckHostName(settings.ProxyHost).Equals(UriHostNameType.Unknown))
                 {
-                    proxy.Credentials = new NetworkCredential(settings.ProxyUsername, settings.ProxyPassword);
+                    var proxy = new WebProxy(settings.ProxyHost + ":" + settings.ProxyPort, true);
+
+                    if (!string.IsNullOrEmpty(settings.ProxyUsername))
+                    {
+                        proxy.Credentials = new NetworkCredential(settings.ProxyUsername, settings.ProxyPassword);
+                    }
+                    proxyHttpClientFactory.Proxy = proxy;
                 }
-                proxyHttpClientFactory.Proxy = proxy;
             }
 
             return proxyHttpClientFactory;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -36,9 +36,11 @@ namespace TogglDesktop.ViewModels
 
         private HotKey _continueStopTimerSaved;
         private HotKey _showHideTogglSaved;
+        private String _proxyHostSaved;
 
         private readonly ValidationHelper _showHideTogglValidation;
         private readonly ValidationHelper _continueStopTimerValidation;
+        private readonly ValidationHelper _proxyHostValidation;
 
         public PreferencesWindowViewModel(ShowMessageBoxDelegate showMessageBox, Action closePreferencesWindow)
         {
@@ -65,6 +67,10 @@ namespace TogglDesktop.ViewModels
                 vm => vm.ContinueStopTimer,
                 hotKey => IsHotKeyValid(hotKey, ContinueStopTimerDescription),
                 hotKey => $"This shortcut is already taken by {_knownShortcuts[hotKey]}");
+            _proxyHostValidation = this.ValidationRule(
+                x => x.ProxyHost,
+                proxyHost => Uri.CheckHostName(proxyHost) != UriHostNameType.Unknown,
+                "Please, enter a valid host");
         }
 
         public ICommand ClearCacheCommand { get; }
@@ -79,10 +85,14 @@ namespace TogglDesktop.ViewModels
         public HotKey GetContinueStopTimerIfChanged() =>
             !object.Equals(ContinueStopTimer, _continueStopTimerSaved) ? (ContinueStopTimer ?? new HotKey(Key.None)) : null;
 
+        [Reactive]
+        public string ProxyHost { get; set; }
+
         public void ResetRecordedShortcuts()
         {
             ShowHideToggl = _showHideTogglSaved;
             ContinueStopTimer = _continueStopTimerSaved;
+            ProxyHost = _proxyHostSaved;
         }
 
         public void LoadShortcutsFromSettings()
@@ -93,10 +103,16 @@ namespace TogglDesktop.ViewModels
             ContinueStopTimer = _continueStopTimerSaved;
         }
 
+        public void SetSavedProxyHost(String savedProxyHost)
+        {
+            _proxyHostSaved = savedProxyHost;
+        }
+
         public void ResetPropsWithErrorsToPreviousValues()
         {
             if (!_showHideTogglValidation.IsValid) ShowHideToggl = _showHideTogglSaved;
             if (!_continueStopTimerValidation.IsValid) ContinueStopTimer = _continueStopTimerSaved;
+            if (!_proxyHostValidation.IsValid) ProxyHost = _proxyHostSaved;
         }
 
         private bool IsHotKeyValid(HotKey hotKey, string hotKeyDescription)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -396,7 +396,8 @@
                                        VerticalAlignment="Center"
                                        Text="Password"/>
                             <TextBox Grid.Row="0" Grid.Column="1"
-                                     Name="proxyHostTextBox" x:FieldModifier="private"/>
+                                     Name="proxyHostTextBox" x:FieldModifier="private"
+                                     Text="{Binding ProxyHost, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}" />
                             <TextBox Grid.Row="1" Grid.Column="1" Margin="0 8 0 0"
                                      Name="proxyPortTextBox" x:FieldModifier="private"/>
                             <TextBox Grid.Row="2" Grid.Column="1" Margin="0 8 0 0"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -152,6 +153,7 @@ namespace TogglDesktop
             #endregion
 
             ViewModel.LoadShortcutsFromSettings();
+            ViewModel.SetSavedProxyHost(settings.ProxyHost);
         }
 
         private static async Task<bool?> IsRunOnStartupEnabled()


### PR DESCRIPTION
### 📒 Description
Added an error message upon user input in the proxy host field for invalid URL types. The proxy host will be reset to the previously valid value set if an invalid value is saved. Also added a check to avoid crashing with UriFormatException in case some invalid value is set manually in the config file.

### 🕶️ Types of changes

- **Bug fix** Checking the value of `proxyHost` before trying to use it to setup proxy.
- **New feature** Added field validation for the `proxyHost` field. When entering an invalid URL, an error message is displayed.

### 👫 Relationships

Closes #4008.
