### PR TITLE
Fix Zoom button is hidden randomly (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -118,6 +118,13 @@ final class TimelineDashboardViewController: NSViewController {
         DesktopLibraryBridge.shared().timelineSetDate(proposedDate)
     }
 
+    private lazy var trackingArea: NSTrackingArea = {
+        return NSTrackingArea(rect: view.bounds,
+                              options: [.mouseEnteredAndExited, .activeAlways],
+                              owner: self,
+                              userInfo: nil)
+    }()
+
     // MARK: View
     
     override func viewDidLoad() {
@@ -126,7 +133,6 @@ final class TimelineDashboardViewController: NSViewController {
         initCommon()
         initNotifications()
         initCollectionView()
-        initTrackingArea()
     }
 
     deinit {
@@ -192,12 +198,18 @@ final class TimelineDashboardViewController: NSViewController {
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
-        zoomContainerView.isHidden = false
+        if event.trackingArea === trackingArea {
+            zoomContainerView.isHidden = false
+        }
     }
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
-        zoomContainerView.isHidden = true
+
+        // Only hide the button if the event is triggered from the Zoom button tracking area
+        if event.trackingArea === trackingArea {
+            zoomContainerView.isHidden = true
+        }
     }
 
     func nextDay() {
@@ -256,6 +268,9 @@ extension TimelineDashboardViewController {
         
         // Forect Render the view
         _ = activityHoverController.view
+
+        // Tracking for Zoom buttons
+        view.addTrackingArea(trackingArea)
     }
 
     fileprivate func initNotifications() {
@@ -283,14 +298,6 @@ extension TimelineDashboardViewController {
                                        selector: #selector(runningTimeEntryNoti(_:)),
                                        name: Notification.Name(kDisplayTimerState),
                                        object: nil)
-    }
-
-    private func initTrackingArea() {
-        let tracking = NSTrackingArea(rect: collectionViewContainerView.bounds,
-                                      options: [.mouseEnteredAndExited, .activeInKeyWindow],
-                                      owner: collectionViewContainerView,
-                                      userInfo: nil)
-        collectionViewContainerView.addTrackingArea(tracking)
     }
 
     fileprivate func initCollectionView() {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -78,7 +78,7 @@ To get the focused application window name properly for the Timeline, TogglDeskt
                             </constraints>
                             <buttonCell key="cell" type="bevel" title="Permission required!" bezelStyle="regularSquare" image="NSCaution" imagePosition="left" alignment="center" controlSize="small" imageScaling="proportionallyDown" inset="2" id="Uj3-3t-CiG">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system" size="10"/>
+                                <font key="font" metaFont="menu" size="10"/>
                             </buttonCell>
                             <connections>
                                 <action selector="permissionBtnOnClicked:" target="-2" id="z5L-tH-fof"/>


### PR DESCRIPTION
### 📒 Description
This PR attempt to fix the Tracking Area of the Zoom button, which causes the button is hidden randomly

### Problem
- Each Time Entry pill has its own NSTrackingArea to show the Detail Popover, it also triggers the event (Entered and Exit) from the Timeline View -> Causes the zoom button is hidden

### Solution
- Check the source of the event and handle the logic properly

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Add logic to determine the source of the events

### 👫 Relationships
Closes #4136 

### 🔎 Review hints
- Make sure we couldn't reproduce the issue anymore

![2020-06-03 14 58 52](https://user-images.githubusercontent.com/5878421/83611551-5444b100-a5ab-11ea-87e6-77ba4a2707c1.gif)


