### PR TITLE
Fix crash in PreferencesWindowViewModel

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -122,7 +122,7 @@ namespace TogglDesktop.ViewModels
 
         private void UpdateKnownShortcuts(HotKey previousValue, HotKey newValue, string hotKeyDescription)
         {
-            if (!previousValue.IsNullOrNone())
+            if (!previousValue.IsNullOrNone() && _knownShortcuts.ContainsKey(previousValue))
             {
                 if (_knownShortcuts[previousValue] == hotKeyDescription)
                 {


### PR DESCRIPTION
### 📒 Description
Steps to reproduce:

1. Open preferences.
2. Set the show/hide toggl shortcut to some key.
3. Then set the start/stop timer to just the same key.
4. Then remove the first shortcut.
5. Then change the shortcut for the second one.

This checks for the key being preset in dictionary.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3995 

### 🔎 Review hints
This is not the ideal fix, as it does not remove the source of the problem. It would be better to make some kind of group validation for the two hotkey boxes (so that when one changes, then the validation is called for both), as change in one hotkey may lead to the situation when the other becomes valid.

