### PR TITLE
Add properties to data models 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(TogglDesktop)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # Set up automatic resource generation to make Qt development easier
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/context.cc
+++ b/src/context.cc
@@ -2708,7 +2708,7 @@ error Context::SetLoggedInUserFromJSON(
     User *user = new User();
 
     // Determine if it's a new user for onboarding check
-    user->IsNewUser = isSignup;
+    user->IsNewUser.Set(isSignup);
 
     err = db()->LoadUserByID(userID, user);
     if (err != noError) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -691,7 +691,7 @@ void Context::updateUI(const UIElements &what) {
                 TimeEntry *te = time_entries[i];
 
                 std::string date_header =
-                    toggl::Formatter::FormatDateHeader(te->Start());
+                    toggl::Formatter::FormatDateHeader(te->StartTime());
 
                 // Calculate total duration for each date:
                 // will be displayed in date header
@@ -880,7 +880,7 @@ void Context::updateUI(const UIElements &what) {
                     continue;
                 }
 
-                Poco::LocalDateTime te_date(Poco::Timestamp::fromEpochTime(te->Start()));
+                Poco::LocalDateTime te_date(Poco::Timestamp::fromEpochTime(te->StartTime()));
                 if (te_date.year() == UI()->TimelineDateAt().year()
                         && te_date.month() == UI()->TimelineDateAt().month()
                         && te_date.day() == UI()->TimelineDateAt().day()) {
@@ -3285,7 +3285,7 @@ error Context::SetTimeEntryDate(
             Poco::Timestamp::fromEpochTime(unix_timestamp));
 
         Poco::LocalDateTime time_part(
-            Poco::Timestamp::fromEpochTime(te->Start()));
+            Poco::Timestamp::fromEpochTime(te->StartTime()));
 
         // Validate date input
         if (date_part.year() < kMinimumAllowedYear || date_part.year() > kMaximumAllowedYear) {
@@ -3374,7 +3374,7 @@ error Context::SetTimeEntryStart(
         }
     }
 
-    Poco::LocalDateTime local(Poco::Timestamp::fromEpochTime(te->Start()));
+    Poco::LocalDateTime local(Poco::Timestamp::fromEpochTime(te->StartTime()));
 
     // Validate time input
     if (local.year() < kMinimumAllowedYear || local.year() > kMaximumAllowedYear) {
@@ -3466,7 +3466,7 @@ error Context::SetTimeEntryStop(
     }
 
     Poco::LocalDateTime stop(
-        Poco::Timestamp::fromEpochTime(te->Stop()));
+        Poco::Timestamp::fromEpochTime(te->StopTime()));
 
     int hours(0), minutes(0);
     if (!toggl::Formatter::ParseTimeInput(value, &hours, &minutes)) {
@@ -3483,7 +3483,7 @@ error Context::SetTimeEntryStop(
 // but is not less than start by hour & minute, then
 // assume that the end must be on same date as start.
     Poco::LocalDateTime start(
-        Poco::Timestamp::fromEpochTime(te->Start()));
+        Poco::Timestamp::fromEpochTime(te->StartTime()));
     if (new_stop.day() != start.day()) {
         if (new_stop.hour() >= start.hour()) {
             new_stop = Poco::LocalDateTime(
@@ -4578,7 +4578,7 @@ void Context::displayPomodoro() {
                 return;
             }
         } else {
-            if (time(nullptr) - current_te->Start()
+            if (time(nullptr) - current_te->StartTime()
                     < settings_.pomodoro_minutes * 60) {
                 return;
             }
@@ -4593,7 +4593,7 @@ void Context::displayPomodoro() {
         wid = current_te->WID();
         Stop(true);
         current_te->SetDurationInSeconds(pomodoroDuration);
-        current_te->SetStop(current_te->Start() + pomodoroDuration);
+        current_te->SetStopTime(current_te->StartTime() + pomodoroDuration);
     }
     UI()->DisplayPomodoro(settings_.pomodoro_minutes);
 
@@ -4637,14 +4637,14 @@ void Context::displayPomodoroBreak() {
             return;
         }
 
-        if (time(nullptr) - current_te->Start()
+        if (time(nullptr) - current_te->StartTime()
                 < settings_.pomodoro_break_minutes * 60) {
             return;
         }
         const Poco::Int64 pomodoroDuration = settings_.pomodoro_break_minutes * 60;
         Stop(true);
         current_te->SetDurationInSeconds(pomodoroDuration);
-        current_te->SetStop(current_te->Start() + pomodoroDuration);
+        current_te->SetStopTime(current_te->StartTime() + pomodoroDuration);
     }
     pomodoro_break_entry_ = nullptr;
 
@@ -5916,7 +5916,7 @@ error Context::syncPull(
 }
 
 bool Context::isTimeEntryLocked(TimeEntry* te) {
-    return isTimeLockedInWorkspace(te->Start(),
+    return isTimeLockedInWorkspace(te->StartTime(),
                                    user_->related.WorkspaceByID(te->WID()));
 }
 
@@ -5925,7 +5925,7 @@ bool Context::canChangeStartTimeTo(TimeEntry* te, time_t t) {
 }
 
 bool Context::canChangeProjectTo(TimeEntry* te, Project* p) {
-    return !isTimeLockedInWorkspace(te->Start(),
+    return !isTimeLockedInWorkspace(te->StartTime(),
                                     user_->related.WorkspaceByID(p->WID()));
 }
 
@@ -6556,7 +6556,7 @@ bool Context::checkIfSkipPomodoro(TimeEntry *te) {
     if (settings_.pomodoro) {
         TimeEntry *current_te = user_->RunningTimeEntry();
         if (current_te && current_te->GUID().compare(te->GUID()) == 0) {
-            if (time(nullptr) - te->Start() >= settings_.pomodoro_minutes * 60) {
+            if (time(nullptr) - te->StartTime() >= settings_.pomodoro_minutes * 60) {
                 return true;
             }
         }

--- a/src/context.cc
+++ b/src/context.cc
@@ -1530,7 +1530,7 @@ error Context::downloadUpdate() {
                     kDownloadStatusStarted);
             }
 
-            std::auto_ptr<std::istream> stream(
+            std::unique_ptr<std::istream> stream(
                 Poco::URIStreamOpener::defaultOpener().open(uri));
             Poco::FileOutputStream fos(file, std::ios::binary);
             Poco::StreamCopier::copyStream(*stream.get(), fos);

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -1934,11 +1934,11 @@ error Database::loadTimeEntriesFromSQLStatement(
                 } else {
                     model->SetUIModifiedAt(rs[10].convert<Poco::Int64>());
                 }
-                model->SetStart(rs[11].convert<Poco::Int64>());
+                model->SetStartTime(rs[11].convert<Poco::Int64>());
                 if (rs[12].isEmpty()) {
-                    model->SetStop(0);
+                    model->SetStopTime(0);
                 } else {
-                    model->SetStop(rs[12].convert<Poco::Int64>());
+                    model->SetStopTime(rs[12].convert<Poco::Int64>());
                 }
                 model->SetDurationInSeconds(rs[13].convert<Poco::Int64>());
                 if (rs[14].isEmpty()) {
@@ -2091,8 +2091,8 @@ error Database::saveModel(
                           useRef(model->Billable()),
                           useRef(model->DurOnly()),
                           useRef(model->UIModifiedAt()),
-                          useRef(model->Start()),
-                          useRef(model->Stop()),
+                          useRef(model->StartTime()),
+                          useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
                           useRef(model->Tags()),
                           useRef(model->CreatedWith()),
@@ -2126,8 +2126,8 @@ error Database::saveModel(
                           useRef(model->Billable()),
                           useRef(model->DurOnly()),
                           useRef(model->UIModifiedAt()),
-                          useRef(model->Start()),
-                          useRef(model->Stop()),
+                          useRef(model->StartTime()),
+                          useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
                           useRef(model->Tags()),
                           useRef(model->CreatedWith()),
@@ -2181,8 +2181,8 @@ error Database::saveModel(
                           useRef(model->Billable()),
                           useRef(model->DurOnly()),
                           useRef(model->UIModifiedAt()),
-                          useRef(model->Start()),
-                          useRef(model->Stop()),
+                          useRef(model->StartTime()),
+                          useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
                           useRef(model->Tags()),
                           useRef(model->CreatedWith()),
@@ -2215,8 +2215,8 @@ error Database::saveModel(
                           useRef(model->Billable()),
                           useRef(model->DurOnly()),
                           useRef(model->UIModifiedAt()),
-                          useRef(model->Start()),
-                          useRef(model->Stop()),
+                          useRef(model->StartTime()),
+                          useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
                           useRef(model->Tags()),
                           useRef(model->CreatedWith()),
@@ -2936,7 +2936,7 @@ error Database::saveModel(
                               useRef(model->Color()),
                               useRef(model->CID()),
                               useRef(model->Active()),
-                              useRef(model->IsPrivate()),
+                              useRef(model->Private()),
                               useRef(model->Billable()),
                               useRef(model->ClientGUID()),
                               now;
@@ -2959,7 +2959,7 @@ error Database::saveModel(
                               useRef(model->Color()),
                               useRef(model->CID()),
                               useRef(model->Active()),
-                              useRef(model->IsPrivate()),
+                              useRef(model->Private()),
                               useRef(model->Billable()),
                               useRef(model->ClientGUID()),
                               now;
@@ -2980,7 +2980,7 @@ error Database::saveModel(
                               useRef(model->Color()),
                               useRef(model->CID()),
                               useRef(model->Active()),
-                              useRef(model->IsPrivate()),
+                              useRef(model->Private()),
                               useRef(model->Billable()),
                               useRef(model->ClientGUID()),
                               now;
@@ -3002,7 +3002,7 @@ error Database::saveModel(
                               useRef(model->Color()),
                               useRef(model->CID()),
                               useRef(model->Active()),
-                              useRef(model->IsPrivate()),
+                              useRef(model->Private()),
                               useRef(model->Billable()),
                               useRef(model->ClientGUID()),
                               now;

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -1799,7 +1799,7 @@ error Database::loadTimelineEvents(
                 if (!rs[2].isEmpty()) {
                     model->SetFilename(rs[2].convert<std::string>());
                 }
-                model->SetStart(rs[3].convert<int>());
+                model->SetStartTime(rs[3].convert<int>());
                 if (!rs[4].isEmpty()) {
                     model->SetEndTime(rs[4].convert<int>());
                 }

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -36,19 +36,19 @@ void TimeEntry::Fill(toggl::TimeEntry * const model) {
     WID = model->WID();
     TID = model->TID();
     PID = model->PID();
-    Started = model->Start();
-    Ended = model->Stop();
+    Started = model->StartTime();
+    Ended = model->StopTime();
     StartTimeString =
         toggl::Formatter::FormatTimeForTimeEntryEditor(
-            model->Start());
+            model->StartTime());
     EndTimeString =
         toggl::Formatter::FormatTimeForTimeEntryEditor(
-            model->Stop());
+            model->StopTime());
     Billable = model->Billable();
     Tags = model->Tags();
     UpdatedAt = model->UpdatedAt();
     DateHeader =
-        toggl::Formatter::FormatDateHeader(model->Start());
+        toggl::Formatter::FormatDateHeader(model->StartTime());
     DurOnly = model->DurOnly();
     Error = model->ValidationError();
     Unsynced = model->Unsynced();

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -665,7 +665,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -729,7 +729,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -784,7 +784,7 @@
 		C55DA5AA17F06A3B00B42178 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
@@ -824,7 +824,7 @@
 		C55DA5AB17F06A3B00B42178 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -456,6 +456,7 @@
     <ClInclude Include="..\..\..\database\migrations.h" />
     <ClInclude Include="..\..\..\netconf.h" />
     <ClInclude Include="..\..\..\model\obm_action.h" />
+    <ClInclude Include="..\..\..\util\property.h" />
     <ClInclude Include="..\..\..\util\random.h" />
     <ClInclude Include="..\..\..\util\rectangle.h" />
     <ClInclude Include="..\..\..\toggl_api.h" />

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
@@ -165,10 +165,10 @@
     <ClInclude Include="..\..\..\model\settings.h">
       <Filter>Header Files\model</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\onboarding_service.h">
+    <ClInclude Include="..\..\..\color_convert.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\cpptime.h">
+    <ClInclude Include="..\..\..\util\property.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -294,6 +294,15 @@
       <Filter>Source Files\model</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\onboarding_service.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\onboarding_service.h">
+      <Filter>Header Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\cpptime.h">
+      <Filter>Header Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\color_convert.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/model/autotracker.cc
+++ b/src/model/autotracker.cc
@@ -10,46 +10,34 @@
 namespace toggl {
 
 bool AutotrackerRule::Matches(const TimelineEvent &event) const {
-    if (Poco::UTF8::toLower(event.Filename()).find(term_)
+    if (Poco::UTF8::toLower(event.Filename()).find(Term())
             != std::string::npos) {
         return true;
     }
-    if (Poco::UTF8::toLower(event.Title()).find(term_)
+    if (Poco::UTF8::toLower(event.Title()).find(Term())
             != std::string::npos) {
         return true;
     }
     return false;
 }
 
-const std::string &AutotrackerRule::Term() const {
-    return term_;
-}
-
 void AutotrackerRule::SetTerm(const std::string &value) {
-    if (term_ != value) {
-        term_ = value;
+    if (Term() != value) {
+        Term.Set(value);
         SetDirty();
     }
-}
-
-const Poco::UInt64 &AutotrackerRule::PID() const {
-    return pid_;
 }
 
 void AutotrackerRule::SetPID(const Poco::UInt64 value) {
-    if (pid_ != value) {
-        pid_ = value;
+    if (PID()  != value) {
+        PID.Set(value);
         SetDirty();
     }
 }
 
-const Poco::UInt64 &AutotrackerRule::TID() const {
-    return tid_;
-}
-
 void AutotrackerRule::SetTID(const Poco::UInt64 value) {
-    if (tid_ != value) {
-        tid_ = value;
+    if (TID() != value) {
+        TID.Set(value);
         SetDirty();
     }
 }
@@ -57,10 +45,10 @@ void AutotrackerRule::SetTID(const Poco::UInt64 value) {
 std::string AutotrackerRule::String() const {
     std::stringstream ss;
     ss << " local_id=" << LocalID()
-       << " term=" << term_
+       << " term=" << Term()
        << " uid=" << UID()
-       << " pid=" << pid_
-       << " tid=" << tid_;
+       << " pid=" << PID()
+       << " tid=" << TID();
     return ss.str();
 }
 

--- a/src/model/autotracker.cc
+++ b/src/model/autotracker.cc
@@ -28,14 +28,14 @@ void AutotrackerRule::SetTerm(const std::string &value) {
     }
 }
 
-void AutotrackerRule::SetPID(const Poco::UInt64 value) {
+void AutotrackerRule::SetPID(Poco::UInt64 value) {
     if (PID()  != value) {
         PID.Set(value);
         SetDirty();
     }
 }
 
-void AutotrackerRule::SetTID(const Poco::UInt64 value) {
+void AutotrackerRule::SetTID(Poco::UInt64 value) {
     if (TID() != value) {
         TID.Set(value);
         SetDirty();

--- a/src/model/autotracker.h
+++ b/src/model/autotracker.h
@@ -16,34 +16,23 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  public:
-    AutotrackerRule()
-        : BaseModel()
-    , term_("")
-    , pid_(0)
-    , tid_(0) {}
-
+    AutotrackerRule() : BaseModel() {}
     virtual ~AutotrackerRule() {}
+
+    Property<std::string> Term { "" };
+    Property<Poco::UInt64> PID { 0 };
+    Property<Poco::UInt64> TID { 0 };
 
     bool Matches(const TimelineEvent &event) const;
 
-    const std::string &Term() const;
     void SetTerm(const std::string &value);
-
-    const Poco::UInt64 &PID() const;
     void SetPID(const Poco::UInt64 value);
-
-    const Poco::UInt64 &TID() const;
     void SetTID(const Poco::UInt64 value);
 
     // Override BaseModel
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-
- private:
-    std::string term_;
-    Poco::UInt64 pid_;
-    Poco::UInt64 tid_;
 };
 
 };  // namespace toggl

--- a/src/model/autotracker.h
+++ b/src/model/autotracker.h
@@ -26,8 +26,8 @@ class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
     bool Matches(const TimelineEvent &event) const;
 
     void SetTerm(const std::string &value);
-    void SetPID(const Poco::UInt64 value);
-    void SetTID(const Poco::UInt64 value);
+    void SetPID(Poco::UInt64 value);
+    void SetTID(Poco::UInt64 value);
 
     // Override BaseModel
     std::string String() const override;

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -27,25 +27,25 @@ bool BaseModel::NeedsPush() const {
 
 bool BaseModel::NeedsPOST() const {
     // No server side ID yet, meaning it's not POSTed yet
-    return !id_ && !(deleted_at_ > 0);
+    return !ID() && !(DeletedAt() > 0);
 }
 
 bool BaseModel::NeedsPUT() const {
     // Model has been updated and is not deleted, needs a PUT
-    return id_ && ui_modified_at_ > 0 && !(deleted_at_ > 0);
+    return ID() && UIModifiedAt() > 0 && !(DeletedAt() > 0);
 }
 
 bool BaseModel::NeedsDELETE() const {
     // Model is deleted, needs a DELETE on server side
-    return id_ && (deleted_at_ > 0);
+    return ID() && (DeletedAt() > 0);
 }
 
 bool BaseModel::NeedsToBeSaved() const {
-    return !local_id_ || dirty_;
+    return !LocalID() || Dirty();
 }
 
 void BaseModel::EnsureGUID() {
-    if (!guid_.empty()) {
+    if (!GUID().empty()) {
         return;
     }
     SetGUID(Database::GenerateGUID());
@@ -56,56 +56,17 @@ void BaseModel::ClearValidationError() {
 }
 
 void BaseModel::SetValidationError(const std::string &value) {
-    if (validation_error_ != value) {
-        validation_error_ = value;
-        SetDirty();
-    }
-}
-
-void BaseModel::SetDeletedAt(const Poco::Int64 value) {
-    if (deleted_at_ != value) {
-        deleted_at_ = value;
-        SetDirty();
-    }
-}
-
-void BaseModel::SetUpdatedAt(const Poco::Int64 value) {
-    if (updated_at_ != value) {
-        updated_at_ = value;
-        SetDirty();
-    }
-}
-
-void BaseModel::SetGUID(const std::string &value) {
-    if (guid_ != value) {
-        guid_ = value;
-        SetDirty();
-    }
-}
-
-void BaseModel::SetUIModifiedAt(const Poco::Int64 value) {
-    if (ui_modified_at_ != value) {
-        ui_modified_at_ = value;
-        SetDirty();
-    }
-}
-
-void BaseModel::SetUID(const Poco::UInt64 value) {
-    if (uid_ != value) {
-        uid_ = value;
-        SetDirty();
-    }
-}
-
-void BaseModel::SetID(const Poco::UInt64 value) {
-    if (id_ != value) {
-        id_ = value;
-        SetDirty();
-    }
+    ValidationError.Set(value);
+    SetDirty();
 }
 
 void BaseModel::SetUpdatedAtString(const std::string &value) {
     SetUpdatedAt(Formatter::Parse8601(value));
+}
+
+void BaseModel::MarkAsDeletedOnServer() {
+    IsMarkedAsDeletedOnServer.Set(true);
+    SetDirty();
 }
 
 error BaseModel::LoadFromDataString(const std::string &data_string) {
@@ -200,12 +161,50 @@ Logger BaseModel::logger() const {
     return { ModelName() };
 }
 
+void BaseModel::SetID(const Poco::UInt64 value) {
+    ID.Set(value);
+    SetDirty();
+}
+
+void BaseModel::SetUIModifiedAt(const Poco::Int64 value) {
+    UIModifiedAt.Set(value);
+    SetDirty();
+}
+
+void BaseModel::SetGUID(const std::string &value) {
+    GUID.Set(value);
+    SetDirty();
+}
+
+void BaseModel::SetUID(const Poco::UInt64 value) {
+    UID.Set(value);
+    SetDirty();
+}
+
 void BaseModel::SetDirty() {
-    dirty_ = true;
+    Dirty.Set(true);
+}
+
+void BaseModel::ClearDirty() {
+    Dirty.Set(false);
 }
 
 void BaseModel::SetUnsynced() {
-    unsynced_ = true;
+    Unsynced.Set(true);
+}
+
+void BaseModel::ClearUnsynced() {
+    Unsynced.Set(false);
+}
+
+void BaseModel::SetDeletedAt(const Poco::Int64 value) {
+    DeletedAt.Set(value);
+    SetDirty();
+}
+
+void BaseModel::SetUpdatedAt(const Poco::Int64 value) {
+    UpdatedAt.Set(value);
+    SetDirty();
 }
 
 }   // namespace toggl

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -161,12 +161,12 @@ Logger BaseModel::logger() const {
     return { ModelName() };
 }
 
-void BaseModel::SetID(const Poco::UInt64 value) {
+void BaseModel::SetID(Poco::UInt64 value) {
     ID.Set(value);
     SetDirty();
 }
 
-void BaseModel::SetUIModifiedAt(const Poco::Int64 value) {
+void BaseModel::SetUIModifiedAt(Poco::Int64 value) {
     UIModifiedAt.Set(value);
     SetDirty();
 }
@@ -176,7 +176,7 @@ void BaseModel::SetGUID(const std::string &value) {
     SetDirty();
 }
 
-void BaseModel::SetUID(const Poco::UInt64 value) {
+void BaseModel::SetUID(Poco::UInt64 value) {
     UID.Set(value);
     SetDirty();
 }
@@ -197,12 +197,12 @@ void BaseModel::ClearUnsynced() {
     Unsynced.Set(false);
 }
 
-void BaseModel::SetDeletedAt(const Poco::Int64 value) {
+void BaseModel::SetDeletedAt(Poco::Int64 value) {
     DeletedAt.Set(value);
     SetDirty();
 }
 
-void BaseModel::SetUpdatedAt(const Poco::Int64 value) {
+void BaseModel::SetUpdatedAt(Poco::Int64 value) {
     UpdatedAt.Set(value);
     SetDirty();
 }

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -13,6 +13,7 @@
 #include "const.h"
 #include "types.h"
 #include "util/logger.h"
+#include "util/property.h"
 
 #include <Poco/Types.h>
 
@@ -22,77 +23,52 @@ class BatchUpdateResult;
 
 class TOGGL_INTERNAL_EXPORT BaseModel {
  public:
-    BaseModel()
-        : local_id_(0)
-    , id_(0)
-    , guid_("")
-    , ui_modified_at_(0)
-    , uid_(0)
-    , dirty_(false)
-    , deleted_at_(0)
-    , is_marked_as_deleted_on_server_(false)
-    , updated_at_(0)
-    , validation_error_("")
-    , unsynced_(false) {}
-
+    BaseModel() {}
     virtual ~BaseModel() {}
 
-    const Poco::Int64 &LocalID() const {
-        return local_id_;
-    }
-    void SetLocalID(const Poco::Int64 value) {
-        local_id_ = value;
-    }
+    Property<Poco::Int64> LocalID { 0 };
+    Property<Poco::UInt64> ID { 0 };
+    Property<guid> GUID { "" };
+    Property<Poco::Int64> UIModifiedAt { 0 };
+    Property<Poco::UInt64> UID { 0 };
+    Property<bool> Dirty { false };
+    Property<Poco::Int64> DeletedAt { 0 };
+    Property<bool> IsMarkedAsDeletedOnServer { false };
+    Property<Poco::Int64> UpdatedAt { 0 };
 
-    const Poco::UInt64 &ID() const {
-        return id_;
+    // If model push to backend results in an error,
+    // the error is attached to the model for later inspection.
+    Property<std::string> ValidationError { "" };
+
+    // Flag is set only when sync fails.
+    // Its for viewing purposes only. It should not
+    // be used to check if a model needs to be
+    // pushed to backend. It only means that some
+    // attempt to push failed somewhere.
+    Property<bool> Unsynced { false };
+
+    void SetLocalID(const Poco::Int64 value) {
+        LocalID.Set(value);
     }
     void SetID(const Poco::UInt64 value);
-
-    const Poco::Int64 &UIModifiedAt() const {
-        return ui_modified_at_;
-    }
     void SetUIModifiedAt(const Poco::Int64 value);
     void SetUIModified() {
         SetUIModifiedAt(time(nullptr));
     }
 
-    const std::string &GUID() const {
-        return guid_;
-    }
     void SetGUID(const std::string &value);
-
-    const Poco::UInt64 &UID() const {
-        return uid_;
-    }
     void SetUID(const Poco::UInt64 value);
 
     void SetDirty();
-    const bool &Dirty() const {
-        return dirty_;
-    }
-    void ClearDirty() {
-        dirty_ = false;
-    }
+    void ClearDirty();
 
-    const bool &Unsynced() const {
-        return unsynced_;
-    }
     void SetUnsynced();
-    void ClearUnsynced() {
-        unsynced_ = false;
-    }
+    void ClearUnsynced();
 
     // Deleting a time entry hides it from
     // UI and flags it for removal from server:
-    const Poco::Int64 &DeletedAt() const {
-        return deleted_at_;
-    }
     void SetDeletedAt(const Poco::Int64 value);
 
-    const Poco::Int64 &UpdatedAt() const {
-        return updated_at_;
-    }
     void SetUpdatedAt(const Poco::Int64 value);
 
     std::string UpdatedAtString() const;
@@ -101,13 +77,7 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     // When a model is deleted
     // on server, it will be removed from local
     // DB using this flag:
-    bool IsMarkedAsDeletedOnServer() const {
-        return is_marked_as_deleted_on_server_;
-    }
-    void MarkAsDeletedOnServer() {
-        is_marked_as_deleted_on_server_ = true;
-        SetDirty();
-    }
+    void MarkAsDeletedOnServer();
 
     bool NeedsPush() const;
     bool NeedsPOST() const;
@@ -120,9 +90,6 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
 
     void ClearValidationError();
     void SetValidationError(const std::string &value);
-    const std::string &ValidationError() const {
-        return validation_error_;
-    }
 
     virtual std::string String() const = 0;
     virtual std::string ModelName() const = 0;
@@ -160,27 +127,6 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
  private:
     std::string batchUpdateRelativeURL() const;
     std::string batchUpdateMethod() const;
-
-    Poco::Int64 local_id_;
-    Poco::UInt64 id_;
-    guid guid_;
-    Poco::Int64 ui_modified_at_;
-    Poco::UInt64 uid_;
-    bool dirty_;
-    Poco::Int64 deleted_at_;
-    bool is_marked_as_deleted_on_server_;
-    Poco::Int64 updated_at_;
-
-    // If model push to backend results in an error,
-    // the error is attached to the model for later inspection.
-    std::string validation_error_;
-
-    // Flag is set only when sync fails.
-    // Its for viewing purposes only. It should not
-    // be used to check if a model needs to be
-    // pushed to backend. It only means that some
-    // attempt to push failed somewhere.
-    bool unsynced_;
 };
 
 }  // namespace toggl

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -47,17 +47,17 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     // attempt to push failed somewhere.
     Property<bool> Unsynced { false };
 
-    void SetLocalID(const Poco::Int64 value) {
+    void SetLocalID(Poco::Int64 value) {
         LocalID.Set(value);
     }
-    void SetID(const Poco::UInt64 value);
-    void SetUIModifiedAt(const Poco::Int64 value);
+    void SetID(Poco::UInt64 value);
+    void SetUIModifiedAt(Poco::Int64 value);
     void SetUIModified() {
         SetUIModifiedAt(time(nullptr));
     }
 
     void SetGUID(const std::string &value);
-    void SetUID(const Poco::UInt64 value);
+    void SetUID(Poco::UInt64 value);
 
     void SetDirty();
     void ClearDirty();
@@ -67,9 +67,9 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
 
     // Deleting a time entry hides it from
     // UI and flags it for removal from server:
-    void SetDeletedAt(const Poco::Int64 value);
+    void SetDeletedAt(Poco::Int64 value);
 
-    void SetUpdatedAt(const Poco::Int64 value);
+    void SetUpdatedAt(Poco::Int64 value);
 
     std::string UpdatedAtString() const;
     void SetUpdatedAtString(const std::string &value);

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -25,22 +25,22 @@ std::string Client::String() const {
     std::stringstream ss;
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
-        << " name=" << name_
-        << " wid=" << wid_
+        << " name=" << Name()
+        << " wid=" << WID()
         << " guid=" << GUID();
     return ss.str();
 }
 
 void Client::SetName(const std::string &value) {
-    if (name_ != value) {
-        name_ = value;
+    if (Name() != value) {
+        Name.Set(value);
         SetDirty();
     }
 }
 
 void Client::SetWID(const Poco::UInt64 value) {
-    if (wid_ != value) {
-        wid_ = value;
+    if (WID() != value) {
+        WID.Set(value);
         SetDirty();
     }
 }

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -38,7 +38,7 @@ void Client::SetName(const std::string &value) {
     }
 }
 
-void Client::SetWID(const Poco::UInt64 value) {
+void Client::SetWID(Poco::UInt64 value) {
     if (WID() != value) {
         WID.Set(value);
         SetDirty();

--- a/src/model/client.h
+++ b/src/model/client.h
@@ -17,19 +17,12 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
  public:
-    Client()
-        : BaseModel()
-    , wid_(0)
-    , name_("") {}
+    Client() : BaseModel() {}
 
-    const Poco::UInt64 &WID() const {
-        return wid_;
-    }
-    void SetWID(const Poco::UInt64 value);
+    Property<Poco::UInt64> WID { 0 };
+    Property<std::string> Name { "" };
 
-    const std::string &Name() const {
-        return name_;
-    }
+    void SetWID(Poco::UInt64 value);
     void SetName(const std::string &value);
 
     // Override BaseModel
@@ -42,9 +35,6 @@ class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
     bool ResourceCannotBeCreated(const toggl::error &err) const override;
 
  private:
-    Poco::UInt64 wid_;
-    std::string name_;
-
     static bool nameHasAlreadyBeenTaken(const error &err);
 };
 

--- a/src/model/obm_action.cc
+++ b/src/model/obm_action.cc
@@ -12,29 +12,29 @@ std::string ObmAction::String() const {
     std::stringstream ss;
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
-        << " experiment_id=" << experiment_id_
-        << " key=" << key_
-        << " value=" << value_;
+        << " experiment_id=" << ExperimentID()
+        << " key=" << Key()
+        << " value=" << Value();
     return ss.str();
 }
 
 void ObmAction::SetExperimentID(const Poco::UInt64 value) {
-    if (experiment_id_ != value) {
-        experiment_id_ = value;
+    if (ExperimentID() != value) {
+        ExperimentID.Set(value);
         SetDirty();
     }
 }
 
 void ObmAction::SetKey(const std::string &value) {
-    if (key_ != value) {
-        key_ = value;
+    if (Key() != value) {
+        Key.Set(value);
         SetDirty();
     }
 }
 
 void ObmAction::SetValue(const std::string &value) {
-    if (value_ != value) {
-        value_ = value;
+    if (Value() != value) {
+        Value.Set(value);
         SetDirty();
     }
 }
@@ -59,37 +59,37 @@ std::string ObmExperiment::String() const {
     std::stringstream ss;
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
-        << " nr=" << nr_
-        << " has seen=" << has_seen_
-        << " included=" << included_
-        << " actions=" << actions_;
+        << " nr=" << Nr()
+        << " has seen=" << HasSeen()
+        << " included=" << Included()
+        << " actions=" << Actions();
     return ss.str();
 }
 
 void ObmExperiment::SetNr(const Poco::UInt64 value) {
-    if (nr_ != value) {
-        nr_ = value;
+    if (Nr() != value) {
+        Nr.Set(value);
         SetDirty();
     }
 }
 
 void ObmExperiment::SetHasSeen(const bool value) {
-    if (has_seen_ != value) {
-        has_seen_ = value;
+    if (HasSeen() != value) {
+        HasSeen.Set(value);
         SetDirty();
     }
 }
 
 void ObmExperiment::SetIncluded(const bool value) {
-    if (included_ != value) {
-        included_ = value;
+    if (Included() != value) {
+        Included.Set(value);
         SetDirty();
     }
 }
 
 void ObmExperiment::SetActions(const std::string &value) {
-    if (actions_ != value) {
-        actions_ = value;
+    if (Actions() != value) {
+        Actions.Set(value);
         SetDirty();
     }
 }

--- a/src/model/obm_action.cc
+++ b/src/model/obm_action.cc
@@ -18,7 +18,7 @@ std::string ObmAction::String() const {
     return ss.str();
 }
 
-void ObmAction::SetExperimentID(const Poco::UInt64 value) {
+void ObmAction::SetExperimentID(Poco::UInt64 value) {
     if (ExperimentID() != value) {
         ExperimentID.Set(value);
         SetDirty();
@@ -66,21 +66,21 @@ std::string ObmExperiment::String() const {
     return ss.str();
 }
 
-void ObmExperiment::SetNr(const Poco::UInt64 value) {
+void ObmExperiment::SetNr(Poco::UInt64 value) {
     if (Nr() != value) {
         Nr.Set(value);
         SetDirty();
     }
 }
 
-void ObmExperiment::SetHasSeen(const bool value) {
+void ObmExperiment::SetHasSeen(bool value) {
     if (HasSeen() != value) {
         HasSeen.Set(value);
         SetDirty();
     }
 }
 
-void ObmExperiment::SetIncluded(const bool value) {
+void ObmExperiment::SetIncluded(bool value) {
     if (Included() != value) {
         Included.Set(value);
         SetDirty();

--- a/src/model/obm_action.h
+++ b/src/model/obm_action.h
@@ -15,25 +15,14 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
  public:
-    ObmAction()
-        : BaseModel()
-    , experiment_id_(0)
-    , key_("")
-    , value_("") {}
+    ObmAction() : BaseModel() {}
 
-    const std::string &Key() const {
-        return key_;
-    }
+    Property<Poco::UInt64> ExperimentID { 0 };
+    Property<std::string> Key { "" };
+    Property<std::string> Value { "" };
+
     void SetKey(const std::string &value);
-
-    const std::string &Value() const {
-        return value_;
-    }
     void SetValue(const std::string &value);
-
-    const Poco::UInt64 &ExperimentID() const {
-        return experiment_id_;
-    }
     void SetExperimentID(const Poco::UInt64 value);
 
     // Override BaseModel
@@ -41,52 +30,26 @@ class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
     std::string ModelName() const override;
     std::string ModelURL() const override;
     Json::Value SaveToJSON() const override;
-
- private:
-    Poco::UInt64 experiment_id_;
-    std::string key_;
-    std::string value_;
 };
 
 class TOGGL_INTERNAL_EXPORT ObmExperiment : public BaseModel {
  public:
-    ObmExperiment()
-        : BaseModel()
-    , included_(false)
-    , nr_(0)
-    , has_seen_(false)
-    , actions_("") {}
+    ObmExperiment() : BaseModel() {}
 
-    const bool &Included() const {
-        return included_;
-    }
-    void SetIncluded(const bool value);
+    Property<std::string> Actions { "" };
+    Property<Poco::UInt64> Nr { 0 };
+    Property<bool> Included { false };
+    Property<bool> HasSeen { false };
 
-    const bool &HasSeen() const {
-        return has_seen_;
-    }
-    void SetHasSeen(const bool value);
-
-    const Poco::UInt64 &Nr() const {
-        return nr_;
-    }
-    void SetNr(const Poco::UInt64 value);
-
-    const std::string &Actions() const {
-        return actions_;
-    }
     void SetActions(const std::string &value);
+    void SetNr(const Poco::UInt64 value);
+    void SetIncluded(const bool value);
+    void SetHasSeen(const bool value);
 
     // Override BaseModel
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-
- private:
-    bool included_;
-    Poco::UInt64 nr_;
-    bool has_seen_;
-    std::string actions_;
 };
 
 }  // namespace toggl

--- a/src/model/obm_action.h
+++ b/src/model/obm_action.h
@@ -23,7 +23,7 @@ class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
 
     void SetKey(const std::string &value);
     void SetValue(const std::string &value);
-    void SetExperimentID(const Poco::UInt64 value);
+    void SetExperimentID(Poco::UInt64 value);
 
     // Override BaseModel
     std::string String() const override;
@@ -42,9 +42,9 @@ class TOGGL_INTERNAL_EXPORT ObmExperiment : public BaseModel {
     Property<bool> HasSeen { false };
 
     void SetActions(const std::string &value);
-    void SetNr(const Poco::UInt64 value);
-    void SetIncluded(const bool value);
-    void SetHasSeen(const bool value);
+    void SetNr(Poco::UInt64 value);
+    void SetIncluded(bool value);
+    void SetHasSeen(bool value);
 
     // Override BaseModel
     std::string String() const override;

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -30,63 +30,62 @@ std::string Project::String() const {
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
         << " guid=" << GUID()
-        << " name=" << name_
-        << " wid=" << wid_
-        << " cid=" << cid_
-        << " client_guid=" << client_guid_
-        << " active=" << active_
-        << " public=" << private_
-        << " color=" << color_
-        << " billable=" << billable_
-        << " client_guid=" << client_guid_;
+        << " name=" << Name()
+        << " wid=" << WID()
+        << " cid=" << CID()
+        << " client_guid=" << ClientGUID()
+        << " active=" << Active()
+        << " public=" << Private()
+        << " color=" << Color()
+        << " billable=" << Billable();
     return ss.str();
 }
 
 std::string Project::FullName() const {
     std::stringstream ss;
-    ss << client_name_
-       << name_;
+    ss << ClientName()
+       << Name();
     return ss.str();
 }
 
 void Project::SetClientGUID(const std::string &value) {
-    if (client_guid_ != value) {
-        client_guid_ = value;
+    if (ClientGUID() != value) {
+        ClientGUID.Set(value);
         SetDirty();
     }
 }
 
 void Project::SetActive(const bool value) {
-    if (active_ != value) {
-        active_ = value;
+    if (Active() != value) {
+        Active.Set(value);
         SetDirty();
     }
 }
 
 void Project::SetPrivate(const bool value) {
-    if (private_ != value) {
-        private_ = value;
+    if (Private() != value) {
+        Private.Set(value);
         SetDirty();
     }
 }
 
 void Project::SetName(const std::string &value) {
-    if (name_ != value) {
-        name_ = value;
+    if (Name() != value) {
+        Name.Set(value);
         SetDirty();
     }
 }
 
 void Project::SetBillable(const bool value) {
-    if (billable_ != value) {
-        billable_ = value;
+    if (Billable() != value) {
+        Billable.Set(value);
         SetDirty();
     }
 }
 
 void Project::SetColor(const std::string &value) {
-    if (color_ != value) {
-        color_ = Poco::UTF8::toLower(value);
+    if (Color() != value) {
+        Color.Set(Poco::UTF8::toLower(value));
         SetDirty();
     }
 }
@@ -105,22 +104,22 @@ error Project::SetColorCode(const std::string &color_code) {
 }
 
 void Project::SetWID(const Poco::UInt64 value) {
-    if (wid_ != value) {
-        wid_ = value;
+    if (WID() != value) {
+        WID.Set(value);
         SetDirty();
     }
 }
 
 void Project::SetCID(const Poco::UInt64 value) {
-    if (cid_ != value) {
-        cid_ = value;
+    if (CID() != value) {
+        CID.Set(value);
         SetDirty();
     }
 }
 
 void Project::SetClientName(const std::string &value) {
-    if (client_name_ != value) {
-        client_name_ = value;
+    if (ClientName() != value) {
+        ClientName.Set(value);
         SetDirty();
     }
 }
@@ -160,7 +159,7 @@ Json::Value Project::SaveToJSON() const {
     }
     // There is no way to set it in UI and free ws gets error when it's sent
     // n["billable"] = Billable();
-    n["is_private"] = IsPrivate();
+    n["is_private"] = Private();
     n["color"] = Poco::UTF8::toLower(Color());
     n["active"] = Active();
 
@@ -199,7 +198,7 @@ bool Project::ResolveError(const toggl::error &err) {
         SetCID(0);
         return true;
     }
-    if (!IsPrivate() && onlyAdminsCanChangeProjectVisibility(err)) {
+    if (!Private() && onlyAdminsCanChangeProjectVisibility(err)) {
         SetPrivate(true);
         return true;
     }

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -55,14 +55,14 @@ void Project::SetClientGUID(const std::string &value) {
     }
 }
 
-void Project::SetActive(const bool value) {
+void Project::SetActive(bool value) {
     if (Active() != value) {
         Active.Set(value);
         SetDirty();
     }
 }
 
-void Project::SetPrivate(const bool value) {
+void Project::SetPrivate(bool value) {
     if (Private() != value) {
         Private.Set(value);
         SetDirty();
@@ -76,7 +76,7 @@ void Project::SetName(const std::string &value) {
     }
 }
 
-void Project::SetBillable(const bool value) {
+void Project::SetBillable(bool value) {
     if (Billable() != value) {
         Billable.Set(value);
         SetDirty();
@@ -103,14 +103,14 @@ error Project::SetColorCode(const std::string &color_code) {
     return noError;
 }
 
-void Project::SetWID(const Poco::UInt64 value) {
+void Project::SetWID(Poco::UInt64 value) {
     if (WID() != value) {
         WID.Set(value);
         SetDirty();
     }
 }
 
-void Project::SetCID(const Poco::UInt64 value) {
+void Project::SetCID(Poco::UInt64 value) {
     if (CID() != value) {
         CID.Set(value);
         SetDirty();

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -15,66 +15,31 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
  public:
-    Project()
-        : BaseModel()
-    , wid_(0)
-    , cid_(0)
-    , name_("")
-    , color_("")
-    , active_(false)
-    , private_(false)
-    , billable_(false)
-    , client_guid_("")
-    , client_name_("") {}
+    Project() : BaseModel() {}
 
-    const Poco::UInt64 &WID() const {
-        return wid_;
-    }
+    Property<std::string> Name { "" };
+    Property<std::string> Color { "" };
+    Property<std::string> ClientGUID { "" };
+    Property<std::string> ClientName { "" };
+    Property<Poco::UInt64> WID { 0 };
+    Property<Poco::UInt64> CID { 0 };
+    Property<bool> Active { false };
+    Property<bool> Private { false };
+    Property<bool> Billable { false };
+
     void SetWID(const Poco::UInt64 value);
-
-    const Poco::UInt64 &CID() const {
-        return cid_;
-    }
     void SetCID(const Poco::UInt64 value);
-
-    const std::string &ClientGUID() const {
-        return client_guid_;
-    }
     void SetClientGUID(const std::string &);
+    void SetActive(const bool value);
+    void SetPrivate(const bool value);
+    void SetBillable(const bool value);
+    void SetClientName(const std::string &value);
 
-    const std::string &Name() const {
-        return name_;
-    }
-    void SetName(const std::string &value);
-
-    const std::string &Color() const {
-        return color_;
-    }
     void SetColor(const std::string &value);
-
     std::string ColorCode() const;
     error SetColorCode(const std::string &color_code);
 
-    const bool &Active() const {
-        return active_;
-    }
-    void SetActive(const bool value);
-
-    const bool &IsPrivate() const {
-        return private_;
-    }
-    void SetPrivate(const bool value);
-
-    const bool &Billable() const {
-        return billable_;
-    }
-    void SetBillable(const bool value);
-
-    const std::string &ClientName() const {
-        return client_name_;
-    }
-    void SetClientName(const std::string &value);
-
+    void SetName(const std::string &value);
     std::string FullName() const;
 
     // Override BaseModel
@@ -92,16 +57,6 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
  private:
     bool clientIsInAnotherWorkspace(const toggl::error &err) const;
     bool onlyAdminsCanChangeProjectVisibility(const toggl::error &err) const;
-
-    Poco::UInt64 wid_;
-    Poco::UInt64 cid_;
-    std::string name_;
-    std::string color_;
-    bool active_;
-    bool private_;
-    bool billable_;
-    std::string client_guid_;
-    std::string client_name_;
 };
 
 template<typename T, size_t N> T *end(T (&ra)[N]);

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -27,12 +27,12 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
     Property<bool> Private { false };
     Property<bool> Billable { false };
 
-    void SetWID(const Poco::UInt64 value);
-    void SetCID(const Poco::UInt64 value);
-    void SetClientGUID(const std::string &);
-    void SetActive(const bool value);
-    void SetPrivate(const bool value);
-    void SetBillable(const bool value);
+    void SetWID(Poco::UInt64 value);
+    void SetCID(Poco::UInt64 value);
+    void SetClientGUID(const std::string &value);
+    void SetActive(bool value);
+    void SetPrivate(bool value);
+    void SetBillable(bool value);
     void SetClientName(const std::string &value);
 
     void SetColor(const std::string &value);

--- a/src/model/tag.cc
+++ b/src/model/tag.cc
@@ -12,22 +12,22 @@ std::string Tag::String() const {
     std::stringstream ss;
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
-        << " name=" << name_
-        << " wid=" << wid_
+        << " name=" << Name()
+        << " wid=" << WID()
         << " guid=" << GUID();
     return ss.str();
 }
 
 void Tag::SetWID(const Poco::UInt64 value) {
-    if (wid_ != value) {
-        wid_ = value;
+    if (WID() != value) {
+        WID.Set(value);
         SetDirty();
     }
 }
 
 void Tag::SetName(const std::string &value) {
-    if (name_ != value) {
-        name_ = value;
+    if (Name() != value) {
+        Name.Set(value);
         SetDirty();
     }
 }

--- a/src/model/tag.cc
+++ b/src/model/tag.cc
@@ -18,7 +18,7 @@ std::string Tag::String() const {
     return ss.str();
 }
 
-void Tag::SetWID(const Poco::UInt64 value) {
+void Tag::SetWID(Poco::UInt64 value) {
     if (WID() != value) {
         WID.Set(value);
         SetDirty();

--- a/src/model/tag.h
+++ b/src/model/tag.h
@@ -19,7 +19,7 @@ class TOGGL_INTERNAL_EXPORT Tag : public BaseModel {
     Property<Poco::UInt64> WID { 0 };
 
     void SetName(const std::string &value);
-    void SetWID(const Poco::UInt64 value);
+    void SetWID(Poco::UInt64 value);
 
     // Override BaseModel
     std::string String() const override;

--- a/src/model/tag.h
+++ b/src/model/tag.h
@@ -13,30 +13,19 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT Tag : public BaseModel {
  public:
-    Tag()
-        : BaseModel()
-    , wid_(0)
-    , name_("") {}
+    Tag() : BaseModel() {}
 
-    const Poco::UInt64 &WID() const {
-        return wid_;
-    }
-    void SetWID(const Poco::UInt64 value);
+    Property<std::string> Name { "" };
+    Property<Poco::UInt64> WID { 0 };
 
-    const std::string &Name() const {
-        return name_;
-    }
     void SetName(const std::string &value);
+    void SetWID(const Poco::UInt64 value);
 
     // Override BaseModel
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
     void LoadFromJSON(Json::Value data) override;
-
- private:
-    Poco::UInt64 wid_;
-    std::string name_;
 };
 
 }  // namespace toggl

--- a/src/model/task.cc
+++ b/src/model/task.cc
@@ -16,14 +16,14 @@ std::string Task::String() const {
     return ss.str();
 }
 
-void Task::SetPID(const Poco::UInt64 value) {
+void Task::SetPID(Poco::UInt64 value) {
     if (PID() != value) {
         PID.Set(value);
         SetDirty();
     }
 }
 
-void Task::SetWID(const Poco::UInt64 value) {
+void Task::SetWID(Poco::UInt64 value) {
     if (WID() != value) {
         WID.Set(value);
         SetDirty();
@@ -37,7 +37,7 @@ void Task::SetName(const std::string &value) {
     }
 }
 
-void Task::SetActive(const bool value) {
+void Task::SetActive(bool value) {
     if (Active() != value) {
         Active.Set(value);
         SetDirty();

--- a/src/model/task.cc
+++ b/src/model/task.cc
@@ -10,36 +10,36 @@ std::string Task::String() const {
     std::stringstream ss;
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
-        << " name=" << name_
-        << " wid=" << wid_
-        << " pid=" << pid_;
+        << " name=" << Name()
+        << " wid=" << WID()
+        << " pid=" << PID();
     return ss.str();
 }
 
 void Task::SetPID(const Poco::UInt64 value) {
-    if (pid_ != value) {
-        pid_ = value;
+    if (PID() != value) {
+        PID.Set(value);
         SetDirty();
     }
 }
 
 void Task::SetWID(const Poco::UInt64 value) {
-    if (wid_ != value) {
-        wid_ = value;
+    if (WID() != value) {
+        WID.Set(value);
         SetDirty();
     }
 }
 
 void Task::SetName(const std::string &value) {
-    if (name_ != value) {
-        name_ = value;
+    if (Name() != value) {
+        Name.Set(value);
         SetDirty();
     }
 }
 
 void Task::SetActive(const bool value) {
-    if (active_ != value) {
-        active_ = value;
+    if (Active() != value) {
+        Active.Set(value);
         SetDirty();
     }
 }

--- a/src/model/task.h
+++ b/src/model/task.h
@@ -15,31 +15,16 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT Task : public BaseModel {
  public:
-    Task()
-        : BaseModel()
-    , name_("")
-    , wid_(0)
-    , pid_(0)
-    , active_(false) {}
+    Task() : BaseModel() {}
 
-    const std::string &Name() const {
-        return name_;
-    }
+    Property<std::string> Name { "" };
+    Property<Poco::UInt64> WID { 0 };
+    Property<Poco::UInt64> PID { 0 };
+    Property<bool> Active { false };
+
     void SetName(const std::string &value);
-
-    const Poco::UInt64 &WID() const {
-        return wid_;
-    }
     void SetWID(const Poco::UInt64 value);
-
-    const Poco::UInt64 &PID() const {
-        return pid_;
-    }
     void SetPID(const Poco::UInt64 value);
-
-    const bool &Active() const {
-        return active_;
-    }
     void SetActive(const bool value);
 
     // Override BaseModel
@@ -47,12 +32,6 @@ class TOGGL_INTERNAL_EXPORT Task : public BaseModel {
     std::string ModelName() const override;
     std::string ModelURL() const override;
     void LoadFromJSON(Json::Value value) override;
-
- private:
-    std::string name_;
-    Poco::UInt64 wid_;
-    Poco::UInt64 pid_;
-    bool active_;
 };
 
 }  // namespace toggl

--- a/src/model/task.h
+++ b/src/model/task.h
@@ -23,9 +23,9 @@ class TOGGL_INTERNAL_EXPORT Task : public BaseModel {
     Property<bool> Active { false };
 
     void SetName(const std::string &value);
-    void SetWID(const Poco::UInt64 value);
-    void SetPID(const Poco::UInt64 value);
-    void SetActive(const bool value);
+    void SetWID(Poco::UInt64 value);
+    void SetPID(Poco::UInt64 value);
+    void SetActive(bool value);
 
     // Override BaseModel
     std::string String() const override;

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -29,23 +29,23 @@
 namespace toggl {
 
 bool TimeEntry::ResolveError(const error &err) {
-    if (durationTooLarge(err) && Stop() && Start()) {
+    if (durationTooLarge(err) && StopTime() && StartTime()) {
         Poco::Int64 seconds =
-            (std::min)(Stop() - Start(),
+            (std::min)(StopTime() - StartTime(),
                        Poco::Int64(kMaxTimeEntryDurationSeconds));
         SetDurationInSeconds(seconds);
         return true;
     }
-    if (startTimeWrongYear(err) && Stop() && Start()) {
+    if (startTimeWrongYear(err) && StopTime() && StartTime()) {
         Poco::Int64 seconds =
-            (std::min)(Stop() - Start(),
+            (std::min)(StopTime() - StartTime(),
                        Poco::Int64(kMaxTimeEntryDurationSeconds));
         SetDurationInSeconds(seconds);
-        SetStart(Stop() - Duration());
+        SetStartTime(StopTime() - Duration());
         return true;
     }
-    if (stopTimeMustBeAfterStartTime(err) && Stop() && Start()) {
-        SetStop(Start() + DurationInSeconds());
+    if (stopTimeMustBeAfterStartTime(err) && StopTime() && StartTime()) {
+        SetStopTime(StartTime() + DurationInSeconds());
         return true;
     }
     if (userCannotAccessWorkspace(err)) {
@@ -126,12 +126,12 @@ void TimeEntry::DiscardAt(const Poco::Int64 at) {
         return;
     }
 
-    if (at < Start()) {
+    if (at < StartTime()) {
         logger().error("Cannot discard time entry with start time bigger than current moment");
         return;
     }
 
-    Poco::Int64 duration = at - Start();
+    Poco::Int64 duration = at - StartTime();
 
     if (duration < 0) {
         logger().error("Discarding with this time entry would result in negative duration");  // NOLINT
@@ -139,7 +139,7 @@ void TimeEntry::DiscardAt(const Poco::Int64 at) {
     }
 
     SetDurationInSeconds(duration);
-    SetStop(at);
+    SetStopTime(at);
     SetUIModified();
 }
 
@@ -152,17 +152,17 @@ std::string TimeEntry::String() const {
     ss  << "TimeEntry"
         << " ID=" << ID()
         << " local_id=" << LocalID()
-        << " description=" << description_
-        << " wid=" << wid_
+        << " description=" << Description()
+        << " wid=" << WID()
         << " guid=" << GUID()
-        << " pid=" << pid_
-        << " tid=" << tid_
-        << " start=" << start_
-        << " stop=" << stop_
-        << " duration=" << duration_in_seconds_
-        << " billable=" << billable_
-        << " unsynced=" << unsynced_
-        << " duronly=" << duronly_
+        << " pid=" << PID()
+        << " tid=" << TID()
+        << " start=" << StartTime()
+        << " stop=" << StopTime()
+        << " duration=" << DurationInSeconds()
+        << " billable=" << Billable()
+        << " unsynced=" << Unsynced()
+        << " duronly=" << DurOnly()
         << " tags=" << Tags()
         << " created_with=" << CreatedWith()
         << " ui_modified_at=" << UIModifiedAt()
@@ -172,61 +172,61 @@ std::string TimeEntry::String() const {
 }
 
 void TimeEntry::SetLastStartAt(const Poco::Int64 value) {
-    if (last_start_at_ != value) {
-        last_start_at_ = value;
+    if (LastStartAt() != value) {
+        LastStartAt.Set(value);
     }
 }
 
 void TimeEntry::SetDurOnly(const bool value) {
-    if (duronly_ != value) {
-        duronly_ = value;
+    if (DurOnly() != value) {
+        DurOnly.Set(value);
         SetDirty();
     }
 }
 
-void TimeEntry::SetStart(const Poco::Int64 value) {
-    if (start_ != value) {
-        start_ = value;
+void TimeEntry::SetStartTime(const Poco::Int64 value) {
+    if (StartTime() != value) {
+        StartTime.Set(value);
         SetDirty();
     }
 }
 
-void TimeEntry::SetStop(const Poco::Int64 value) {
-    if (stop_ != value) {
-        stop_ = value;
+void TimeEntry::SetStopTime(const Poco::Int64 value) {
+    if (StopTime() != value) {
+        StopTime.Set(value);
         SetDirty();
     }
 }
 
 void TimeEntry::SetDescription(const std::string &value) {
     const std::string &trimValue = trim_whitespace(value);
-    if (description_ != trimValue) {
-        description_ = trimValue;
+    if (Description() != trimValue) {
+        Description.Set(trimValue);
         SetDirty();
     }
 }
 
 void TimeEntry::SetStopString(const std::string &value) {
-    SetStop(Formatter::Parse8601(value));
+    SetStopTime(Formatter::Parse8601(value));
 }
 
 void TimeEntry::SetCreatedWith(const std::string &value) {
-    if (created_with_ != value) {
-        created_with_ = value;
+    if (CreatedWith() != value) {
+        CreatedWith.Set(value);
         SetDirty();
     }
 }
 
 void TimeEntry::SetBillable(const bool value) {
-    if (billable_ != value) {
-        billable_ = value;
+    if (Billable() != value) {
+        Billable.Set(value);
         SetDirty();
     }
 }
 
 void TimeEntry::SetWID(const Poco::UInt64 value) {
-    if (wid_ != value) {
-        wid_ = value;
+    if (WID() != value) {
+        WID.Set(value);
         SetDirty();
     }
 }
@@ -234,21 +234,21 @@ void TimeEntry::SetWID(const Poco::UInt64 value) {
 void TimeEntry::SetStopUserInput(const std::string &value) {
     SetStopString(value);
 
-    if (Stop() < Start()) {
+    if (StopTime() < StartTime()) {
         // Stop time cannot be before start time,
         // it'll get an error from backend.
         Poco::Timestamp ts =
-            Poco::Timestamp::fromEpochTime(Stop()) + 1*Poco::Timespan::DAYS;
-        SetStop(ts.epochTime());
+            Poco::Timestamp::fromEpochTime(StopTime()) + 1*Poco::Timespan::DAYS;
+        SetStopTime(ts.epochTime());
     }
 
-    if (Stop() < Start()) {
+    if (StopTime() < StartTime()) {
         logger().error("Stop time must be after start time!");
         return;
     }
 
     if (!IsTracking()) {
-        SetDurationInSeconds(Stop() - Start());
+        SetDurationInSeconds(StopTime() - StartTime());
     }
 
     if (Dirty()) {
@@ -258,8 +258,8 @@ void TimeEntry::SetStopUserInput(const std::string &value) {
 }
 
 void TimeEntry::SetTID(const Poco::UInt64 value) {
-    if (tid_ != value) {
-        tid_ = value;
+    if (TID() != value) {
+        TID.Set(value);
         SetDirty();
     }
 }
@@ -268,13 +268,13 @@ static const char kTagSeparator = '\t';
 
 void TimeEntry::SetTags(const std::string &tags) {
     if (Tags() != tags) {
-        TagNames.clear();
+        TagNames->clear();
         if (!tags.empty()) {
             std::stringstream ss(tags);
             while (ss.good()) {
                 std::string tag;
                 getline(ss, tag, kTagSeparator);
-                TagNames.push_back(tag);
+                TagNames->push_back(tag);
             }
         }
         SetDirty();
@@ -282,15 +282,15 @@ void TimeEntry::SetTags(const std::string &tags) {
 }
 
 void TimeEntry::SetPID(const Poco::UInt64 value) {
-    if (pid_ != value) {
-        pid_ = value;
+    if (PID() != value) {
+        PID.Set(value);
         SetDirty();
     }
 }
 
 void TimeEntry::SetDurationInSeconds(const Poco::Int64 value) {
-    if (duration_in_seconds_ != value) {
-        duration_in_seconds_ = value;
+    if (DurationInSeconds() != value) {
+        DurationInSeconds.Set(value);
         SetDirty();
     }
 }
@@ -301,14 +301,14 @@ void TimeEntry::SetStartUserInput(const std::string &value,
     if (IsTracking()) {
         SetDurationInSeconds(-start);
     } else {
-        auto stop = Stop();
+        auto stop = StopTime();
         if (keepEndTimeFixed && stop > start) {
             SetDurationInSeconds(stop - start);
         } else {
-            SetStop(start + DurationInSeconds());
+            SetStopTime(start + DurationInSeconds());
         }
     }
-    SetStart(start);
+    SetStartTime(start);
 
     if (Dirty()) {
         ClearValidationError();
@@ -317,7 +317,7 @@ void TimeEntry::SetStartUserInput(const std::string &value,
 }
 
 void TimeEntry::SetStartString(const std::string &value) {
-    SetStart(Formatter::Parse8601(value));
+    SetStartTime(Formatter::Parse8601(value));
 }
 
 void TimeEntry::SetDurationUserInput(const std::string &value) {
@@ -325,12 +325,12 @@ void TimeEntry::SetDurationUserInput(const std::string &value) {
     if (IsTracking()) {
         time_t now = time(nullptr);
         time_t start = now - seconds;
-        SetStart(start);
+        SetStartTime(start);
         SetDurationInSeconds(-start);
     } else {
         SetDurationInSeconds(seconds);
     }
-    SetStop(Start() + seconds);
+    SetStopTime(StartTime() + seconds);
 
     if (Dirty()) {
         ClearValidationError();
@@ -339,16 +339,16 @@ void TimeEntry::SetDurationUserInput(const std::string &value) {
 }
 
 void TimeEntry::SetProjectGUID(const std::string &value) {
-    if (project_guid_ != value) {
-        project_guid_ = value;
+    if (ProjectGUID() != value) {
+        ProjectGUID.Set(value);
         SetDirty();
     }
 }
 
 const std::string TimeEntry::Tags() const {
     std::stringstream ss;
-    for (auto it = TagNames.begin(); it != TagNames.end(); ++it) {
-        if (it != TagNames.begin()) {
+    for (auto it = TagNames->begin(); it != TagNames->end(); ++it) {
+        if (it != TagNames->begin()) {
             ss << kTagSeparator;
         }
         ss << *it;
@@ -357,7 +357,7 @@ const std::string TimeEntry::Tags() const {
 }
 
 const std::string TimeEntry::TagsHash() const {
-    std::vector<std::string> sortedTagNames(TagNames);
+    std::vector<std::string> sortedTagNames(TagNames());
     sort(sortedTagNames.begin(), sortedTagNames.end());
     std::stringstream ss;
     for (auto it = sortedTagNames.begin(); it != sortedTagNames.end(); ++it) {
@@ -370,16 +370,16 @@ const std::string TimeEntry::TagsHash() const {
 }
 
 std::string TimeEntry::StopString() const {
-    return Formatter::Format8601(stop_);
+    return Formatter::Format8601(StopTime());
 }
 
 std::string TimeEntry::StartString() const {
-    return Formatter::Format8601(start_);
+    return Formatter::Format8601(StartTime());
 }
 
 const std::string TimeEntry::GroupHash() const {
     std::stringstream ss;
-    ss << toggl::Formatter::FormatDateHeader(Start())
+    ss << toggl::Formatter::FormatDateHeader(StartTime())
        << Description()
        << WID()
        << PID()
@@ -391,7 +391,7 @@ const std::string TimeEntry::GroupHash() const {
 }
 
 bool TimeEntry::IsToday() const {
-    Poco::Timestamp ts = Poco::Timestamp::fromEpochTime(Start());
+    Poco::Timestamp ts = Poco::Timestamp::fromEpochTime(StartTime());
     Poco::LocalDateTime datetime(ts);
     Poco::LocalDateTime today;
     return today.year() == datetime.year() &&
@@ -496,7 +496,7 @@ Json::Value TimeEntry::SaveToJSON() const {
     }
 
     n["start"] = StartString();
-    if (Stop()) {
+    if (StopTime()) {
         n["stop"] = StopString();
     }
     n["duration"] = Json::Int64(DurationInSeconds());
@@ -506,9 +506,9 @@ Json::Value TimeEntry::SaveToJSON() const {
     n["created_with"] = Formatter::EscapeJSONString(CreatedWith());
 
     Json::Value tag_nodes;
-    if (TagNames.size() > 0) {
-        for (std::vector<std::string>::const_iterator it = TagNames.begin();
-                it != TagNames.end();
+    if (TagNames->size() > 0) {
+        for (std::vector<std::string>::const_iterator it = TagNames->begin();
+                it != TagNames->end();
                 ++it) {
             std::string tag_name = Formatter::EscapeJSONString(*it);
             tag_nodes.append(Json::Value(tag_name));
@@ -529,12 +529,12 @@ Poco::Int64 TimeEntry::RealDurationInSeconds() const {
 }
 
 void TimeEntry::loadTagsFromJSON(Json::Value list) {
-    TagNames.clear();
+    TagNames->clear();
 
     for (unsigned int i = 0; i < list.size(); i++) {
         std::string tag = list[i].asString();
         if (!tag.empty()) {
-            TagNames.push_back(tag);
+            TagNames->push_back(tag);
         }
     }
 }
@@ -556,7 +556,7 @@ std::string TimeEntry::ModelURL() const {
 }
 
 void TimeEntry::SetSkipPomodoro(const bool value) {
-    skipPomodoro = value;
+    SkipPomodoro.Set(value);
 }
 
 }   // namespace toggl

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -171,27 +171,27 @@ std::string TimeEntry::String() const {
     return ss.str();
 }
 
-void TimeEntry::SetLastStartAt(const Poco::Int64 value) {
+void TimeEntry::SetLastStartAt(Poco::Int64 value) {
     if (LastStartAt() != value) {
         LastStartAt.Set(value);
     }
 }
 
-void TimeEntry::SetDurOnly(const bool value) {
+void TimeEntry::SetDurOnly(bool value) {
     if (DurOnly() != value) {
         DurOnly.Set(value);
         SetDirty();
     }
 }
 
-void TimeEntry::SetStartTime(const Poco::Int64 value) {
+void TimeEntry::SetStartTime(Poco::Int64 value) {
     if (StartTime() != value) {
         StartTime.Set(value);
         SetDirty();
     }
 }
 
-void TimeEntry::SetStopTime(const Poco::Int64 value) {
+void TimeEntry::SetStopTime(Poco::Int64 value) {
     if (StopTime() != value) {
         StopTime.Set(value);
         SetDirty();
@@ -217,14 +217,14 @@ void TimeEntry::SetCreatedWith(const std::string &value) {
     }
 }
 
-void TimeEntry::SetBillable(const bool value) {
+void TimeEntry::SetBillable(bool value) {
     if (Billable() != value) {
         Billable.Set(value);
         SetDirty();
     }
 }
 
-void TimeEntry::SetWID(const Poco::UInt64 value) {
+void TimeEntry::SetWID(Poco::UInt64 value) {
     if (WID() != value) {
         WID.Set(value);
         SetDirty();
@@ -257,7 +257,7 @@ void TimeEntry::SetStopUserInput(const std::string &value) {
     }
 }
 
-void TimeEntry::SetTID(const Poco::UInt64 value) {
+void TimeEntry::SetTID(Poco::UInt64 value) {
     if (TID() != value) {
         TID.Set(value);
         SetDirty();
@@ -281,14 +281,14 @@ void TimeEntry::SetTags(const std::string &tags) {
     }
 }
 
-void TimeEntry::SetPID(const Poco::UInt64 value) {
+void TimeEntry::SetPID(Poco::UInt64 value) {
     if (PID() != value) {
         PID.Set(value);
         SetDirty();
     }
 }
 
-void TimeEntry::SetDurationInSeconds(const Poco::Int64 value) {
+void TimeEntry::SetDurationInSeconds(Poco::Int64 value) {
     if (DurationInSeconds() != value) {
         DurationInSeconds.Set(value);
         SetDirty();
@@ -296,7 +296,7 @@ void TimeEntry::SetDurationInSeconds(const Poco::Int64 value) {
 }
 
 void TimeEntry::SetStartUserInput(const std::string &value,
-                                  const bool keepEndTimeFixed) {
+                                  bool keepEndTimeFixed) {
     Poco::Int64 start = Formatter::Parse8601(value);
     if (IsTracking()) {
         SetDurationInSeconds(-start);
@@ -555,7 +555,7 @@ std::string TimeEntry::ModelURL() const {
     return relative_url.str();
 }
 
-void TimeEntry::SetSkipPomodoro(const bool value) {
+void TimeEntry::SetSkipPomodoro(bool value) {
     SkipPomodoro.Set(value);
 }
 

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -36,30 +36,30 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
 
     void SetDescription(const std::string &value);
     void SetCreatedWith(const std::string &value);
-    void SetProjectGUID(const std::string &);
+    void SetProjectGUID(const std::string &value);
 
     const std::string Tags() const;
     void SetTags(const std::string &tags);
     const std::string TagsHash() const;
 
-    void SetWID(const Poco::UInt64 value);
-    void SetPID(const Poco::UInt64 value);
-    void SetTID(const Poco::UInt64 value);
+    void SetWID(Poco::UInt64 value);
+    void SetPID(Poco::UInt64 value);
+    void SetTID(Poco::UInt64 value);
 
     std::string StartString() const;
     void SetStartString(const std::string &value);
-    void SetStartTime(const Poco::Int64 value);
+    void SetStartTime(Poco::Int64 value);
 
     std::string StopString() const;
     void SetStopString(const std::string &value);
-    void SetStopTime(const Poco::Int64 value);
+    void SetStopTime(Poco::Int64 value);
 
     void SetDurationInSeconds(const Poco::Int64 value);
-    void SetLastStartAt(const Poco::Int64 value);
+    void SetLastStartAt(Poco::Int64 value);
 
-    void SetBillable(const bool value);
-    void SetDurOnly(const bool value);
-    void SetSkipPomodoro(const bool value);
+    void SetBillable(bool value);
+    void SetDurOnly(bool value);
+    void SetSkipPomodoro(bool value);
 
     // Derived information and modifiers
     bool IsToday() const;

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -16,120 +16,73 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
  public:
-    TimeEntry()
-        : BaseModel()
-    , wid_(0)
-    , pid_(0)
-    , tid_(0)
-    , billable_(false)
-    , start_(0)
-    , stop_(0)
-    , duration_in_seconds_(0)
-    , description_("")
-    , duronly_(false)
-    , created_with_("")
-    , project_guid_("")
-    , unsynced_(false)
-    , last_start_at_(0)
-    , skipPomodoro(false) {}
-
+    TimeEntry() : BaseModel() {}
     virtual ~TimeEntry() {}
 
-    const Poco::Int64 &LastStartAt() const {
-        return last_start_at_;
-    }
-    void SetLastStartAt(const Poco::Int64 value);
+    Property<std::string> Description { "" };
+    Property<std::string> CreatedWith { "" };
+    Property<std::string> ProjectGUID { "" };
+    Property<std::vector<std::string>> TagNames;
+    Property<Poco::UInt64> WID { 0 };
+    Property<Poco::UInt64> PID { 0 };
+    Property<Poco::UInt64> TID { 0 };
+    Property<Poco::Int64> StartTime { 0 };
+    Property<Poco::Int64> StopTime { 0 };
+    Property<Poco::Int64> DurationInSeconds { 0 };
+    Property<Poco::Int64> LastStartAt { 0 };
+    Property<bool> Billable { false };
+    Property<bool> DurOnly { false };
+    Property<bool> SkipPomodoro { false };
 
-    std::vector<std::string> TagNames;
+    void SetDescription(const std::string &value);
+    void SetCreatedWith(const std::string &value);
+    void SetProjectGUID(const std::string &);
 
     const std::string Tags() const;
     void SetTags(const std::string &tags);
-
     const std::string TagsHash() const;
 
-    const Poco::UInt64 &WID() const {
-        return wid_;
-    }
     void SetWID(const Poco::UInt64 value);
-
-    const Poco::UInt64 &PID() const {
-        return pid_;
-    }
     void SetPID(const Poco::UInt64 value);
-
-    const Poco::UInt64 &TID() const {
-        return tid_;
-    }
     void SetTID(const Poco::UInt64 value);
-
-    const bool &Billable() const {
-        return billable_;
-    }
-    void SetBillable(const bool value);
-
-    const Poco::Int64 &DurationInSeconds() const {
-        return duration_in_seconds_;
-    }
-    void SetDurationInSeconds(const Poco::Int64 value);
-
-    const bool &DurOnly() const {
-        return duronly_;
-    }
-    void SetDurOnly(const bool value);
-
-    const std::string &Description() const {
-        return description_;
-    }
-    void SetDescription(const std::string &value);
 
     std::string StartString() const;
     void SetStartString(const std::string &value);
-
-    const Poco::Int64 &Start() const override {
-        return start_;
-    }
-    void SetStart(const Poco::Int64 value);
+    void SetStartTime(const Poco::Int64 value);
 
     std::string StopString() const;
     void SetStopString(const std::string &value);
+    void SetStopTime(const Poco::Int64 value);
 
-    const Poco::Int64 &Stop() const {
-        return stop_;
-    }
-    void SetStop(const Poco::Int64 value);
+    void SetDurationInSeconds(const Poco::Int64 value);
+    void SetLastStartAt(const Poco::Int64 value);
 
-    const std::string &CreatedWith() const {
-        return created_with_;
-    }
-    void SetCreatedWith(const std::string &value);
+    void SetBillable(const bool value);
+    void SetDurOnly(const bool value);
+    void SetSkipPomodoro(const bool value);
 
-    void DiscardAt(const Poco::Int64);
-
+    // Derived information and modifiers
     bool IsToday() const;
 
-    void SetSkipPomodoro(const bool value);
-    const bool &SkipPomodoro() const {
-        return skipPomodoro;
+    bool IsTracking() const {
+        return DurationInSeconds() < 0;
     }
 
-    const std::string &ProjectGUID() const {
-        return project_guid_;
-    }
-    void SetProjectGUID(const std::string &);
+    Poco::Int64 RealDurationInSeconds() const;
+
+    void DiscardAt(const Poco::Int64);
+    void StopTracking();
+
+    bool isNotFound(const error &err) const;
+
+    const std::string GroupHash() const;
 
     // User-triggered changes to timer:
     void SetDurationUserInput(const std::string &);
     void SetStopUserInput(const std::string &);
     void SetStartUserInput(const std::string &, const bool);
 
-    bool IsTracking() const {
-        return duration_in_seconds_ < 0;
-    }
-
-    void StopTracking();
-
     // Override BaseModel
-
     std::string ModelName() const override;
     std::string ModelURL() const override;
     std::string String() const override;
@@ -138,32 +91,14 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     Json::Value SaveToJSON() const override;
 
     // Implement TimedEvent
-
+    virtual const Poco::Int64 &Start() const {
+        return StartTime();
+    }
     virtual const Poco::Int64 &Duration() const {
         return DurationInSeconds();
     }
 
-    Poco::Int64 RealDurationInSeconds() const;
-
-    bool isNotFound(const error &err) const;
-
-    const std::string GroupHash() const;
-
  private:
-    Poco::UInt64 wid_;
-    Poco::UInt64 pid_;
-    Poco::UInt64 tid_;
-    bool billable_;
-    Poco::Int64 start_;
-    Poco::Int64 stop_;
-    Poco::Int64 duration_in_seconds_;
-    std::string description_;
-    bool duronly_;
-    std::string created_with_;
-    std::string project_guid_;
-    bool unsynced_;
-    Poco::Int64 last_start_at_;
-    bool skipPomodoro;
 
     bool setDurationStringHHMMSS(const std::string &value);
     bool setDurationStringHHMM(const std::string &value);

--- a/src/model/timeline_event.cc
+++ b/src/model/timeline_event.cc
@@ -29,52 +29,52 @@ std::string TimelineEvent::ModelURL() const {
 }
 
 void TimelineEvent::SetTitle(const std::string &value) {
-    if (title_ != value) {
-        title_ = value;
+    if (Title() != value) {
+        Title.Set(value);
         SetDirty();
     }
 }
 
 void TimelineEvent::SetStart(const Poco::Int64 value) {
-    if (start_time_ != value) {
-        start_time_ = value;
+    if (StartTime() != value) {
+        StartTime.Set(value);
         updateDuration();
         SetDirty();
     }
 }
 
 void TimelineEvent::SetEndTime(const Poco::Int64 value) {
-    if (end_time_ != value) {
-        end_time_ = value;
+    if (EndTime() != value) {
+        EndTime.Set(value);
         updateDuration();
         SetDirty();
     }
 }
 
 void TimelineEvent::SetIdle(const bool value) {
-    if (idle_ != value) {
-        idle_ = value;
+    if (Idle() != value) {
+        Idle.Set(value);
         SetDirty();
     }
 }
 
 void TimelineEvent::SetFilename(const std::string &value) {
-    if (filename_ != value) {
-        filename_ = value;
+    if (Filename() != value) {
+        Filename.Set(value);
         SetDirty();
     }
 }
 
 void TimelineEvent::SetChunked(const bool value) {
-    if (chunked_ != value) {
-        chunked_ = value;
+    if (Chunked() != value) {
+        Chunked.Set(value);
         SetDirty();
     }
 }
 
 void TimelineEvent::SetUploaded(const bool value) {
-    if (uploaded_ != value) {
-        uploaded_ = value;
+    if (Uploaded() != value) {
+        Uploaded.Set(value);
         SetDirty();
     }
 }
@@ -91,8 +91,8 @@ Json::Value TimelineEvent::SaveToJSON() const {
 }
 
 void TimelineEvent::updateDuration() {
-    Poco::Int64 value = end_time_ - start_time_;
-    duration_ = value < 0 ? 0 : value;
+    Poco::Int64 value = EndTime() - StartTime();
+    DurationInSeconds.Set(value < 0 ? 0 : value);
 }
 
 }   // namespace toggl

--- a/src/model/timeline_event.cc
+++ b/src/model/timeline_event.cc
@@ -35,7 +35,7 @@ void TimelineEvent::SetTitle(const std::string &value) {
     }
 }
 
-void TimelineEvent::SetStart(const Poco::Int64 value) {
+void TimelineEvent::SetStartTime(Poco::Int64 value) {
     if (StartTime() != value) {
         StartTime.Set(value);
         updateDuration();
@@ -43,7 +43,7 @@ void TimelineEvent::SetStart(const Poco::Int64 value) {
     }
 }
 
-void TimelineEvent::SetEndTime(const Poco::Int64 value) {
+void TimelineEvent::SetEndTime(Poco::Int64 value) {
     if (EndTime() != value) {
         EndTime.Set(value);
         updateDuration();
@@ -51,7 +51,7 @@ void TimelineEvent::SetEndTime(const Poco::Int64 value) {
     }
 }
 
-void TimelineEvent::SetIdle(const bool value) {
+void TimelineEvent::SetIdle(bool value) {
     if (Idle() != value) {
         Idle.Set(value);
         SetDirty();
@@ -65,14 +65,14 @@ void TimelineEvent::SetFilename(const std::string &value) {
     }
 }
 
-void TimelineEvent::SetChunked(const bool value) {
+void TimelineEvent::SetChunked(bool value) {
     if (Chunked() != value) {
         Chunked.Set(value);
         SetDirty();
     }
 }
 
-void TimelineEvent::SetUploaded(const bool value) {
+void TimelineEvent::SetUploaded(bool value) {
     if (Uploaded() != value) {
         Uploaded.Set(value);
         SetDirty();

--- a/src/model/timeline_event.h
+++ b/src/model/timeline_event.h
@@ -28,12 +28,12 @@ class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent 
     Property<bool> Uploaded { false };
 
     void SetTitle(const std::string &value);
-    void SetStart(const Poco::Int64 value);
-    void SetEndTime(const Poco::Int64 value);
-    void SetIdle(const bool value);
     void SetFilename(const std::string &value);
-    void SetChunked(const bool value);
-    void SetUploaded(const bool value);
+    void SetStartTime(Poco::Int64 value);
+    void SetEndTime(Poco::Int64 value);
+    void SetIdle(bool value);
+    void SetChunked(bool value);
+    void SetUploaded(bool value);
 
     // Derived data
     bool VisibleToUser() const {

--- a/src/model/timeline_event.h
+++ b/src/model/timeline_event.h
@@ -15,78 +15,46 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent {
  public:
-    TimelineEvent()
-        : BaseModel()
-    , title_("")
-    , filename_("")
-    , start_time_(0)
-    , end_time_(0)
-    , duration_(0)
-    , idle_(false)
-    , chunked_(false)
-    , uploaded_(false) {}
-
+    TimelineEvent() : BaseModel() {}
     virtual ~TimelineEvent() {}
 
-    const std::string &Title() const {
-        return title_;
-    }
+    Property<std::string> Title { "" };
+    Property<std::string> Filename { "" };
+    Property<Poco::Int64> StartTime { 0 };
+    Property<Poco::Int64> EndTime { 0 };
+    Property<Poco::Int64> DurationInSeconds { 0 };
+    Property<bool> Idle { false };
+    Property<bool> Chunked { false };
+    Property<bool> Uploaded { false };
+
     void SetTitle(const std::string &value);
-
-    const Poco::Int64 &Start() const  override {
-        return start_time_;
-    }
     void SetStart(const Poco::Int64 value);
-
-    const Poco::Int64 &EndTime() const {
-        return end_time_;
-    }
     void SetEndTime(const Poco::Int64 value);
-
-    const Poco::Int64 &Duration() const {
-        return duration_;
-    }
-
-    const bool &Idle() const {
-        return idle_;
-    }
     void SetIdle(const bool value);
-
-    const std::string &Filename() const {
-        return filename_;
-    }
     void SetFilename(const std::string &value);
-
-    const bool &Chunked() const {
-        return chunked_;
-    }
     void SetChunked(const bool value);
-
-    const bool &Uploaded() const {
-        return uploaded_;
-    }
     void SetUploaded(const bool value);
 
+    // Derived data
     bool VisibleToUser() const {
         return !Uploaded() && !DeletedAt() && Chunked();
     }
 
-    // Override BaseModel
+    // Override TimedEvent
+    const Poco::Int64 &Start() const  override {
+        return StartTime();
+    }
+    const Poco::Int64 &Duration() const {
+        return DurationInSeconds();
+    }
 
+    // Override BaseModel
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
     Json::Value SaveToJSON() const override;
 
  private:
-    std::string title_;
-    std::string filename_;
-    Poco::Int64 start_time_;
-    Poco::Int64 end_time_;
-    Poco::Int64 duration_;
-    bool idle_;
-    bool chunked_;
-    bool uploaded_;
 
     void updateDuration();
 };

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -189,18 +189,18 @@ TimeEntry *User::Start(
         if (!duration.empty()) {
             int seconds = Formatter::ParseDurationString(duration);
             te->SetDurationInSeconds(seconds);
-            te->SetStop(now);
-            te->SetStart(te->Stop() - te->DurationInSeconds());
+            te->SetStopTime(now);
+            te->SetStartTime(te->StopTime() - te->DurationInSeconds());
         } else {
             te->SetDurationInSeconds(-now);
             // dont set Stop, TE is running
-            te->SetStart(now);
+            te->SetStartTime(now);
         }
     } else {
         int seconds = int(ended - started);
         te->SetDurationInSeconds(seconds);
-        te->SetStop(ended);
-        te->SetStart(started);
+        te->SetStopTime(ended);
+        te->SetStartTime(started);
     }
 
     // Try to set workspace ID from project
@@ -273,7 +273,7 @@ TimeEntry *User::Continue(
     result->SetBillable(existing->Billable());
     result->SetTags(existing->Tags());
     result->SetUID(ID());
-    result->SetStart(now);
+    result->SetStartTime(now);
 
     if (!manual_mode) {
         result->SetDurationInSeconds(-now);
@@ -288,13 +288,13 @@ TimeEntry *User::Continue(
 
 std::string User::DateDuration(TimeEntry * const te) const {
     Poco::Int64 date_duration(0);
-    std::string date_header = Formatter::FormatDateHeader(te->Start());
+    std::string date_header = Formatter::FormatDateHeader(te->StartTime());
     for (std::vector<TimeEntry *>::const_iterator it =
         related.TimeEntries.begin();
             it != related.TimeEntries.end();
             ++it) {
         TimeEntry *n = *it;
-        if (Formatter::FormatDateHeader(n->Start()) == date_header) {
+        if (Formatter::FormatDateHeader(n->StartTime()) == date_header) {
             Poco::Int64 duration = n->DurationInSeconds();
             if (duration > 0) {
                 date_duration += duration;
@@ -331,52 +331,52 @@ bool User::CanAddProjects() const {
 }
 
 void User::SetFullname(const std::string &value) {
-    if (fullname_ != value) {
-        fullname_ = value;
+    if (Fullname() != value) {
+        Fullname.Set(value);
         SetDirty();
     }
 }
 
 void User::SetTimeOfDayFormat(const std::string &value) {
     Formatter::TimeOfDayFormat = value;
-    if (timeofday_format_ != value) {
-        timeofday_format_ = value;
+    if (TimeOfDayFormat() != value) {
+        TimeOfDayFormat.Set(value);
         SetDirty();
     }
 }
 
 void User::SetDurationFormat(const std::string &value) {
     Formatter::DurationFormat = value;
-    if (duration_format_ != value) {
-        duration_format_ = value;
+    if (DurationFormat() != value) {
+        DurationFormat.Set(value);
         SetDirty();
     }
 }
 
 void User::SetOfflineData(const std::string &value) {
-    if (offline_data_ != value) {
-        offline_data_ = value;
+    if (OfflineData() != value) {
+        OfflineData.Set(value);
         SetDirty();
     }
 }
 
 void User::SetStoreStartAndStopTime(const bool value) {
-    if (store_start_and_stop_time_ != value) {
-        store_start_and_stop_time_ = value;
+    if (StoreStartAndStopTime() != value) {
+        StoreStartAndStopTime.Set(value);
         SetDirty();
     }
 }
 
 void User::SetRecordTimeline(const bool value) {
-    if (record_timeline_ != value) {
-        record_timeline_ = value;
+    if (RecordTimeline() != value) {
+        RecordTimeline.Set(value);
         SetDirty();
     }
 }
 
 void User::SetEmail(const std::string &value) {
-    if (email_ != value) {
-        email_ = value;
+    if (Email() != value) {
+        Email.Set(value);
         SetDirty();
     }
 }
@@ -384,40 +384,40 @@ void User::SetEmail(const std::string &value) {
 void User::SetAPIToken(const std::string &value) {
     // API token is not saved into DB, so no
     // no dirty checking needed for it.
-    api_token_ = value;
+    APIToken.Set(value);
 }
 
 void User::SetSince(const Poco::Int64 value) {
-    if (since_ != value) {
-        since_ = value;
+    if (Since() != value) {
+        Since.Set(value);
         SetDirty();
     }
 }
 
 void User::SetDefaultWID(const Poco::UInt64 value) {
-    if (default_wid_ != value) {
-        default_wid_ = value;
+    if (DefaultWID() != value) {
+        DefaultWID.Set(value);
         SetDirty();
     }
 }
 
 void User::SetDefaultPID(const Poco::UInt64 value) {
-    if (default_pid_ != value) {
-        default_pid_ = value;
+    if (DefaultPID() != value) {
+        DefaultPID.Set(value);
         SetDirty();
     }
 }
 
 void User::SetDefaultTID(const Poco::UInt64 value) {
-    if (default_tid_ != value) {
-        default_tid_ = value;
+    if (DefaultTID() != value) {
+        DefaultTID.Set(value);
         SetDirty();
     }
 }
 
 void User::SetCollapseEntries(const bool value) {
-    if (collapse_entries_ != value) {
-        collapse_entries_ = value;
+    if (CollapseEntries() != value) {
+        CollapseEntries.Set(value);
         SetDirty();
     }
 }
@@ -464,7 +464,7 @@ TimeEntry *User::DiscardTimeAt(
         TimeEntry *split = new TimeEntry();
         split->SetCreatedWith(HTTPClient::Config.UserAgent());
         split->SetUID(ID());
-        split->SetStart(at);
+        split->SetStartTime(at);
         split->SetDurationInSeconds(-at);
         split->SetUIModified();
         split->SetWID(te->WID());
@@ -508,10 +508,10 @@ std::string User::String() const {
     std::stringstream ss;
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
-        << " default_wid=" << default_wid_
-        << " api_token=" << api_token_
-        << " since=" << since_
-        << " record_timeline=" << record_timeline_;
+        << " default_wid=" << DefaultWID()
+        << " api_token=" << APIToken()
+        << " since=" << Since()
+        << " record_timeline=" << RecordTimeline();
     return ss.str();
 }
 

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -23,25 +23,27 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT User : public BaseModel {
  public:
-    User()
-        : api_token_("")
-    , default_wid_(0)
-    , since_(0)
-    , fullname_("")
-    , email_("")
-    , record_timeline_(false)
-    , store_start_and_stop_time_(true)
-    , timeofday_format_("")
-    , duration_format_("")
-    , offline_data_("")
-    , default_pid_(0)
-    , default_tid_(0)
-    , has_loaded_more_(false)
-    , collapse_entries_(false)
-    , IsNewUser(false) {}
-
+    User() : BaseModel() {}
     ~User();
-    bool IsNewUser;
+
+    Property<std::string> APIToken { "" };
+    Property<std::string> Fullname { "" };
+    Property<std::string> Email { "" };
+    Property<std::string> TimeOfDayFormat { "" };
+    Property<std::string> DurationFormat { "" };
+    Property<std::string> OfflineData { "" };
+    Property<Poco::UInt64> DefaultWID { 0 };
+    Property<Poco::UInt64> DefaultPID { 0 };
+    Property<Poco::UInt64> DefaultTID { 0 };
+    // Unix timestamp of the user data; returned from API
+    Property<Poco::Int64> Since { 0 };
+    Property<bool> RecordTimeline { false };
+    Property<bool> StoreStartAndStopTime { false };
+
+    Property<bool> HasLoadedMore { false };
+    Property<bool> CollapseEntries { false };
+
+    Property<bool> IsNewUser { false };
 
     error EnableOfflineLogin(
         const std::string &password);
@@ -103,73 +105,38 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     std::string DateDuration(TimeEntry *te) const;
 
-    const std::string &APIToken() const {
-        return api_token_;
-    }
     void SetAPIToken(const std::string &api_token);
 
-    const Poco::UInt64 &DefaultWID() const {
-        return default_wid_;
-    }
     void SetDefaultWID(Poco::UInt64 value);
 
     // Unix timestamp of the user data; returned from API
-    const Poco::Int64 &Since() const {
-        return since_;
-    }
     void SetSince(const Poco::Int64 value);
 
     bool HasValidSinceDate() const;
 
-    const std::string &Fullname() const {
-        return fullname_;
-    }
     void SetFullname(const std::string &value);
 
-    const std::string &TimeOfDayFormat() const {
-        return timeofday_format_;
-    }
     void SetTimeOfDayFormat(const std::string &value);
 
-    const std::string &Email() const {
-        return email_;
-    }
     void SetEmail(const std::string &value);
 
-    const bool &RecordTimeline() const {
-        return record_timeline_;
-    }
     void SetRecordTimeline(const bool value);
 
-    const std::string &DurationFormat() const {
-        return duration_format_;
-    }
     void SetDurationFormat(const std::string &);
 
-    const bool &StoreStartAndStopTime() const {
-        return store_start_and_stop_time_;
-    }
     void SetStoreStartAndStopTime(const bool value);
 
-    const std::string & OfflineData() const {
-        return offline_data_;
-    }
     void SetOfflineData(const std::string &);
 
-    const Poco::UInt64& DefaultPID() const {
-        return default_pid_;
-    }
     void SetDefaultPID(const Poco::UInt64);
 
-    const Poco::UInt64& DefaultTID() const {
-        return default_tid_;
-    }
     void SetDefaultTID(const Poco::UInt64);
 
-    const bool &CollapseEntries() const {
-        return collapse_entries_;
-    }
     void SetCollapseEntries(const bool value);
+
+    void ConfirmLoadedMore() {
+        HasLoadedMore.Set(true);
+    }
 
     RelatedData related;
 
@@ -251,14 +218,6 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         const std::string &password,
         std::string *result);
 
-    bool HasLoadedMore() {
-        return has_loaded_more_;
-    }
-
-    void ConfirmLoadedMore() {
-        has_loaded_more_ = true;
-    }
-
  private:
     void loadUserTagFromJSON(
         Json::Value data,
@@ -330,23 +289,6 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     std::vector<TimelineEvent> CompressedTimeline(
         const Poco::LocalDateTime *date = nullptr, bool is_for_upload = true) const;
-
-    std::string api_token_;
-    Poco::UInt64 default_wid_;
-    // Unix timestamp of the user data; returned from API
-    Poco::Int64 since_;
-    std::string fullname_;
-    std::string email_;
-    bool record_timeline_;
-    bool store_start_and_stop_time_;
-    std::string timeofday_format_;
-    std::string duration_format_;
-    std::string offline_data_;
-    Poco::UInt64 default_pid_;
-    Poco::UInt64 default_tid_;
-
-    bool has_loaded_more_;
-    bool collapse_entries_;
 
     Poco::Mutex loadTimeEntries_m_;
 };

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -45,6 +45,25 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     Property<bool> IsNewUser { false };
 
+    void SetAPIToken(const std::string &api_token);
+    void SetFullname(const std::string &value);
+    void SetEmail(const std::string &value);
+    void SetTimeOfDayFormat(const std::string &value);
+    void SetDurationFormat(const std::string &value);
+    void SetOfflineData(const std::string &value);
+    void SetDefaultWID(Poco::UInt64 value);
+    void SetDefaultPID(Poco::UInt64 value);
+    void SetDefaultTID(Poco::UInt64 value);
+    // Unix timestamp of the user data; returned from API
+    void SetSince(Poco::Int64 value);
+    void SetRecordTimeline(bool value);
+    void SetStoreStartAndStopTime(bool value);
+    void ConfirmLoadedMore();
+    void SetCollapseEntries(bool value);
+
+    // Derived data and modifiers
+    bool HasValidSinceDate() const;
+
     error EnableOfflineLogin(
         const std::string &password);
 
@@ -64,17 +83,17 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     TimeEntry *Start(
         const std::string &description,
         const std::string &duration,
-        const Poco::UInt64 task_id,
-        const Poco::UInt64 project_id,
+        Poco::UInt64 task_id,
+        Poco::UInt64 project_id,
         const std::string project_guid,
         const std::string tags,
-        const time_t started,
-        const time_t ended,
-        const bool stop_current_running);
+        time_t started,
+        time_t ended,
+        bool stop_current_running);
 
     TimeEntry *Continue(
-        const std::string &GUID,
-        const bool manual_mode);
+        const std::string &guid,
+        bool manual_mode);
 
     void Stop(std::vector<TimeEntry *> *stopped = nullptr);
 
@@ -82,61 +101,28 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     // the discarded time was split into a new time entry
     TimeEntry *DiscardTimeAt(
         const std::string &guid,
-        const Poco::Int64 at,
-        const bool split_into_new_entry);
+        Poco::Int64 at,
+        bool split_into_new_entry);
 
     Project *CreateProject(
-        const Poco::UInt64 workspace_id,
-        const Poco::UInt64 client_id,
+        Poco::UInt64 workspace_id,
+        Poco::UInt64 client_id,
         const std::string &client_guid,
         const std::string &client_name,
         const std::string &project_name,
-        const bool is_private,
+        bool is_private,
         const std::string &project_color,
-        const bool billable);
+        bool billable);
 
     void AddProjectToList(Project *p);
 
     Client *CreateClient(
-        const Poco::UInt64 workspace_id,
+        Poco::UInt64 workspace_id,
         const std::string &client_name);
 
     void AddClientToList(Client *c);
 
     std::string DateDuration(TimeEntry *te) const;
-
-    void SetAPIToken(const std::string &api_token);
-
-    void SetDefaultWID(Poco::UInt64 value);
-
-    // Unix timestamp of the user data; returned from API
-    void SetSince(const Poco::Int64 value);
-
-    bool HasValidSinceDate() const;
-
-    void SetFullname(const std::string &value);
-
-    void SetTimeOfDayFormat(const std::string &value);
-
-    void SetEmail(const std::string &value);
-
-    void SetRecordTimeline(const bool value);
-
-    void SetDurationFormat(const std::string &);
-
-    void SetStoreStartAndStopTime(const bool value);
-
-    void SetOfflineData(const std::string &);
-
-    void SetDefaultPID(const Poco::UInt64);
-
-    void SetDefaultTID(const Poco::UInt64);
-
-    void SetCollapseEntries(const bool value);
-
-    void ConfirmLoadedMore() {
-        HasLoadedMore.Set(true);
-    }
 
     RelatedData related;
 
@@ -146,16 +132,16 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     std::string ModelURL() const override;
 
     // Handle related model deletions
-    void DeleteRelatedModelsWithWorkspace(const Poco::UInt64 wid);
-    void RemoveClientFromRelatedModels(const Poco::UInt64 cid);
-    void RemoveProjectFromRelatedModels(const Poco::UInt64 pid);
-    void RemoveTaskFromRelatedModels(const Poco::UInt64 tid);
+    void DeleteRelatedModelsWithWorkspace(Poco::UInt64 wid);
+    void RemoveClientFromRelatedModels(Poco::UInt64 cid);
+    void RemoveProjectFromRelatedModels(Poco::UInt64 pid);
+    void RemoveTaskFromRelatedModels(Poco::UInt64 tid);
 
     error LoadUserUpdateFromJSONString(const std::string &json);
 
     error LoadUserAndRelatedDataFromJSONString(
         const std::string &json,
-        const bool &including_related_data);
+        bool including_related_data);
 
     error LoadWorkspacesFromJSONString(const std::string & json);
 
@@ -272,13 +258,6 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         std::vector<TimeEntry *> *dirty,
         std::vector<error> *errors);
 
-    error requestJSON(
-        const std::string &method,
-        const std::string &relative_url,
-        const std::string &json,
-        const bool authenticate_with_api_token,
-        std::string *response_body);
-
     void parseResponseArray(
         const std::string &response_body,
         std::vector<BatchUpdateResult> *responses);
@@ -299,11 +278,11 @@ void deleteZombies(
     const std::set<Poco::UInt64> &alive);
 
 template <typename T>
-void deleteRelatedModelsWithWorkspace(const Poco::UInt64 wid,
+void deleteRelatedModelsWithWorkspace(Poco::UInt64 wid,
                                       std::vector<T *> *list);
 
 template <typename T>
-void removeProjectFromRelatedModels(const Poco::UInt64 pid,
+void removeProjectFromRelatedModels(Poco::UInt64 pid,
                                     std::vector<T *> *list);
 
 }  // namespace toggl

--- a/src/model/workspace.cc
+++ b/src/model/workspace.cc
@@ -11,55 +11,55 @@ std::string Workspace::String() const {
     std::stringstream ss;
     ss  << "ID=" << ID()
         << " local_id=" << LocalID()
-        << " name=" << name_;
+        << " name=" << Name();
     return ss.str();
 }
 
 void Workspace::SetName(const std::string &value) {
-    if (name_ != value) {
-        name_ = value;
+    if (Name() != value) {
+        Name.Set(value);
         SetDirty();
     }
 }
 
 void Workspace::SetPremium(const bool value) {
-    if (premium_ != value) {
-        premium_ = value;
+    if (Premium() != value) {
+        Premium.Set(value);
         SetDirty();
     }
 }
 
 void Workspace::SetOnlyAdminsMayCreateProjects(const bool value) {
-    if (only_admins_may_create_projects_ != value) {
-        only_admins_may_create_projects_ = value;
+    if (OnlyAdminsMayCreateProjects() != value) {
+        OnlyAdminsMayCreateProjects.Set(value);
         SetDirty();
     }
 }
 
 void Workspace::SetAdmin(const bool value) {
-    if (admin_ != value) {
-        admin_ = value;
+    if (Admin() != value) {
+        Admin.Set(value);
         SetDirty();
     }
 }
 
 void Workspace::SetProjectsBillableByDefault(const bool value) {
-    if (projects_billable_by_default_ != value) {
-        projects_billable_by_default_ = value;
+    if (ProjectsBillableByDefault() != value) {
+        ProjectsBillableByDefault.Set(value);
         SetDirty();
     }
 }
 
 void Workspace::SetBusiness(const bool value) {
-    if (business_ != value) {
-        business_ = value;
+    if (Business() != value) {
+        Business.Set(value);
         SetDirty();
     }
 }
 
 void Workspace::SetLockedTime(const time_t value) {
-    if (locked_time_ != value) {
-        locked_time_ = value;
+    if (LockedTime() != value) {
+        LockedTime.Set(value);
         SetDirty();
     }
 }

--- a/src/model/workspace.cc
+++ b/src/model/workspace.cc
@@ -22,42 +22,42 @@ void Workspace::SetName(const std::string &value) {
     }
 }
 
-void Workspace::SetPremium(const bool value) {
+void Workspace::SetPremium(bool value) {
     if (Premium() != value) {
         Premium.Set(value);
         SetDirty();
     }
 }
 
-void Workspace::SetOnlyAdminsMayCreateProjects(const bool value) {
+void Workspace::SetOnlyAdminsMayCreateProjects(bool value) {
     if (OnlyAdminsMayCreateProjects() != value) {
         OnlyAdminsMayCreateProjects.Set(value);
         SetDirty();
     }
 }
 
-void Workspace::SetAdmin(const bool value) {
+void Workspace::SetAdmin(bool value) {
     if (Admin() != value) {
         Admin.Set(value);
         SetDirty();
     }
 }
 
-void Workspace::SetProjectsBillableByDefault(const bool value) {
+void Workspace::SetProjectsBillableByDefault(bool value) {
     if (ProjectsBillableByDefault() != value) {
         ProjectsBillableByDefault.Set(value);
         SetDirty();
     }
 }
 
-void Workspace::SetBusiness(const bool value) {
+void Workspace::SetBusiness(bool value) {
     if (Business() != value) {
         Business.Set(value);
         SetDirty();
     }
 }
 
-void Workspace::SetLockedTime(const time_t value) {
+void Workspace::SetLockedTime(time_t value) {
     if (LockedTime() != value) {
         LockedTime.Set(value);
         SetDirty();

--- a/src/model/workspace.h
+++ b/src/model/workspace.h
@@ -24,12 +24,12 @@ class TOGGL_INTERNAL_EXPORT Workspace : public BaseModel {
     Property<bool> Business { false };
 
     void SetName(const std::string &value);
-    void SetPremium(const bool value);
-    void SetOnlyAdminsMayCreateProjects(const bool);
-    void SetAdmin(const bool);
-    void SetProjectsBillableByDefault(const bool);
-    void SetBusiness(const bool value);
-    void SetLockedTime(const time_t value);
+    void SetPremium(bool value);
+    void SetOnlyAdminsMayCreateProjects(bool);
+    void SetAdmin(bool);
+    void SetProjectsBillableByDefault(bool);
+    void SetBusiness(bool value);
+    void SetLockedTime(time_t value);
 
     // Override BaseModel
     std::string String() const override;

--- a/src/model/workspace.h
+++ b/src/model/workspace.h
@@ -13,49 +13,22 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT Workspace : public BaseModel {
  public:
-    Workspace()
-        : BaseModel()
-    , name_("")
-    , premium_(false)
-    , only_admins_may_create_projects_(false)
-    , admin_(false)
-    , projects_billable_by_default_(false)
-    , business_(false)
-    , locked_time_(0) {}
+    Workspace() : BaseModel() {}
 
-    const std::string &Name() const {
-        return name_;
-    }
+    Property<std::string> Name { "" };
+    Property<time_t> LockedTime { 0 };
+    Property<bool> Premium { false };
+    Property<bool> OnlyAdminsMayCreateProjects { false };
+    Property<bool> Admin { false };
+    Property<bool> ProjectsBillableByDefault { false };
+    Property<bool> Business { false };
+
     void SetName(const std::string &value);
-
-    const bool &Premium() const {
-        return premium_;
-    }
     void SetPremium(const bool value);
-
-    const bool &OnlyAdminsMayCreateProjects() const {
-        return only_admins_may_create_projects_;
-    }
     void SetOnlyAdminsMayCreateProjects(const bool);
-
-    const bool &Admin() const {
-        return admin_;
-    }
     void SetAdmin(const bool);
-
-    const bool &ProjectsBillableByDefault() const {
-        return projects_billable_by_default_;
-    }
     void SetProjectsBillableByDefault(const bool);
-
-    const bool &Business() const {
-        return business_;
-    }
     void SetBusiness(const bool value);
-
-    const time_t &LockedTime() const {
-        return locked_time_;
-    }
     void SetLockedTime(const time_t value);
 
     // Override BaseModel
@@ -65,15 +38,6 @@ class TOGGL_INTERNAL_EXPORT Workspace : public BaseModel {
     void LoadFromJSON(Json::Value value) override;
 
     void LoadSettingsFromJson(Json::Value value);
-
- private:
-    std::string name_;
-    bool premium_;
-    bool only_admins_may_create_projects_;
-    bool admin_;
-    bool projects_billable_by_default_;
-    bool business_;
-    time_t locked_time_;
 };
 
 }  // namespace toggl

--- a/src/onboarding_service.cpp
+++ b/src/onboarding_service.cpp
@@ -220,7 +220,7 @@ bool OnboardingService::hasAtLeastOneTimelineTimeEntryOnCurrentDay() {
     for (std::vector<TimeEntry *>::const_iterator it = user->related.TimeEntries.begin();
          it != user->related.TimeEntries.end(); ++it) {
         TimeEntry *item = *it;
-        time_t start_time_entry = Poco::Timestamp::fromEpochTime(item->Start()).epochTime();
+        time_t start_time_entry = Poco::Timestamp::fromEpochTime(item->StartTime()).epochTime();
 
         // If we have at least one Time Entry in current Timeline day
         if (start_time_entry >= start_day) {
@@ -351,7 +351,7 @@ bool OnboardingService::handleNewUserOnboarding() {
          1. when user installs the app
          2. when users comes back to the app after more than 24 hours and still hasn’t tracked any time
      */
-    if (user->IsNewUser && state->timeEntryTotal == 0) {
+    if (user->IsNewUser() && state->timeEntryTotal == 0) {
         bool isTrigger = false;
 
         // Present twice
@@ -389,7 +389,7 @@ bool OnboardingService::handleOldUserOnboarding() {
          1. when user installs the app
          2. when users comes back to the app after more than 24 hours and still hasn’t tracked any time
      */
-    if (!user->IsNewUser) {
+    if (!user->IsNewUser()) {
         bool isTrigger = false;
         time_t elapsed = std::time(NULL) - state->createdAt;
 
@@ -421,7 +421,7 @@ void OnboardingService::getFirstTimeEntryCreatedAtFromUser(User *user) {
     if (!user->related.TimeEntries.empty()) {
         TimeEntry *firstTimeEntry = user->related.TimeEntries.front();
         if (firstTimeEntry != nullptr) {
-            state->firstTimeEntryCreatedAt = firstTimeEntry->Start();
+            state->firstTimeEntryCreatedAt = firstTimeEntry->StartTime();
         }
     }
 }

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -144,7 +144,7 @@ std::vector<TimeEntry *> RelatedData::VisibleTimeEntries() const {
 }
 
 Poco::Int64 RelatedData::TotalDurationForDate(const TimeEntry *match) const {
-    std::string date_header = Formatter::FormatDateHeader(match->Start());
+    std::string date_header = Formatter::FormatDateHeader(match->StartTime());
     Poco::Int64 duration(0);
     for (std::vector<TimeEntry *>::const_iterator it =
         TimeEntries.begin();
@@ -156,7 +156,7 @@ Poco::Int64 RelatedData::TotalDurationForDate(const TimeEntry *match) const {
         if (te->DeletedAt() > 0) {
             continue;
         }
-        if (Formatter::FormatDateHeader(te->Start()) == date_header) {
+        if (Formatter::FormatDateHeader(te->StartTime()) == date_header) {
             duration += Formatter::AbsDuration(te->Duration());
         }
     }
@@ -190,7 +190,7 @@ TimeEntry *RelatedData::LatestTimeEntry() const {
             continue;
         }
 
-        if (!latest || (te->Stop() > latest->Stop())) {
+        if (!latest || (te->StopTime() > latest->StopTime())) {
             latest = te;
         }
     }

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -127,7 +127,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     TimelineEvent *good = new TimelineEvent();
     good->SetUID(user_id);
     // started yesterday, "16 minutes ago"
-    good->SetStart(time(0) - 86400 - 60*16);
+    good->SetStartTime(time(0) - 86400 - 60*16);
     good->SetEndTime(good->Start() + good_duration_seconds);
     good->SetFilename("Notepad.exe");
     good->SetTitle("untitled");
@@ -139,7 +139,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     // can be uploaded to Toggl backend.
     TimelineEvent *good2 = new TimelineEvent();
     good2->SetUID(user_id);
-    good2->SetStart(good->EndTime() + 1);  // started after first event
+    good2->SetStartTime(good->EndTime() + 1);  // started after first event
     good2->SetEndTime(good2->Start() + good2_duration_seconds);
     good2->SetFilename("Notepad.exe");
     good2->SetTitle("untitled");
@@ -149,7 +149,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     // but has already been uploaded to Toggl backend.
     TimelineEvent *uploaded = new TimelineEvent();;
     uploaded->SetUID(user_id);
-    uploaded->SetStart(good2->EndTime() + 1);  // started after second event
+    uploaded->SetStartTime(good2->EndTime() + 1);  // started after second event
     uploaded->SetEndTime(uploaded->Start() + 10);
     uploaded->SetFilename("Notepad.exe");
     uploaded->SetTitle("untitled");
@@ -160,7 +160,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     // so it must not be uploaded
     TimelineEvent *too_fresh = new TimelineEvent();
     too_fresh->SetUID(user_id);
-    too_fresh->SetStart(time(0) - 60);  // started 1 minute ago
+    too_fresh->SetStartTime(time(0) - 60);  // started 1 minute ago
     too_fresh->SetEndTime(time(0));  // lasted until now
     too_fresh->SetFilename("Notepad.exe");
     too_fresh->SetTitle("notes");
@@ -170,7 +170,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     // so it must not be uploaded, just deleted
     TimelineEvent *too_old = new TimelineEvent();
     too_old->SetUID(user_id);
-    too_old->SetStart(time(0) - kTimelineSecondsToKeep - 1);  // 7 days ago
+    too_old->SetStartTime(time(0) - kTimelineSecondsToKeep - 1);  // 7 days ago
     too_old->SetEndTime(too_old->EndTime() + 120);  // lasted 2 minutes
     too_old->SetFilename("Notepad.exe");
     too_old->SetTitle("diary");
@@ -1562,7 +1562,7 @@ TEST(JSON, ConvertTimelineToJSON) {
     const std::string desktop_id("12345");
 
     TimelineEvent event;
-    event.SetStart(time(0) - 10);
+    event.SetStartTime(time(0) - 10);
     event.SetEndTime(time(0));
     event.SetFilename("Is this the real life?");
     event.SetTitle("Is this just fantasy?");

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -107,7 +107,7 @@ TEST(Project, ResolveOnlyAdminsCanChangeProjectVisibility) {
     p.SetPrivate(false);
     error err = error("Only admins can change project visibility");
     ASSERT_TRUE(p.ResolveError(err));
-    ASSERT_TRUE(p.IsPrivate());
+    ASSERT_TRUE(p.Private());
 }
 
 TEST(User, CreateCompressedTimelineBatchForUpload) {
@@ -791,12 +791,12 @@ TEST(User, ParsesAndSavesData) {
     //ASSERT_EQ("07fba193-91c4-0ec8-2894-820df0548a8f", user.related.TimeEntries[0]->GUID());
     ASSERT_EQ(uint(2567324), user.related.TimeEntries[0]->PID());
     ASSERT_TRUE(user.related.TimeEntries[0]->Billable());
-    ASSERT_EQ(uint(1378362830), user.related.TimeEntries[0]->Start());
-    ASSERT_EQ(uint(1378369186), user.related.TimeEntries[0]->Stop());
+    ASSERT_EQ(uint(1378362830), user.related.TimeEntries[0]->StartTime());
+    ASSERT_EQ(uint(1378369186), user.related.TimeEntries[0]->StopTime());
     ASSERT_EQ(6356, user.related.TimeEntries[0]->DurationInSeconds());
     ASSERT_EQ("Important things",
               user.related.TimeEntries[0]->Description());
-    ASSERT_EQ(uint(0), user.related.TimeEntries[0]->TagNames.size());
+    ASSERT_EQ(uint(0), user.related.TimeEntries[0]->TagNames->size());
     ASSERT_FALSE(user.related.TimeEntries[0]->DurOnly());
     ASSERT_EQ(user.ID(), user.related.TimeEntries[0]->UID());
 
@@ -1261,13 +1261,13 @@ TEST(TimeEntry, ParseDurationLargerThan24Hours) {
 TEST(TimeEntry, InterpretsCrazyStartAndStopAsMissingValues) {
     TimeEntry te;
 
-    ASSERT_EQ(Poco::UInt64(0), te.Start());
+    ASSERT_EQ(Poco::UInt64(0), te.StartTime());
     te.SetStartString("0003-03-16T-7:-19:-24Z");
-    ASSERT_EQ(Poco::UInt64(0), te.Start());
+    ASSERT_EQ(Poco::UInt64(0), te.StartTime());
 
-    ASSERT_EQ(Poco::UInt64(0), te.Stop());
+    ASSERT_EQ(Poco::UInt64(0), te.StopTime());
     te.SetStopString("0003-03-16T-5:-52:-51Z");
-    ASSERT_EQ(Poco::UInt64(0), te.Stop());
+    ASSERT_EQ(Poco::UInt64(0), te.StopTime());
 }
 
 TEST(User, Continue) {
@@ -1296,15 +1296,15 @@ TEST(TimeEntry, SetDurationOnRunningTimeEntryWithDurOnlySetting) {
     TimeEntry *te = user.related.TimeEntryByID(164891639);
     ASSERT_TRUE(te);
     ASSERT_TRUE(te->IsTracking());
-    ASSERT_LT(te->Start(), te->Stop());
+    ASSERT_LT(te->StartTime(), te->StopTime());
 
     te->SetDurationUserInput("00:59:47");
     ASSERT_TRUE(te->IsTracking());
-    ASSERT_LT(te->Start(), te->Stop());
+    ASSERT_LT(te->StartTime(), te->StopTime());
 
     te->StopTracking();
     ASSERT_FALSE(te->IsTracking());
-    ASSERT_LT(te->Start(), te->Stop());
+    ASSERT_LT(te->StartTime(), te->StopTime());
 }
 
 TEST(Formatter, CollectErrors) {
@@ -1666,7 +1666,7 @@ TEST(JSON, Project) {
     //ASSERT_EQ(p.GUID(), p2.GUID());
     ASSERT_EQ(p.CID(), p2.CID());
     //ASSERT_EQ(p.Billable(), p2.Billable());
-    ASSERT_EQ(p.IsPrivate(), p2.IsPrivate());
+    ASSERT_EQ(p.Private(), p2.Private());
     ASSERT_EQ(p.UIModifiedAt(), p2.UIModifiedAt());
 }
 
@@ -1698,8 +1698,8 @@ TEST(JSON, TimeEntry) {
     ASSERT_EQ(Poco::UInt64(123456789), t.WID());
     //ASSERT_EQ("07fba193-91c4-0ec8-2345-820df0548123", t.GUID());
     ASSERT_TRUE(t.Billable());
-    ASSERT_EQ(Poco::UInt64(1378362830000 / 1000), t.Start());
-    ASSERT_EQ(Poco::UInt64(1378369186000 / 1000), t.Stop());
+    ASSERT_EQ(Poco::UInt64(1378362830000 / 1000), t.StartTime());
+    ASSERT_EQ(Poco::UInt64(1378369186000 / 1000), t.StopTime());
     ASSERT_EQ(Poco::Int64(6356), t.DurationInSeconds());
     ASSERT_EQ("A deleted time entry", t.Description());
     ASSERT_EQ("ahaa", t.Tags());
@@ -1712,8 +1712,8 @@ TEST(JSON, TimeEntry) {
     ASSERT_EQ(t.WID(), t2.WID());
     //ASSERT_EQ(t.GUID(), t2.GUID());
     ASSERT_EQ(t.Billable(), t2.Billable());
-    ASSERT_EQ(t.Start(), t2.Start());
-    ASSERT_EQ(t.Stop(), t2.Stop());
+    ASSERT_EQ(t.StartTime(), t2.StartTime());
+    ASSERT_EQ(t.StopTime(), t2.StopTime());
     ASSERT_EQ(t.DurationInSeconds(), t2.DurationInSeconds());
     ASSERT_EQ(t.Description(), t2.Description());
     ASSERT_EQ(t.Tags(), t2.Tags());
@@ -2024,8 +2024,8 @@ TEST(Sync, LegacyFormat) {
     ASSERT_EQ(user.related.TimeEntries[0]->Description(), "time entry");
     ASSERT_EQ(user.related.TimeEntries[0]->WID(), 2817276);
     ASSERT_EQ(user.related.TimeEntries[0]->UID(), 4187712);
-    ASSERT_EQ(user.related.TimeEntries[0]->Start(), 1590593622);
-    ASSERT_EQ(user.related.TimeEntries[0]->Stop(), 1590594037);
+    ASSERT_EQ(user.related.TimeEntries[0]->StartTime(), 1590593622);
+    ASSERT_EQ(user.related.TimeEntries[0]->StopTime(), 1590594037);
     ASSERT_EQ(user.related.TimeEntries[0]->Duration(), 415);
 
     ASSERT_EQ(user.related.Workspaces[0]->ID(), 2817276);
@@ -2070,8 +2070,8 @@ TEST(Sync, BatchedFormat) {
     ASSERT_EQ(user.related.TimeEntries[0]->Description(), "time entry");
     ASSERT_EQ(user.related.TimeEntries[0]->WID(), 2817276);
     ASSERT_EQ(user.related.TimeEntries[0]->UID(), 4187712);
-    ASSERT_EQ(user.related.TimeEntries[0]->Start(), 1590593622);
-    ASSERT_EQ(user.related.TimeEntries[0]->Stop(), 1590594037);
+    ASSERT_EQ(user.related.TimeEntries[0]->StartTime(), 1590593622);
+    ASSERT_EQ(user.related.TimeEntries[0]->StopTime(), 1590594037);
     ASSERT_EQ(user.related.TimeEntries[0]->Duration(), 415);
 
     ASSERT_EQ(user.related.Workspaces[0]->ID(), 2817276);

--- a/src/test/toggl_api_test.cc
+++ b/src/test/toggl_api_test.cc
@@ -173,8 +173,8 @@ void on_time_entry_list(
         te.SetID(it->ID);
         te.SetDurationInSeconds(it->DurationInSeconds);
         te.SetDescription(to_string(it->Description));
-        te.SetStart(it->Started);
-        te.SetStop(it->Ended);
+        te.SetStartTime(it->Started);
+        te.SetStopTime(it->Ended);
         testing::testresult::time_entries.push_back(te);
         it = reinterpret_cast<TogglTimeEntryView *>(it->Next);
     }
@@ -286,7 +286,7 @@ void on_display_timer_state(TogglTimeEntryView *te) {
     testing::testresult::timer_state = TimeEntry();
     if (te) {
         testing::testresult::timer_state.SetID(te->ID);
-        testing::testresult::timer_state.SetStart(te->Started);
+        testing::testresult::timer_state.SetStartTime(te->Started);
         testing::testresult::timer_state.SetGUID(to_string(te->GUID));
         testing::testresult::timer_state.SetDurationInSeconds(
             te->DurationInSeconds);
@@ -1064,7 +1064,7 @@ TEST(toggl_api, toggl_continue_in_manual_mode) {
 
     ASSERT_NE(guid, testing::testresult::timer_state.GUID());
 
-    ASSERT_FALSE(testing::testresult::timer_state.Start());
+    ASSERT_FALSE(testing::testresult::timer_state.StartTime());
     ASSERT_FALSE(testing::testresult::timer_state.DurationInSeconds());
 
     ASSERT_NE("", testing::testresult::editor_state.GUID());
@@ -1184,7 +1184,7 @@ TEST(toggl_api, toggl_continue_latest_with_manual_mode) {
 
     ASSERT_EQ(noError, testing::testresult::error);
 
-    ASSERT_FALSE(testing::testresult::timer_state.Start());
+    ASSERT_FALSE(testing::testresult::timer_state.StartTime());
     ASSERT_FALSE(testing::testresult::timer_state.DurationInSeconds());
 
     ASSERT_NE("", testing::testresult::editor_state.GUID());
@@ -1667,8 +1667,8 @@ TEST(toggl_api, toggl_discard_time_at) {
         }
     }
     ASSERT_EQ(guid, te.GUID());
-    ASSERT_TRUE(started == te.Start() || started + 1 == te.Start());
-    ASSERT_TRUE(stopped == te.Stop() || stopped + 1 == te.Stop());
+    ASSERT_TRUE(started == te.StartTime() || started + 1 == te.StartTime());
+    ASSERT_TRUE(stopped == te.StopTime() || stopped + 1 == te.StopTime());
 
     // Start another time entry
 
@@ -1695,13 +1695,13 @@ TEST(toggl_api, toggl_discard_time_at) {
         }
     }
     ASSERT_EQ(guid, te.GUID());
-    ASSERT_TRUE(started == te.Start() || started + 1 == te.Start());
-    ASSERT_TRUE(stopped == te.Stop() || stopped + 1 == te.Stop());
+    ASSERT_TRUE(started == te.StartTime() || started + 1 == te.StartTime());
+    ASSERT_TRUE(stopped == te.StopTime() || stopped + 1 == te.StopTime());
 
     // Check that a new time entry was created
 
     ASSERT_TRUE(!testing::testresult::timer_state.GUID().empty());
-    ASSERT_EQ(stopped, testing::testresult::timer_state.Start());
+    ASSERT_EQ(stopped, testing::testresult::timer_state.StartTime());
     ASSERT_TRUE(testing::testresult::timer_state.IsTracking());
     ASSERT_EQ("", testing::testresult::timer_state.Description());
 }
@@ -1747,7 +1747,7 @@ TEST(toggl_api, toggl_set_time_entry_date) {
     toggl::TimeEntry te = testing::testresult::time_entry_by_id(89818605);
     std::string guid = te.GUID();
 
-    Poco::DateTime datetime(Poco::Timestamp::fromEpochTime(te.Start()));
+    Poco::DateTime datetime(Poco::Timestamp::fromEpochTime(te.StartTime()));
     ASSERT_EQ(2013, datetime.year());
     ASSERT_EQ(9, datetime.month());
     ASSERT_EQ(5, datetime.day());
@@ -1762,7 +1762,7 @@ TEST(toggl_api, toggl_set_time_entry_date) {
                                           unix_timestamp));
 
     te = testing::testresult::time_entry_by_id(89818605);
-    datetime = Poco::DateTime(Poco::Timestamp::fromEpochTime(te.Start()));
+    datetime = Poco::DateTime(Poco::Timestamp::fromEpochTime(te.StartTime()));
     ASSERT_EQ(2014, datetime.year());
     ASSERT_EQ(10, datetime.month());
     ASSERT_EQ(27, datetime.day());
@@ -1778,7 +1778,7 @@ TEST(toggl_api, toggl_set_time_entry_start) {
     toggl::TimeEntry te = testing::testresult::time_entry_by_id(89818605);
     std::string guid = te.GUID();
 
-    Poco::DateTime datetime(Poco::Timestamp::fromEpochTime(te.Start()));
+    Poco::DateTime datetime(Poco::Timestamp::fromEpochTime(te.StartTime()));
     ASSERT_EQ(2013, datetime.year());
     ASSERT_EQ(9, datetime.month());
     ASSERT_EQ(5, datetime.day());
@@ -1790,7 +1790,7 @@ TEST(toggl_api, toggl_set_time_entry_start) {
 
     te = testing::testresult::time_entry_by_id(89818605);
     Poco::LocalDateTime local =
-        Poco::DateTime(Poco::Timestamp::fromEpochTime(te.Start()));
+        Poco::DateTime(Poco::Timestamp::fromEpochTime(te.StartTime()));
     ASSERT_EQ(2013, local.year());
     ASSERT_EQ(9, local.month());
     ASSERT_EQ(5, local.day());
@@ -1810,7 +1810,7 @@ TEST(toggl_api, toggl_set_time_entry_end) {
     toggl::TimeEntry te = testing::testresult::time_entry_by_id(89818605);
     std::string guid = te.GUID();
 
-    Poco::DateTime datetime(Poco::Timestamp::fromEpochTime(te.Stop()));
+    Poco::DateTime datetime(Poco::Timestamp::fromEpochTime(te.StopTime()));
     ASSERT_EQ(2013, datetime.year());
     ASSERT_EQ(9, datetime.month());
     ASSERT_EQ(5, datetime.day());
@@ -1822,7 +1822,7 @@ TEST(toggl_api, toggl_set_time_entry_end) {
 
     te = testing::testresult::time_entry_by_id(89818605);
     Poco::LocalDateTime local =
-        Poco::DateTime(Poco::Timestamp::fromEpochTime(te.Stop()));
+        Poco::DateTime(Poco::Timestamp::fromEpochTime(te.StopTime()));
     ASSERT_EQ(2013, local.year());
     ASSERT_EQ(9, local.month());
     ASSERT_EQ(5, local.day());
@@ -1852,8 +1852,8 @@ TEST(toggl_api, toggl_set_time_entry_end_prefers_same_day) {
     // take the updated time entry
     te = testing::testresult::time_entry_by_id(89818605);
 
-    Poco::DateTime start(Poco::Timestamp::fromEpochTime(te.Start()));
-    Poco::DateTime end(Poco::Timestamp::fromEpochTime(te.Stop()));
+    Poco::DateTime start(Poco::Timestamp::fromEpochTime(te.StartTime()));
+    Poco::DateTime end(Poco::Timestamp::fromEpochTime(te.StopTime()));
     ASSERT_EQ(start.year(), end.year());
     ASSERT_EQ(start.month(), end.month());
     ASSERT_EQ(start.day(), end.day());

--- a/src/util/property.h
+++ b/src/util/property.h
@@ -1,0 +1,94 @@
+// Copyright 2020 Toggl Desktop developers.
+
+#ifndef PROPERTY_H
+#define PROPERTY_H
+
+#include <memory>
+#include <string>
+
+namespace toggl {
+
+/**
+ * Property protection class
+ * Tracks last unsynced change
+ */
+template <class T>
+class Property {
+public:
+    Property(const T& value) {
+        current_ = value;
+        previous_ = value;
+    }
+    Property(T&& value = T {}) {
+        current_ = std::move(value);
+        previous_ = current_;
+    }
+    // on some beautiful day in the future, we could also be able to delete the copy assignment operator
+    // it's required for settings, obmexperiments and timeline for now
+    // Property& operator=(const Property &o) = delete;
+    /* Dirtiness implementation */
+    // Property is dirty when the current and previous versions of it are different.
+    //     I opted for comparing these two instead of a bool flag because most of the strings
+    // we're working with are pretty short (<24 characters) so SSO will make comparing them very fast.
+    bool IsDirty() const {
+        return current_ != previous_;
+    }
+    void SetNotDirty() {
+        previous_ = current_;
+    }
+    /* Setters */
+    void Set(const T& value, bool makeDirty = true) {
+        if (makeDirty)
+            previous_ = std::move(current_);
+        else
+            previous_ = value;
+        current_ = value;
+    }
+    void Set(const T&& value, bool makeDirty = true) {
+        if (makeDirty)
+            previous_ = std::move(current_);
+        else
+            previous_ = std::move(value);
+        current_ = value;
+    }
+    /* Data access operators */
+    // Notice that references are returned only as const
+    // Only the -> operator is allowed to modify data inside (but should probably be const as well in the future)
+    T* operator ->() {
+        return &current_;
+    }
+    const T* operator ->() const {
+        return &current_;
+    }
+    const T& operator()() const {
+        return current_;
+    }
+    // TODO remove? confusing syntax with conversion operator
+    /*
+    operator const T() const {
+        return current_;
+    }
+    */
+    const T& Get() const {
+        return current_;
+    }
+    /* Equality */
+    bool operator ==(const Property<T> &o) const {
+        return current_ == o.current_;
+    }
+    bool operator ==(const T &o) const {
+        return current_ == o;
+    }
+private:
+    T current_;
+    T previous_;
+};
+
+/* A helper method to check if any of the selected properties is dirty */
+template<typename... Args> static bool IsAnyPropertyDirty(Args&... args) { return (... || args.IsDirty()); }
+/* A helper method to clear the dirty flag for more properties at once */
+template<typename... Args> static void AllPropertiesClearDirty(Args&... args) { (... , args.SetNotDirty()); }
+
+} // namespace toggl
+
+#endif // PROPERTY_H

--- a/src/util/property.h
+++ b/src/util/property.h
@@ -79,6 +79,12 @@ public:
     bool operator ==(const T &o) const {
         return current_ == o;
     }
+    bool operator !=(const Property<T> &o) const {
+        return current_ != o.current_;
+    }
+    bool operator !=(const T &o) const {
+        return current_ != o;
+    }
 private:
     T current_;
     T previous_;

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -77,7 +77,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
             last_autotracker_title_ = title;
 
             TimelineEvent event;
-            event.SetStart(last_event_started_at_);
+            event.SetStartTime(last_event_started_at_);
             event.SetEndTime(now);
             event.SetTitle(title);
             event.SetIdle(false);
@@ -109,7 +109,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
         // if window was focussed at least X seconds, save it to timeline
         if (time_delta >= kWindowFocusThresholdSeconds && !last_idle_) {
             TimelineEvent *event = new TimelineEvent();
-            event->SetStart(last_event_started_at_);
+            event->SetStartTime(last_event_started_at_);
             event->SetEndTime(now);
             event->SetFilename(last_filename_);
             event->SetTitle(last_title_);


### PR DESCRIPTION
### 📒 Description
This PR slightly (especially compared to the previous version of the same PR) changes how data members are handled in the data model classes.

Adds a `Property<T>` class that will track the changes to the separate properties (for syncing to the server but probably even the database in some future stage).

All property getters are now gone. There is very little change to the current code because `const T& Property<T>::operator()` is implemented.
Setters are still mostly the same but they call `Property<T>::Set(T)` internally. 

WARNING: Please note that calling for example `client->GUID.Set("whatever");` won't change the `Dirty` flag and this change won't be stored to the database. The right way is to call `client->SetGUID("whatever");`.
Again, this is something that should be changed in a future version of properties - doing the setters in this PR would be a very disruptive change and we can live without it now.

One extra thing I did here was to sanitize the setter arguments (it doesn't make sense to pass `const` integral types as arguments) and reorganized the structure of the class headers slightly so they are more readable.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Depends on #4112.

### 🔎 Review hints
There should be no change to behavior of the app. 
This will be a bit annoying to review because it'll be mostly looking if I made a typo somewhere.

