### PR TITLE
Add pinch to zoom gesture on Timeline view

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -48,11 +48,14 @@ final class TimelineDashboardViewController: NSViewController {
     private var isFirstTime = true
     lazy var datePickerView: DatePickerView = DatePickerView.xibView()
     private lazy var datasource = TimelineDatasource(collectionView)
+
     private var zoomLevel: TimelineDatasource.ZoomLevel = .x1 {
         didSet {
             datasource.update(zoomLevel)
         }
     }
+    private var zoomGestureDelta: CGFloat = 0
+
     private lazy var timeEntryHoverController: TimelineTimeEntryHoverViewController = {
         return TimelineTimeEntryHoverViewController(nibName: "TimelineTimeEntryHoverViewController", bundle: nil)
     }()
@@ -171,16 +174,6 @@ final class TimelineDashboardViewController: NSViewController {
         }
     }
 
-    @IBAction func zoomLevelDecreaseOnChange(_ sender: Any) {
-        guard let next = zoomLevel.nextLevel else { return }
-        zoomLevel = next
-    }
-
-    @IBAction func zoomLevelIncreaseOnChange(_ sender: Any) {
-        guard let previous = zoomLevel.previousLevel else { return }
-        zoomLevel = previous
-    }
-
     @IBAction func permissionBtnOnClicked(_ sender: Any) {
         SystemPermissionManager.shared.grant(.screenRecording)
     }
@@ -201,6 +194,38 @@ final class TimelineDashboardViewController: NSViewController {
 
     func previousDay() {
         datePickerView.previousDateBtnOnTap(self)
+    }
+
+    // MARK: Zoom
+
+    @IBAction func zoomLevelDecreaseOnChange(_ sender: Any) {
+        guard let next = zoomLevel.nextLevel else { return }
+        zoomLevel = next
+    }
+
+    @IBAction func zoomLevelIncreaseOnChange(_ sender: Any) {
+        guard let previous = zoomLevel.previousLevel else { return }
+        zoomLevel = previous
+    }
+
+    override func magnify(with event: NSEvent) {
+        super.magnify(with: event)
+
+        let location = view.convert(event.locationInWindow, from: nil)
+        guard collectionViewContainerView.frame.contains(location) else {
+            return
+        }
+
+        if event.phase == .began {
+            zoomGestureDelta = zoomLevel.gestureDelta
+        } else if event.phase == .changed {
+            zoomGestureDelta += event.deltaZ
+
+            let newZoomLevel = TimelineDatasource.ZoomLevel(gestureDelta: zoomGestureDelta)
+            if newZoomLevel != zoomLevel {
+                zoomLevel = newZoomLevel
+            }
+        }
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -69,6 +69,34 @@ final class TimelineDatasource: NSObject {
         var minimumGap: CGFloat {
             return 2.0
         }
+
+        var gestureDelta: CGFloat {
+            switch self {
+            case .x1:
+                return 0
+            case .x2:
+                return -100
+            case .x3:
+                return -250
+            case .x4:
+                return -400
+            }
+        }
+
+        init(gestureDelta: CGFloat) {
+            switch gestureDelta {
+            case Self.x2.gestureDelta ..< Self.x1.gestureDelta:
+                self = .x1
+            case Self.x3.gestureDelta ..< Self.x2.gestureDelta:
+                self = .x2
+            case Self.x4.gestureDelta ..< Self.x3.gestureDelta:
+                self = .x3
+            case ..<Self.x4.gestureDelta:
+                self = .x4
+            default:
+                self = .x1
+            }
+        }
     }
 
     // MARK: Variables


### PR DESCRIPTION
### 📒 Description
Handling pinch gesture if the initial cursor location is in bounds of the timeline view.
Pich delta value is converted into existing `ZoomLevel` enum and applied to the timeline view layout.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #4103 

### 🔎 Review hints
Run the app to test if zooming fills "natural".
To play with the sensitivity of the pinch gesture update values in `TimelineDatasource.ZoomLevel.gestureDelta`.

