### PR TITLE
Add Tracking for Timeline Menu Context

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -381,7 +381,7 @@ void Analytics::TrackUserAuthentication(const std::string &client_id, const std:
 void Analytics::trackTimelineMenuContext(const std::string &client_id,
                                          const std::string &view) {
     std::stringstream ss;
-    ss << "/" << "click" << "/" << view;
+    ss << "click" << "/" << view;
     Track(client_id, "timeline-menu-context", ss.str());
 }
 

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -378,4 +378,32 @@ void Analytics::TrackUserAuthentication(const std::string &client_id, const std:
     Track(client_id, "user", ss.str());
 }
 
+void Analytics::trackTimelineMenuContext(const std::string &client_id,
+                                         const std::string &os,
+                                         const std::string &view) {
+    std::stringstream ss;
+    ss << os << "/" << "click" << "/" << view;
+    Track(client_id, "timeline-menu-context", ss.str());
+}
+
+void Analytics::TrackTimelineMenuContext(const std::string &client_id, const std::string& os, const TimelineMenuContextType type) {
+    switch (type) {
+        case TimelineMenuContextTypeContinueEntry:
+            trackTimelineMenuContext(client_id, os, "continue-this-entry");
+            break;
+        case TimelineMenuContextTypeStartEntryFromEnd:
+            trackTimelineMenuContext(client_id, os, "start-entry-from-the-end-of-this-entry");
+            break;
+        case TimelineMenuContextTypeDelete:
+            trackTimelineMenuContext(client_id, os, "delete");
+            break;
+        case TimelineMenuContextTypeChangeFirstEntryStopTime:
+            trackTimelineMenuContext(client_id, os, "change-first-entry-stop-time");
+            break;
+        case TimelineMenuContextTypeChangeLastEntryStartTime:
+            trackTimelineMenuContext(client_id, os, "change-last-entry-start-time");
+            break;
+    }
+}
+
 }  // namespace toggl

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -379,29 +379,28 @@ void Analytics::TrackUserAuthentication(const std::string &client_id, const std:
 }
 
 void Analytics::trackTimelineMenuContext(const std::string &client_id,
-                                         const std::string &os,
                                          const std::string &view) {
     std::stringstream ss;
-    ss << os << "/" << "click" << "/" << view;
+    ss << "/" << "click" << "/" << view;
     Track(client_id, "timeline-menu-context", ss.str());
 }
 
-void Analytics::TrackTimelineMenuContext(const std::string &client_id, const std::string& os, const TimelineMenuContextType type) {
+void Analytics::TrackTimelineMenuContext(const std::string &client_id, const TimelineMenuContextType type) {
     switch (type) {
         case TimelineMenuContextTypeContinueEntry:
-            trackTimelineMenuContext(client_id, os, "continue-this-entry");
+            trackTimelineMenuContext(client_id, "continue-this-entry");
             break;
         case TimelineMenuContextTypeStartEntryFromEnd:
-            trackTimelineMenuContext(client_id, os, "start-entry-from-the-end-of-this-entry");
+            trackTimelineMenuContext(client_id, "start-entry-from-the-end-of-this-entry");
             break;
         case TimelineMenuContextTypeDelete:
-            trackTimelineMenuContext(client_id, os, "delete");
+            trackTimelineMenuContext(client_id, "delete");
             break;
         case TimelineMenuContextTypeChangeFirstEntryStopTime:
-            trackTimelineMenuContext(client_id, os, "change-first-entry-stop-time");
+            trackTimelineMenuContext(client_id, "change-first-entry-stop-time");
             break;
         case TimelineMenuContextTypeChangeLastEntryStartTime:
-            trackTimelineMenuContext(client_id, os, "change-last-entry-start-time");
+            trackTimelineMenuContext(client_id, "change-last-entry-start-time");
             break;
     }
 }

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -91,7 +91,7 @@ class Analytics : public Poco::TaskManager {
     void TrackSignupWithApple(const std::string &client_id);
     void TrackLoginWithApple(const std::string &client_id);
 
-    void TrackTimelineMenuContext(const std::string &client_id, const std::string& os, const TimelineMenuContextType type);
+    void TrackTimelineMenuContext(const std::string &client_id, const TimelineMenuContextType type);
 
  private:
     Poco::LocalDateTime settings_sync_date;
@@ -111,7 +111,6 @@ class Analytics : public Poco::TaskManager {
                                  const std::string &from);
 
     void trackTimelineMenuContext(const std::string &client_id,
-                                  const std::string &os,
                                   const std::string &view);
 };
 

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -14,6 +14,14 @@
 
 namespace toggl {
 
+enum TimelineMenuContextType {
+    TimelineMenuContextTypeContinueEntry,
+    TimelineMenuContextTypeStartEntryFromEnd,
+    TimelineMenuContextTypeDelete,
+    TimelineMenuContextTypeChangeFirstEntryStopTime,
+    TimelineMenuContextTypeChangeLastEntryStartTime
+};
+
 class Analytics : public Poco::TaskManager {
  public:
     Analytics()
@@ -83,6 +91,8 @@ class Analytics : public Poco::TaskManager {
     void TrackSignupWithApple(const std::string &client_id);
     void TrackLoginWithApple(const std::string &client_id);
 
+    void TrackTimelineMenuContext(const std::string &client_id, const std::string& os, const TimelineMenuContextType type);
+
  private:
     Poco::LocalDateTime settings_sync_date;
 
@@ -99,6 +109,10 @@ class Analytics : public Poco::TaskManager {
     void TrackUserAuthentication(const std::string &client_id,
                                  const std::string &action,
                                  const std::string &from);
+
+    void trackTimelineMenuContext(const std::string &client_id,
+                                  const std::string &os,
+                                  const std::string &view);
 };
 
 class GoogleAnalyticsEvent : public Poco::Task {

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -11,16 +11,9 @@
 #include "proxy.h"
 #include "model/settings.h"
 #include "util/rectangle.h"
+#include "toggl_api.h"
 
 namespace toggl {
-
-enum TimelineMenuContextType {
-    TimelineMenuContextTypeContinueEntry,
-    TimelineMenuContextTypeStartEntryFromEnd,
-    TimelineMenuContextTypeDelete,
-    TimelineMenuContextTypeChangeFirstEntryStopTime,
-    TimelineMenuContextTypeChangeLastEntryStartTime
-};
 
 class Analytics : public Poco::TaskManager {
  public:

--- a/src/context.cc
+++ b/src/context.cc
@@ -6822,5 +6822,10 @@ bool Context::checkIfSkipPomodoro(TimeEntry *te) {
     return false;
 }
 
+void Context::TrackTimelineMenuContext(const TimelineMenuContextType type) {
+    if ("production" == environment_) {
+        analytics_.TrackTimelineMenuContext(db_->AnalyticsClientID(), type);
+    }
+}
 
 }  // namespace toggl

--- a/src/context.h
+++ b/src/context.h
@@ -565,6 +565,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void UserDidTurnOnRecordActivity();
     void UserDidEditOrAddTimeEntryOnTimelineView();
 
+    void TrackTimelineMenuContext(const TimelineMenuContextType type);
+
  protected:
     void uiUpdaterActivity();
     void checkReminders();

--- a/src/script/generate_cs_api.go
+++ b/src/script/generate_cs_api.go
@@ -128,7 +128,7 @@ func main() {
 			write("public enum" + csclass)
 			write("{")
 		} else if len(csclass) != 0 {
-			if strings.Contains(s, "} Toggl") {
+			if strings.Contains(s, "} ") {
 				csclass = ""
 				if len(firstStringField) > 0 {
 					write("")

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1634,3 +1634,23 @@ TogglHsvColor toggl_get_adaptive_hsv_color(
     TogglAdaptiveColor type) {
     return toggl::ColorConverter::GetAdaptiveColor(rgbColor, type);
 }
+
+void toggl_track_timeline_menu_context_continue_entry(void *context) {
+    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeContinueEntry);
+}
+
+void toggl_track_timeline_menu_context_start_entry_from_end(void *context) {
+    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeStartEntryFromEnd);
+}
+
+void toggl_track_timeline_menu_context_delete(void *context) {
+    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeDelete);
+}
+
+void toggl_track_timeline_menu_context_change_first_entry(void *context) {
+    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeChangeFirstEntryStopTime);
+}
+
+void toggl_track_timeline_menu_context_change_last_entry(void *context) {
+    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeChangeLastEntryStartTime);
+}

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1635,22 +1635,6 @@ TogglHsvColor toggl_get_adaptive_hsv_color(
     return toggl::ColorConverter::GetAdaptiveColor(rgbColor, type);
 }
 
-void toggl_track_timeline_menu_context_continue_entry(void *context) {
-    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeContinueEntry);
-}
-
-void toggl_track_timeline_menu_context_start_entry_from_end(void *context) {
-    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeStartEntryFromEnd);
-}
-
-void toggl_track_timeline_menu_context_delete(void *context) {
-    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeDelete);
-}
-
-void toggl_track_timeline_menu_context_change_first_entry(void *context) {
-    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeChangeFirstEntryStopTime);
-}
-
-void toggl_track_timeline_menu_context_change_last_entry(void *context) {
-    app(context)->TrackTimelineMenuContext(toggl::TimelineMenuContextTypeChangeLastEntryStartTime);
+void toggl_track_timeline_menu_context(void *context, TimelineMenuContextType menuType) {
+    app(context)->TrackTimelineMenuContext(menuType);
 }

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1253,9 +1253,9 @@ extern "C" {
         TogglRgbColor rgbColor,
         TogglAdaptiveColor type);
 
-    TOGGL_EXPORT HsvColor toggl_get_adaptive_hsv_color(
-        RgbColor rgbColor,
-        AdaptiveColor type);
+    TOGGL_EXPORT TogglHsvColor toggl_get_adaptive_hsv_color(
+        TogglRgbColor rgbColor,
+        TogglAdaptiveColor type);
 
     TOGGL_EXPORT void toggl_track_timeline_menu_context_continue_entry(
         void *context);

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -234,7 +234,7 @@ extern "C" {
     } TogglAdaptiveColor;
 
     typedef enum {
-        TimelineMenuContextTypeContinueEntry = 0,
+        TimelineMenuContextTypeContinueEntry,
         TimelineMenuContextTypeStartEntryFromEnd,
         TimelineMenuContextTypeDelete,
         TimelineMenuContextTypeChangeFirstEntryStopTime,
@@ -1256,10 +1256,6 @@ extern "C" {
     TOGGL_EXPORT void toggl_on_continue_sign_in(
         void *context,
         TogglContinueSignIn cb);
-
-    TOGGL_EXPORT TogglHsvColor toggl_get_adaptive_hsv_color(
-        TogglRgbColor rgbColor,
-        TogglAdaptiveColor type);
 
     TOGGL_EXPORT TogglHsvColor toggl_get_adaptive_hsv_color(
         TogglRgbColor rgbColor,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1253,6 +1253,25 @@ extern "C" {
         TogglRgbColor rgbColor,
         TogglAdaptiveColor type);
 
+    TOGGL_EXPORT HsvColor toggl_get_adaptive_hsv_color(
+        RgbColor rgbColor,
+        AdaptiveColor type);
+
+    TOGGL_EXPORT void toggl_track_timeline_menu_context_continue_entry(
+        void *context);
+
+    TOGGL_EXPORT void toggl_track_timeline_menu_context_start_entry_from_end(
+        void *context);
+
+    TOGGL_EXPORT void toggl_track_timeline_menu_context_delete(
+        void *context);
+
+    TOGGL_EXPORT void toggl_track_timeline_menu_context_change_first_entry(
+        void *context);
+
+    TOGGL_EXPORT void toggl_track_timeline_menu_context_change_last_entry(
+        void *context);
+
 #undef TOGGL_EXPORT
 
 #ifdef __cplusplus

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -233,6 +233,14 @@ extern "C" {
         AdaptiveColorTextOnDarkBackground
     } TogglAdaptiveColor;
 
+    typedef enum {
+        TimelineMenuContextTypeContinueEntry = 0,
+        TimelineMenuContextTypeStartEntryFromEnd,
+        TimelineMenuContextTypeDelete,
+        TimelineMenuContextTypeChangeFirstEntryStopTime,
+        TimelineMenuContextTypeChangeLastEntryStartTime
+    } TimelineMenuContextType;
+
     // Callbacks that need to be implemented in UI
 
     typedef void (*TogglDisplayApp)(
@@ -1257,20 +1265,9 @@ extern "C" {
         TogglRgbColor rgbColor,
         TogglAdaptiveColor type);
 
-    TOGGL_EXPORT void toggl_track_timeline_menu_context_continue_entry(
-        void *context);
-
-    TOGGL_EXPORT void toggl_track_timeline_menu_context_start_entry_from_end(
-        void *context);
-
-    TOGGL_EXPORT void toggl_track_timeline_menu_context_delete(
-        void *context);
-
-    TOGGL_EXPORT void toggl_track_timeline_menu_context_change_first_entry(
-        void *context);
-
-    TOGGL_EXPORT void toggl_track_timeline_menu_context_change_last_entry(
-        void *context);
+    TOGGL_EXPORT void toggl_track_timeline_menu_context(
+        void *context,
+        TimelineMenuContextType menuType);
 
 #undef TOGGL_EXPORT
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -127,11 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Tracking
 
--(void) trackTimelineMenuContextContinue;
--(void) trackTimelineMenuContextStart;
--(void) trackTimelineMenuContextDelete;
--(void) trackTimelineMenuContextChangeFirst;
--(void) trackTimelineMenuContextChangeLast;
+-(void) trackTimelineMenuContextType:(TimelineMenuContextType) type;
 
 @end
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -125,6 +125,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)userDidTurnOnRecordActivity;
 - (void)userDidEditOrAddTimeEntryDirectlyOnTimelineView;
 
+#pragma mark - Tracking
+
+-(void) trackTimelineMenuContextContinue;
+-(void) trackTimelineMenuContextStart;
+-(void) trackTimelineMenuContextDelete;
+-(void) trackTimelineMenuContextChangeFirst;
+-(void) trackTimelineMenuContextChangeLast;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -442,28 +442,8 @@ void *ctx;
     toggl_user_did_edit_add_timeentry_on_timeline_view(ctx);
 }
 
--(void) trackTimelineMenuContextContinue
+-(void) trackTimelineMenuContextType:(TimelineMenuContextType) type
 {
-    toggl_track_timeline_menu_context_continue_entry(ctx);
-}
-
--(void) trackTimelineMenuContextStart
-{
-    toggl_track_timeline_menu_context_start_entry_from_end(ctx);
-}
-
--(void) trackTimelineMenuContextDelete
-{
-    toggl_track_timeline_menu_context_delete(ctx);
-}
-
--(void) trackTimelineMenuContextChangeFirst
-{
-    toggl_track_timeline_menu_context_change_first_entry(ctx);
-}
-
--(void) trackTimelineMenuContextChangeLast
-{
-    toggl_track_timeline_menu_context_change_last_entry(ctx);
+    toggl_track_timeline_menu_context(ctx, type);
 }
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -442,4 +442,28 @@ void *ctx;
     toggl_user_did_edit_add_timeentry_on_timeline_view(ctx);
 }
 
+-(void) trackTimelineMenuContextContinue
+{
+    toggl_track_timeline_menu_context_continue_entry(ctx);
+}
+
+-(void) trackTimelineMenuContextStart
+{
+    toggl_track_timeline_menu_context_start_entry_from_end(ctx);
+}
+
+-(void) trackTimelineMenuContextDelete
+{
+    toggl_track_timeline_menu_context_delete(ctx);
+}
+
+-(void) trackTimelineMenuContextChangeFirst
+{
+    toggl_track_timeline_menu_context_change_first_entry(ctx);
+}
+
+-(void) trackTimelineMenuContextChangeLast
+{
+    toggl_track_timeline_menu_context_change_last_entry(ctx);
+}
 @end

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -20,7 +20,7 @@ protocol TimelineTimeEntryMenuDelegate: class {
 /// Menu Contextual on the Timeline Time Entry
 /// It will be shown by right-click on the cell
 /// Support some resolve conflict funcs
-@objc final class TimelineTimeEntryMenu: NSMenu {
+final class TimelineTimeEntryMenu: NSMenu {
 
     // MARK: Variables
 
@@ -84,31 +84,31 @@ extension TimelineTimeEntryMenu {
 
     @objc private func continueMenuOnTap() {
         guard let timeEntry = timeEntry else { return }
-        DesktopLibraryBridge.shared().trackTimelineMenuContextContinue()
+        DesktopLibraryBridge.shared().trackTimelineMenuContextType(TimelineMenuContextTypeContinueEntry)
         menuDelegate?.timelineMenuContinue(timeEntry)
     }
 
     @objc private func startEntryOnTap() {
         guard let timeEntry = timeEntry else { return }
-        DesktopLibraryBridge.shared().trackTimelineMenuContextStart()
+        DesktopLibraryBridge.shared().trackTimelineMenuContextType(TimelineMenuContextTypeStartEntryFromEnd)
         menuDelegate?.timelineMenuStartEntry(timeEntry)
     }
 
     @objc private func deleteEntryOnTap() {
         guard let timeEntry = timeEntry else { return }
-        DesktopLibraryBridge.shared().trackTimelineMenuContextDelete()
+        DesktopLibraryBridge.shared().trackTimelineMenuContextType(TimelineMenuContextTypeDelete)
         menuDelegate?.timelineMenuDelete(timeEntry)
     }
 
     @objc private func changeFirstEntryStopTimeOnTap() {
         guard let timeEntry = timeEntry else { return }
-        DesktopLibraryBridge.shared().trackTimelineMenuContextChangeFirst()
+        DesktopLibraryBridge.shared().trackTimelineMenuContextType(TimelineMenuContextTypeChangeFirstEntryStopTime)
         menuDelegate?.timelineMenuChangeFirstEntryStopTime(timeEntry)
     }
 
     @objc private func changeLastEntryStartTimeOnTap() {
         guard let timeEntry = timeEntry else { return }
-        DesktopLibraryBridge.shared().trackTimelineMenuContextChangeLast()
+        DesktopLibraryBridge.shared().trackTimelineMenuContextType(TimelineMenuContextTypeChangeLastEntryStartTime)
         menuDelegate?.timelineMenuChangeLastEntryStartTime(timeEntry)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -20,7 +20,7 @@ protocol TimelineTimeEntryMenuDelegate: class {
 /// Menu Contextual on the Timeline Time Entry
 /// It will be shown by right-click on the cell
 /// Support some resolve conflict funcs
-final class TimelineTimeEntryMenu: NSMenu {
+@objc final class TimelineTimeEntryMenu: NSMenu {
 
     // MARK: Variables
 
@@ -84,26 +84,31 @@ extension TimelineTimeEntryMenu {
 
     @objc private func continueMenuOnTap() {
         guard let timeEntry = timeEntry else { return }
+        DesktopLibraryBridge.shared().trackTimelineMenuContextContinue()
         menuDelegate?.timelineMenuContinue(timeEntry)
     }
 
     @objc private func startEntryOnTap() {
         guard let timeEntry = timeEntry else { return }
+        DesktopLibraryBridge.shared().trackTimelineMenuContextStart()
         menuDelegate?.timelineMenuStartEntry(timeEntry)
     }
 
     @objc private func deleteEntryOnTap() {
         guard let timeEntry = timeEntry else { return }
+        DesktopLibraryBridge.shared().trackTimelineMenuContextDelete()
         menuDelegate?.timelineMenuDelete(timeEntry)
     }
 
     @objc private func changeFirstEntryStopTimeOnTap() {
         guard let timeEntry = timeEntry else { return }
+        DesktopLibraryBridge.shared().trackTimelineMenuContextChangeFirst()
         menuDelegate?.timelineMenuChangeFirstEntryStopTime(timeEntry)
     }
 
     @objc private func changeLastEntryStartTimeOnTap() {
         guard let timeEntry = timeEntry else { return }
+        DesktopLibraryBridge.shared().trackTimelineMenuContextChangeLast()
         menuDelegate?.timelineMenuChangeLastEntryStartTime(timeEntry)
     }
 }

--- a/src/ui/osx/TogglDesktop/Other/TogglDesktop-Bridging-Header.h
+++ b/src/ui/osx/TogglDesktop/Other/TogglDesktop-Bridging-Header.h
@@ -21,3 +21,4 @@
 #import "BetterFocusAutoCompleteInput.h"
 #import "Settings.h"
 #import "AppDelegate.h"
+#import "toggl_api.h"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -389,6 +389,15 @@ public static partial class Toggl
         AdaptiveColorTextOnDarkBackground
     }
 
+    public enum    TimelineMenuContextType
+    {
+        TimelineMenuContextTypeContinueEntry,
+        TimelineMenuContextTypeStartEntryFromEnd,
+        TimelineMenuContextTypeDelete,
+        TimelineMenuContextTypeChangeFirstEntryStopTime,
+        TimelineMenuContextTypeChangeLastEntryStartTime
+    }
+
     // Callbacks that need to be implemented in UI
 
     [UnmanagedFunctionPointer(convention)]
@@ -1478,6 +1487,27 @@ public static partial class Toggl
 
     // returns GUID of the started time entry. you must free() the result
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern string toggl_start_with_current_running(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string description,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string duration,
+        UInt64 task_id,
+        UInt64 project_id,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string project_guid,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string tags,
+        [MarshalAs(UnmanagedType.I1)]
+        bool prevent_on_app,
+        UInt64 started,
+        UInt64 ended,
+        [MarshalAs(UnmanagedType.I1)]
+        bool stop_current_running);
+
+    // returns GUID of the started time entry. you must free() the result
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern string toggl_start(
         IntPtr context,
         [MarshalAs(UnmanagedType.LPWStr)]
@@ -1856,6 +1886,11 @@ public static partial class Toggl
     private static extern TogglHsvColor toggl_get_adaptive_hsv_color(
         TogglRgbColor rgbColor,
         TogglAdaptiveColor type);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void toggl_track_timeline_menu_context(
+        IntPtr context,
+        TimelineMenuContextType menuType);
 
 
 


### PR DESCRIPTION
### 📒 Description
This PR attempts to add some tracking when the user click on each menu item of the Timeline Menu

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Add tracking to library with defined enums
- Add tracking to macOS when the user clicks on the menu item

### 👫 Relationships
Closes #4133

### 🔎 Review hints
1. Start the app with Production schema
2. Right-click on the Timeline Time Entry pill and select any items
3. Check if the analytic or Set a breakpoint that it triggers the event
 