### PR TITLE
Default edit view width cuts off start/end time in the 12-hour format

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -7,7 +7,7 @@
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-             mc:Ignorable="d" MinWidth="300">
+             mc:Ignorable="d" MinWidth="320">
     <Grid Background="{DynamicResource Toggl.CardBackground}">
         <Grid Name="contentGrid" x:FieldModifier="private" Margin="28 20">
             <Grid.RowDefinitions>
@@ -198,10 +198,10 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="19*" />
-                        <ColumnDefinition Width="18*"/>
+                        <ColumnDefinition Width="21*" />
+                        <ColumnDefinition Width="17*"/>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="18*" />
+                        <ColumnDefinition Width="17*" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 0 0 8" Text="Duration" />
                     <toggl:ExtendedTextBox x:Name="durationTextBox" x:FieldModifier="private" Grid.Row="1" Grid.Column="0"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -198,10 +198,10 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="23*" />
-                        <ColumnDefinition Width="16*"/>
+                        <ColumnDefinition Width="19*" />
+                        <ColumnDefinition Width="18*"/>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="16*" />
+                        <ColumnDefinition Width="18*" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 0 0 8" Text="Duration" />
                     <toggl:ExtendedTextBox x:Name="durationTextBox" x:FieldModifier="private" Grid.Row="1" Grid.Column="0"


### PR DESCRIPTION
### 📒 Description
This makes the editboxes for start/end time wider and removes the cuts off start/end time in the 12-hour format.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
Changes grid markup in xaml.

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3934 

