### PR TITLE
Fix Cycle dependencies build error on macOS

### DIFF
--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -542,11 +542,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C55DA5A917F06A3B00B42178 /* Build configuration list for PBXNativeTarget "TogglDesktopLibrary" */;
 			buildPhases = (
+				BAA842212403D96100BCCB67 /* CopyFiles */,
 				C55DA59817F06A3B00B42178 /* Sources */,
 				C55DA59917F06A3B00B42178 /* Frameworks */,
 				C55DA59A17F06A3B00B42178 /* Headers */,
 				C5DA1FB317F19052001C4565 /* ShellScript */,
-				BAA842212403D96100BCCB67 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -1970,7 +1970,6 @@
 				74E3CDDA17FC37A500C3ADD3 /* Run Script (install bugsnag) */,
 				74A50AA818434D90006F37BB /* CopyFiles */,
 				69FC17EF17E6534400B96425 /* Resources */,
-				7407F1F41AA80466000380C4 /* Run Script (Fix dynamic library paths in Frameworks) */,
 				BA6406F121C8FC690074BC96 /* Run Formatter */,
 				CE4DD35122BF90B10398A0A6 /* [CP] Embed Pods Frameworks */,
 				B984F0D8FC24E4374FFADFBB /* Upload Bugsnag dSYM */,
@@ -2245,20 +2244,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		7407F1F41AA80466000380C4 /* Run Script (Fix dynamic library paths in Frameworks) */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script (Fix dynamic library paths in Frameworks)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "fix() {\n    pocolib=$1\n    lib=$2\n    oldpath=$(otool -L $pocolib|fgrep $lib|awk -F' ' '{print $1}'|grep -v @loader_path|grep -v \":\")\n    if [ -z \"$oldpath\" ]; then\n    return\n    fi\n    install_name_tool -change $oldpath @loader_path/$lib $pocolib\n    \n    # get shared library id name\n    file=$(otool -D $pocolib |grep -v \":\")\n    # get base name of the path we got\n    basename=${file##*/}\n        # change shared library id name\n        install_name_tool -id @loader_path/$basename $pocolib\n    }\n    \n    fix_poco_paths() {\n        f=$1\n        fix $f libPocoUtil.60.dylib\n        fix $f libPocoData.60.dylib\n        fix $f libPocoNetSSL.60.dylib\n        fix $f libPocoXML.60.dylib\n        fix $f libPocoDataSQLite.60.dylib\n        fix $f libPocoNet.60.dylib\n        fix $f libPocoFoundation.60.dylib\n        fix $f libPocoCrypto.60.dylib\n        fix $f libPocoJSON.60.dylib\n        fix $f libcrypto.1.1.dylib\n        fix $f libssl.1.1.dylib\n    }\n    \n    # Change dylib references in all dylibs found in Frameworks\n    for f in $BUILT_PRODUCTS_DIR/TogglDesktop.app/Contents/Frameworks/*.dylib\n                                                                                        do\n                                                                                        fix_poco_paths $f\n                                                                                        done\n";
 		};
 		74E3CDDA17FC37A500C3ADD3 /* Run Script (install bugsnag) */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
### 📒 Description
We would see this build error only on incremental builds.
From the [documentation](https://help.apple.com/xcode/mac/current/#/dev621201fb0):
> To allow fast and correct incremental builds, every build after the initial build uses information discovered during the prior builds to learn about additional dependencies in your source code, such as included headers or imported modules. This may lead to dependency cycles which are only discovered after the first successful build.

Did some experiments and this combination fixed the issue:
1. In TogglDesktop target remove from the Build Phases `Run Script (Fix dynamic library paths in Frameworks)`
1. Go to TogglDesktopLibrary target -> Build Phases
1. Move "Copy File" section up so it is now above "Compile Sources"

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)

### 👫 Relationships
Closes #4067

### 🔎 Review hints
To reproduce the compile error you would do next:
1. Clean project
1. Build
1. Change something in the library (e.g. add whitespace line to `toggl_api.cc`)
1. Build
1. Build again

At step 5 you'll get compile error: Cycle in dependencies between targets 'TogglDesktop' and 'TogglDesktopLibrary'.

After applying changes from PR this error should go away.

### TODO
-[] Test if GitHub Actions still work
-[] Tested with release builds
-[] Test and apply if needed to TogglDesktop-AppStore target