### PR TITLE
Apply rounded corners to onboarding views

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingBackgroundView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Onboarding/OnboardingBackgroundView.swift
@@ -28,6 +28,8 @@ final class OnboardingBackgroundView: NSView {
     }()
     private var maskFrame: CGRect?
 
+    private let maskCornerRadius: CGFloat = 4
+
     // MARK: Init
 
     override init(frame frameRect: NSRect) {
@@ -53,12 +55,13 @@ final class OnboardingBackgroundView: NSView {
         maskFrame = frame
 
         // Create a bezier path
-        let path = NSBezierPath(rect: frame)
-        path.append(NSBezierPath(rect: bounds))
+        let path = NSBezierPath(
+            roundedRect: frame,
+            xRadius: maskCornerRadius,
+            yRadius: maskCornerRadius
+        ).flattened
 
-        //TODO: Find the way to support 4 rounded corners
-        // For some reasons, the NSBezierPath is skew
-        // https://github.com/toggl-open-source/toggldesktop/issues/4106
+        path.append(NSBezierPath(rect: bounds))
 
         // Set mask
         maskLayer.path = path.cgPath


### PR DESCRIPTION
### 📒 Description
To fix the issue I've used a flattened version of the path - `NSBezierPath.flattened`

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4106 

### 🔎 Review hints
Trigger onboarding with sign up or from code.

@NghiaTranUIT I don't know why but this solution works 😅. Couldn't find why this issue occurs in the first place (e.g. on iOS it would work with no problems).
Here is the documentation: [NSBezierPath.flattened](https://developer.apple.com/documentation/appkit/nsbezierpath/1520733-flattened)

<img width="508" alt="Screenshot 2020-06-02 at 10 55 14" src="https://user-images.githubusercontent.com/3470113/83496148-56324580-a4c1-11ea-95bb-e926a4e2072d.png">

