### PR TITLE
Add the (hopefully final) sync server URLs

### DIFF
--- a/src/urls.cc
+++ b/src/urls.cc
@@ -39,9 +39,9 @@ std::string API() {
 
 std::string SyncAPI() {
     if (use_staging_as_backend) {
-        // TODO
+        return "https://sync.toggl.space/";
     }
-    return "http://localhost:8080";
+    return "https://sync.toggl.com/";
 }
 
 std::string TimelineUpload() {


### PR DESCRIPTION
### 📒 Description
Not much to say here, the URLs are now changed to staging and stable servers so we can test (for now only staging) against "real" servers. Really a very simple change.

### 🕶️ Types of changes
 - **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
Pulling from sync server should now work without running your own Sync server instance.

