### PR TITLE
Fixing tags dropdown behavior in edit view

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TagList.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TagList.xaml
@@ -25,7 +25,7 @@
                                        ConfirmCompletion="autoComplete_OnConfirmCompletion"
                                        ConfirmWithoutCompletion="autoComplete_OnConfirmWithoutCompletion"
                                        KeepOpenWhenSelecting="True"
-                                       StaysOpen="True"
+                                       StaysOpen="False"
                                        IsOpenChanged="AutoComplete_OnIsOpenChanged"
                                        ActionButtonText="{Binding ElementName=textBox, Path=Text, Converter={StaticResource StringFormatIfNotEmptyConverter}, ConverterParameter='Add tag &quot;{0}&quot;'}"
                                        ActionButtonClick="AutoComplete_OnActionButtonClick"/>


### PR DESCRIPTION
### 📒 Description
Changes the behavior of tags dropdown so that it closes when user clicks outside it.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4004 

### 🔎 Review hints
Now the behavior for prject dropdown and for tags dropdown is the same.

