### PR TITLE
Fix undoing time entry stopping the timer

### DIFF
--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -639,7 +639,7 @@ char_t *toggl_format_tracked_time_duration(
     return copy_string(formatted);
 }
 
-char_t *toggl_start(
+char_t *toggl_start_with_current_running(
     void *context,
     const char_t *description,
     const char_t *duration,
@@ -649,7 +649,8 @@ char_t *toggl_start(
     const char_t *tags,
     const bool_t prevent_on_app,
     const uint64_t started,
-    const uint64_t ended) {
+    const uint64_t ended,
+    const bool_t stop_current_running) {
 
     logger().debug("toggl_start");
 
@@ -683,11 +684,36 @@ char_t *toggl_start(
         prevent_on_app,
         started,
         ended,
-        true);
+        stop_current_running);
     if (te) {
         return copy_string(te->GUID());
     }
     return nullptr;
+}
+
+char_t *toggl_start(
+    void *context,
+    const char_t *description,
+    const char_t *duration,
+    const uint64_t task_id,
+    const uint64_t project_id,
+    const char_t *project_guid,
+    const char_t *tags,
+    const bool_t prevent_on_app,
+    const uint64_t started,
+    const uint64_t ended) {
+
+    return toggl_start_with_current_running(context,
+                                            description,
+                                            duration,
+                                            task_id,
+                                            project_id,
+                                            project_guid,
+                                            tags,
+                                            prevent_on_app,
+                                            started,
+                                            ended,
+                                            true); // stopping current tasks by default
 }
 
 char_t *toggl_create_empty_time_entry(

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -958,6 +958,20 @@ extern "C" {
         void *context);
 
     // returns GUID of the started time entry. you must free() the result
+    TOGGL_EXPORT char_t *toggl_start_with_current_running(
+        void *context,
+        const char_t *description,
+        const char_t *duration,
+        const uint64_t task_id,
+        const uint64_t project_id,
+        const char_t *project_guid,
+        const char_t *tags,
+        const bool_t prevent_on_app,
+        const uint64_t started,
+        const uint64_t ended,
+        const bool_t stop_current_running);
+
+    // returns GUID of the started time entry. you must free() the result
     TOGGL_EXPORT char_t *toggl_start(
         void *context,
         const char_t *description,

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -358,7 +358,7 @@ void *ctx;
     if (tags == nil) {
         tags = @"";
     }
-    char *guid = toggl_start(ctx,
+    char *guid = toggl_start_with_current_running(ctx,
                              [item.Description UTF8String],
                              [item.duration UTF8String],
                              item.TaskID,
@@ -367,7 +367,8 @@ void *ctx;
                              [tags UTF8String],
                              false,
                              [item.started timeIntervalSince1970],
-                             [item.ended timeIntervalSince1970]);
+                             [item.ended timeIntervalSince1970],
+                             false);
     if (guid != nil) {
         NSString *GUID = [NSString stringWithUTF8String:guid];
         free(guid);


### PR DESCRIPTION
### 📒 Description
Undo manager was using `toggl_start` to recreate removed entities.
By default `toggl_start` was calling `Context::Start` with `stop_current_running == true`. Because of that current timer always automatically stops.

Added new function `toggl_start_with_current_running` where we can pass `stop_current_running` if needed. Now undo manager uses it with `stop_current_running == false`.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)
### 👫 Relationships
Closes #4073 

### 🔎 Review hints
See issue for steps to reproduce.
