### PR TITLE
Update timeline date if user leaves app open

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -111,6 +111,10 @@ final class TimelineDashboardViewController: NSViewController {
             !datePickerView.isShown
     }
 
+    private var initialDateProvider = TimelineInitialDateProvider { proposedDate in
+        DesktopLibraryBridge.shared().timelineSetDate(proposedDate)
+    }
+
     // MARK: View
     
     override func viewDidLoad() {
@@ -124,6 +128,12 @@ final class TimelineDashboardViewController: NSViewController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+
+    override func viewWillAppear() {
+        super.viewWillAppear()
+
+        initialDateProvider.timelineOpened()
     }
 
     override func viewDidAppear() {
@@ -144,6 +154,8 @@ final class TimelineDashboardViewController: NSViewController {
     override func viewWillDisappear() {
         super.viewWillDisappear()
         isOpening = false
+
+        initialDateProvider.timelineClosed()
     }
 
     func scrollToVisibleItem() {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineInitialDateProvider.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineInitialDateProvider.swift
@@ -1,0 +1,49 @@
+//
+//  TimelineInitialDateProvider.swift
+//  TogglDesktop
+//
+//  Created by Andrew Nester on 01.06.2020.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Foundation
+
+/// Calculates what date to show to the user when opening the Timeline screen
+/// based on a last user session and current date.
+struct TimelineInitialDateProvider {
+
+    private struct Constants {
+        static let lastTimelineActiveDateKey = "lastTimelineActiveDate"
+    }
+
+    var dateUpdatedHandler: ((Date) -> Void)?
+
+    // TODO: consider using @propertyWrapper's for UserDefaults storage
+    private var lastActiveDate: Date {
+        get {
+            let timeInterval = defaults.double(forKey: Constants.lastTimelineActiveDateKey)
+            return Date(timeIntervalSince1970: timeInterval)
+        }
+        set {
+            defaults.set(Date().timeIntervalSince1970, forKey: Constants.lastTimelineActiveDateKey)
+        }
+    }
+
+    private var defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard, dateUpdatedHandler: ((Date) -> Void)?) {
+        self.defaults = defaults
+        self.dateUpdatedHandler = dateUpdatedHandler
+    }
+
+    func timelineOpened() {
+        if Calendar.current.isDateInToday(lastActiveDate) {
+            return
+        }
+        dateUpdatedHandler?(Date())
+    }
+
+    mutating func timelineClosed() {
+        lastActiveDate = Date()
+    }
+}

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3CD7AD6F19ED579700372797 /* NSResize.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CD7AD6E19ED579700372797 /* NSResize.m */; };
 		3CE1CAC11C774F2B00D0ADD5 /* LoadMoreCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE1CAC01C774F2B00D0ADD5 /* LoadMoreCell.m */; };
 		3CE30E022052BD8B00AF2E2A /* AutoCompleteTableContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE30E012052BD8B00AF2E2A /* AutoCompleteTableContainer.m */; };
+		492F5F02248550F800FFEC70 /* TimelineInitialDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492F5F01248550F800FFEC70 /* TimelineInitialDateProvider.swift */; };
 		622BBF654A6A958692A4633B /* Pods_TogglDesktop.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 776525112125F6AD81DF4DEF /* Pods_TogglDesktop.framework */; };
 		69FC17F517E6534400B96425 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69FC17F417E6534400B96425 /* Cocoa.framework */; };
 		69FC17FF17E6534400B96425 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 69FC17FD17E6534400B96425 /* InfoPlist.strings */; };
@@ -720,6 +721,7 @@
 		3CE1CAC01C774F2B00D0ADD5 /* LoadMoreCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoadMoreCell.m; sourceTree = "<group>"; };
 		3CE30E002052BD8B00AF2E2A /* AutoCompleteTableContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoCompleteTableContainer.h; sourceTree = "<group>"; };
 		3CE30E012052BD8B00AF2E2A /* AutoCompleteTableContainer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoCompleteTableContainer.m; sourceTree = "<group>"; };
+		492F5F01248550F800FFEC70 /* TimelineInitialDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineInitialDateProvider.swift; sourceTree = "<group>"; };
 		4BCB2D1F3BD02A806D947C18 /* Pods-TogglDesktop-AppStore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TogglDesktop-AppStore.release.xcconfig"; path = "Target Support Files/Pods-TogglDesktop-AppStore/Pods-TogglDesktop-AppStore.release.xcconfig"; sourceTree = "<group>"; };
 		523FD02C959288FBFA20F5B1 /* Pods-TogglDesktop-AppStore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TogglDesktop-AppStore.debug.xcconfig"; path = "Target Support Files/Pods-TogglDesktop-AppStore/Pods-TogglDesktop-AppStore.debug.xcconfig"; sourceTree = "<group>"; };
 		5F76040E605C5D6E37B6F73B /* Pods_TogglDesktop_AppStore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TogglDesktop_AppStore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1684,6 +1686,7 @@
 				BA5E988C23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.xib */,
 				BAA3107123CC476D008F2893 /* LayerBackedViewController.swift */,
 				BAB5FFD323F13F75003781D3 /* TimelineDraggingSession.swift */,
+				492F5F01248550F800FFEC70 /* TimelineInitialDateProvider.swift */,
 			);
 			path = Timeline;
 			sourceTree = "<group>";
@@ -2622,6 +2625,7 @@
 				BA4791F522F0478A00E24F79 /* NSView+Ext.swift in Sources */,
 				BA01404A22570893000E5B91 /* Tag.swift in Sources */,
 				BA75FF3322BCC58000D3F08C /* TimelineActivity.swift in Sources */,
+				492F5F02248550F800FFEC70 /* TimelineInitialDateProvider.swift in Sources */,
 				BAB818E9228D5A97008C2367 /* DescriptionContentCellView.swift in Sources */,
 				BA6F1B3821EEE998009265E4 /* Theme+Notification.swift in Sources */,
 				7430750418204EFB009019CB /* AboutWindowController.m in Sources */,


### PR DESCRIPTION
### 📒 Description
Saving last usage date - when was the last time when the user was working with Timeline screen.
Comparing the saved date with the current day to see if day has passed.

E.g., save that user was working with the app on Monday. Next time when showing Timeline screen check that the day has passed and set the new date for context.

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)

### 👫 Relationships
Closes #4080 

### 🔎 Review hints
Covered use cases:

**Case 1:**
1. Hide app
2. Wait for next day
3. Open app
_Result: timeline shows next (current) day_

**Case 2:**
1. Choose previous (or any other) day on Timeline
2. Hide app
3. Wait for next day
4. Open app
_Result: timeline shows next (current) day_

**Case 3:**
1. Choose previous (or any other) day on Timeline
2. Hide app
3. Open on the same day
_Result: timeline shows the same day - nothing changed_

**Case 4:**
1. Monday
2. Timeline is visible and app is active
3. 00:00 happens
_Result: Timeline stays on Monday, so not to confuse user with this automatic switching while he is working with the timeline_

**Case 5:**
1. Case 4 plus next steps
2. Hide app
3. Open again
_Result: Timeline shows Monday because last time (this day) user was working with Monday timeline. We redirect the user to current day only if we detect that last time he was working with the app day before (or more)_

**Case 6:**
1. Monday
2. Timeline is invisible. User is on List
3. 00:00 happens
4. User switches to Timeline
_Result: Timeline shows Tuesday (new current day)_