### PR TITLE
Implement push and pull from the Sync server

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -6309,8 +6309,6 @@ error Context::syncHandleResponse(Json::Value &array, const std::vector<T*> &sou
     auto findByLocalID = [](auto &source, auto localID) -> typename std::remove_reference<decltype(source)>::type::value_type {
         auto id = stoi(localID);
         id = id < 0 ? -id : id;
-        if (id < 0)
-            id = -id;
         for (auto i : source) {
             if (i->LocalID() == id) {
                 return i;
@@ -6319,11 +6317,8 @@ error Context::syncHandleResponse(Json::Value &array, const std::vector<T*> &sou
         return nullptr;
     };
     auto findByID = [](auto &source, auto ID) -> typename std::remove_reference<decltype(source)>::type::value_type {
-        auto id = ID < 0 ? -ID : ID;
-        if (id < 0)
-            id = -id;
         for (auto i : source) {
-            if (i->ID() == id) {
+            if (i->ID() == ID) {
                 return i;
             }
         }

--- a/src/context.cc
+++ b/src/context.cc
@@ -5351,9 +5351,6 @@ error Context::pushBatchedChanges(
             }
         }
 
-        std::stringstream ss;
-        ss << "Sync success (";
-
         Json::Value request;
 
         // the conditions should be here so we don't create unnecessary empty JSON items
@@ -5402,8 +5399,7 @@ error Context::pushBatchedChanges(
         syncHandleResponse(responseJson["time_entries"], time_entries);
 
         stopwatch.stop();
-        ss << ") Total = " << stopwatch.elapsed() / 1000 << " ms";
-        logger.debug(ss.str());
+        logger.debug("Sync success. Total = ", stopwatch.elapsed() / 1000, " ms");
     } catch(const Poco::Exception& exc) {
         return exc.displayText();
     } catch(const std::exception& ex) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -50,8 +50,9 @@
 #include <Poco/Stopwatch.h>
 #include <Poco/StreamCopier.h>
 #include <Poco/URI.h>
-#include <Poco/UTF8String.h>
 #include <Poco/URIStreamOpener.h>
+#include <Poco/UUIDGenerator.h>
+#include <Poco/UTF8String.h>
 #include <Poco/Util/TimerTask.h>
 #include <Poco/Util/TimerTaskAdapter.h>
 #include <mutex> // NOLINT
@@ -125,7 +126,7 @@ Context::Context(const std::string &app_name, const std::string &app_version)
     OnboardingService::getInstance()->RegisterEvents([&] (const OnboardingType onboardingType) {
         UI()->DisplayOnboarding(onboardingType);
     });
-    
+
     TogglClient::GetInstance().SetSyncStateMonitor(UI());
 }
 
@@ -4996,7 +4997,7 @@ void Context::batchedSyncerActivity() {
     {
         Poco::Mutex::ScopedLock lock(syncer_m_);
 
-        if (trigger_sync_) {
+        if (trigger_sync_ || trigger_push_) {
 
             error err = pullBatchedUserData();
             if (err != noError) {
@@ -5005,7 +5006,7 @@ void Context::batchedSyncerActivity() {
 
             setOnline("Data pulled");
 
-            err = pushChanges(&trigger_sync_);
+            err = pushBatchedChanges(&trigger_sync_);
             trigger_push_ = false;
             if (err != noError) {
                 user_->ConfirmLoadedMore();
@@ -5026,30 +5027,6 @@ void Context::batchedSyncerActivity() {
             displayError(save(false));
         }
 
-    }
-
-    {
-        Poco::Mutex::ScopedLock lock(syncer_m_);
-
-        if (trigger_push_) {
-            error err = pushChanges(&trigger_sync_);
-            if (err != noError) {
-                user_->ConfirmLoadedMore();
-                displayError(err);
-            } else {
-                setOnline("Data pushed");
-            }
-            trigger_push_ = false;
-
-            // Push cached OBM action
-            err = pushObmAction();
-            if (err != noError) {
-                std::cout << "SYNC: pushObm ERROR\n";
-                logger.error("Error pushing OBM action: " + err);
-            }
-
-            displayError(save(false));
-        }
     }
 }
 
@@ -5264,22 +5241,11 @@ error Context::pullBatchedUserData() {
         std::string user_data_json("");
         error err = noError;
 
-        // For keeping it as simple as possible, start out with only full pulls without since
-        // fall back to /v8/me when we have a since argument
-        if (since) {
-            err = me(
-                api_token,
-                "api_token",
-                &user_data_json,
-                since);
-        }
-        else {
-            err = syncPull(
-                api_token,
-                "api_token",
-                &user_data_json,
-                since);
-        }
+        err = syncPull(
+            api_token,
+            "api_token",
+            &user_data_json,
+            since);
 
         Json::Value json;
         Json::Reader reader;
@@ -5296,7 +5262,7 @@ error Context::pullBatchedUserData() {
             }
             TimeEntry *running_entry = user_->RunningTimeEntry();
 
-            error err = user_->LoadUserAndRelatedDataFromJSONString(user_data_json, !since);
+            user_->LoadUserAndRelatedDataFromJSON(json, !since);
 
             if (err != noError) {
                 return err;
@@ -5321,6 +5287,123 @@ error Context::pullBatchedUserData() {
 
         stopwatch.stop();
         logger.debug("User with related data JSON fetched and parsed in ", stopwatch.elapsed() / 1000, " ms");
+    } catch(const Poco::Exception& exc) {
+        return exc.displayText();
+    } catch(const std::exception& ex) {
+        return ex.what();
+    } catch(const std::string & ex) {
+        return ex;
+    }
+    return noError;
+}
+
+error Context::pushBatchedChanges(
+    bool *had_something_to_push) {
+
+    try {
+        Poco::Stopwatch stopwatch;
+        stopwatch.start();
+
+        poco_check_ptr(had_something_to_push);
+
+        *had_something_to_push = true;
+
+        bool isPremium = false;
+
+        std::map<std::string, BaseModel *> models;
+
+        std::vector<TimeEntry *> time_entries;
+        std::vector<Project *> projects;
+        std::vector<Client *> clients;
+
+        std::string api_token("");
+
+        {
+            Poco::Mutex::ScopedLock lock(user_m_);
+            if (!user_) {
+                logger.warning("cannot push changes when logged out");
+                return noError;
+            }
+
+            api_token = user_->APIToken();
+            if (api_token.empty()) {
+                return error("cannot push changes without API token");
+            }
+            isPremium = user_->HasPremiumWorkspaces();
+
+            collectPushableModels(
+                user_->related.TimeEntries,
+                &time_entries,
+                &models);
+            collectPushableModels(
+                user_->related.Projects,
+                &projects,
+                &models);
+            collectPushableModels(
+                user_->related.Clients,
+                &clients,
+                &models);
+            if (time_entries.empty()
+                    && projects.empty()
+                    && clients.empty()) {
+                *had_something_to_push = false;
+                return noError;
+            }
+        }
+
+        std::stringstream ss;
+        ss << "Sync success (";
+
+        Json::Value request;
+
+        // the conditions should be here so we don't create unnecessary empty JSON items
+        // (accessing a JSON item by a name allocates an empty item)
+        if (!clients.empty())
+            syncCollectJSON(request["clients"], clients, isPremium);
+        if (!projects.empty())
+            syncCollectJSON(request["projects"], projects, isPremium);
+        if (!time_entries.empty())
+            syncCollectJSON(request["time_entries"], time_entries, isPremium);
+
+        if (request.empty())
+            return noError;
+
+        Json::FastWriter w;
+        std::string payload = w.write(request);
+
+        lastRequestUUID_ = Poco::UUIDGenerator().createOne().toString();
+
+        HTTPRequest req;
+        req.payload = payload;
+        req.host = urls::SyncAPI();
+        req.relative_url = "/push/" + lastRequestUUID_;
+        req.basic_auth_username = api_token;
+        req.basic_auth_password = "api_token";
+
+        auto response = TogglClient::GetInstance().Post(req);
+
+        std::cerr << "REQUEST: " << request.toStyledString() << std::endl;
+
+        if (response.err != noError) {
+            logger.log("Sync error: ", response.err);
+            return displayError(response.err);
+        }
+
+        Json::Reader reader;
+        Json::Value responseJson;
+        reader.parse(response.body, responseJson);
+
+        std::cerr << "RESPONSE: " << responseJson.toStyledString() << std::endl;
+
+        syncHandleResponse(responseJson["clients"], clients);
+        updateProjectClients(clients, projects);
+        syncHandleResponse(responseJson["projects"], projects);
+        updateEntryProjects(projects, time_entries);
+        syncHandleResponse(responseJson["time_entries"], time_entries);
+
+        stopwatch.stop();
+        ss << ") Total = " << stopwatch.elapsed() / 1000 << " ms";
+        logger.debug(ss.str());
     } catch(const Poco::Exception& exc) {
         return exc.displayText();
     } catch(const std::exception& ex) {
@@ -5560,6 +5643,23 @@ error Context::pushProjects(
     return err;
 }
 
+error Context::updateProjectClients(const std::vector<Client *> &clients,
+                                     const std::vector<Project *> &projects) {
+    for (auto it = projects.cbegin(); it != projects.cend(); ++it) {
+        if (!(*it)->CID() && !(*it)->ClientGUID().empty()) {
+            // Find client id
+            for (auto itc = clients.begin(); itc != clients.end(); ++itc) {
+                if ((*itc)->GUID().compare((*it)->ClientGUID()) == 0) {
+                    (*it)->SetCID((*itc)->ID());
+                    break;
+                }
+            }
+        }
+    }
+
+    return noError;
+}
+
 error Context::updateEntryProjects(const std::vector<Project *> &projects,
                                    const std::vector<TimeEntry *> &time_entries) {
     for (std::vector<TimeEntry *>::const_iterator it =
@@ -5678,7 +5778,7 @@ error Context::pushEntries(
         }
 
         if (!(*it)->ID()) {
-            if (!(user_->SetTimeEntryID(id, (*it)))) {
+            if (!(user_->SetModelID(id, (*it)))) {
                 continue;
             }
         }
@@ -6127,6 +6227,150 @@ error Context::pullUserPreferences() {
     return noError;
 }
 
+template<typename T>
+void Context::syncCollectJSON(Json::Value &array, const std::vector<T*> &source, bool isPremium) {
+    // The actual heavy lifting
+    // Go through the list of pointers and ask each model to generate a Sync server JSON
+    // The generation itself is split into three parts - We need to know:
+    //   * the type
+    //   * the metadata (usually the ID of the item and the workspace) and
+    //   * the payload (properties when creating or the ones that have changed)
+    // The payload has to be modified for some special cases (it's much easier to do this little hack now
+    // than to fix it properly - we'd have to change the storage of a ton of properties)
+    // Also, we don't track the relationships between entities in a very smart way so SyncPayload
+    // returns a GUID in place of a foreign ID (of clients and projects) and we then look for the actual
+    // local ID of the entity and question and use that instead.
+    for (auto i : source) {
+        Json::Value item, meta;
+
+        i->EnsureGUID();
+
+        item["type"] = i->SyncType();
+        item["meta"] = i->SyncMetadata();
+
+        Json::Value payload = i->SyncPayload();
+
+        // Remove some premium-feature-only data because we don't have a nullable bool property here nor in the database
+        if (!isPremium)
+            syncStripPremiumDataFromModelJSON(payload);
+
+        // And also translate local GUIDs to LocalIDs because Sync server went with using TmpID instead of GUIDs
+        // This is fine for now (the actual resolution of these dependencies will happen only when syncing a large chunk of offline data)
+        // but in the future we should think about using entity pointers instead of storing foreign IDs and GUIDs for Clients and Projects
+        // When removing this, see the SyncPayload method, it relies on returning GUIDs
+        syncTranslateGUIDToLocalID(payload);
+
+        if (!payload.isNull())
+            item["payload"] = payload;
+
+        array.append(item);
+    }
+}
+
+void Context::syncStripPremiumDataFromModelJSON(Json::Value &item) {
+    if (item.isMember("billable"))
+        item.removeMember("billable");
+    if (item.isMember("task_id"))
+        item.removeMember("task_id");
+}
+
+void Context::syncTranslateGUIDToLocalID(Json::Value &item) {
+    if (item.isMember("project_id") && item["project_id"].isString()) {
+        auto guid = item["project_id"].asString();
+        if (guid.empty()) {
+            item["project_id"] = Json::nullValue;
+        }
+        else {
+            Project *project = this->user_->related.ProjectByGUID(guid);
+            if (project) {
+                auto localID = project->LocalID();
+                item["project_id"] = Json::Int64(-localID);
+            }
+        }
+    }
+    if (item.isMember("client_id") && item["client_id"].isString()) {
+        auto guid = item["client_id"].asString();
+        if (guid.empty()) {
+            item["client_id"] = Json::nullValue;
+        }
+        else {
+            Client *client = this->user_->related.ClientByGUID(guid);
+            if (client) {
+                auto localID = client->LocalID();
+                item["client_id"] = Json::Int64(-localID);
+            }
+        }
+    }
+}
+
+template<typename T>
+error Context::syncHandleResponse(Json::Value &array, const std::vector<T*> &source) {
+    // this only looks into the container of modified items, not the whole RelatedData container
+    auto findByLocalID = [](auto &source, auto localID) -> typename std::remove_reference<decltype(source)>::type::value_type {
+        auto id = stoi(localID);
+        id = id < 0 ? -id : id;
+        if (id < 0)
+            id = -id;
+        for (auto i : source) {
+            if (i->LocalID() == id) {
+                return i;
+            }
+        }
+        return nullptr;
+    };
+    auto findByID = [](auto &source, auto ID) -> typename std::remove_reference<decltype(source)>::type::value_type {
+        auto id = ID < 0 ? -ID : ID;
+        if (id < 0)
+            id = -id;
+        for (auto i : source) {
+            if (i->ID() == id) {
+                return i;
+            }
+        }
+        return nullptr;
+    };
+    for (auto i : array) {
+        if (!i["payload"].empty()) {
+            auto model = findByLocalID(source, i["meta"]["client_assigned_id"].asString());
+            if (!model)
+                model = findByID(source, i["meta"]["id"].asUInt64());
+            std::string modelInfo = model ? (model->ModelName() + "-localID:" + std::to_string(model->LocalID())) : "<nullptr>";
+            if (i["payload"]["success"].asBool()) {
+                if (model) {
+                    auto &root = i["payload"]["result"];
+                    auto id = root["id"].asUInt64();
+                    if (!id) {
+                        continue;
+                    }
+
+                    if (!model->ID()) {
+                        user_->SetModelID(id, model);
+                    }
+
+                    if (model->ID() != id) {
+                        return error("Backend has changed the ID of the entry");
+                    }
+
+                    model->LoadFromJSON(i["payload"]["result"]);
+                    model->ClearDirty();
+                    model->ClearUnsynced();
+                }
+            }
+            else if (i["payload"]["result"].isMember("error_message") && i["payload"]["result"]["error_message"].isMember("default_message")) {
+                std::string errorMessage = i["payload"]["result"]["error_message"]["default_message"].asString();
+                logger.warning("Sync: Error when syncing ", modelInfo, ": ", errorMessage);
+                displayError(errorMessage);
+            }
+            else {
+                logger.warning("Sync: Server sent a malformed response for the item ", modelInfo);
+                logger.log("Sync: The response: ", i.toStyledString());
+                continue;
+            }
+        }
+    }
+    return noError;
+}
+
 error Context::signupGoogle(
     const std::string &access_token,
     std::string *user_data_json,
@@ -6563,5 +6807,6 @@ bool Context::checkIfSkipPomodoro(TimeEntry *te) {
     }
     return false;
 }
+
 
 }  // namespace toggl

--- a/src/context.h
+++ b/src/context.h
@@ -674,6 +674,15 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pullChanges();
     error pullUserPreferences();
 
+    template <typename T>
+    void syncCollectJSON(Json::Value &array, const std::vector<T*> &source, bool isPremium);
+    void syncStripPremiumDataFromModelJSON(Json::Value &item);
+    void syncTranslateGUIDToLocalID(Json::Value &item);
+    template <typename T>
+    error syncHandleResponse(Json::Value &array, const std::vector<T*> &source);
+
+    error pushBatchedChanges(
+            bool *had_something_to_push);
     error pushChanges(
         bool *had_something_to_push);
     error pushClients(
@@ -687,6 +696,9 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const std::map<std::string, BaseModel *> &models,
         const std::vector<TimeEntry *> &time_entries,
         const std::string &api_token);
+    error updateProjectClients(
+        const std::vector<Client *> &clients,
+        const std::vector<Project *> &projects);
     error updateEntryProjects(
         const std::vector<Project *> &projects,
         const std::vector<TimeEntry *> &time_entries);
@@ -803,6 +815,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     Poco::Mutex syncer_m_;
     Poco::Activity<Context> syncer_;
+    std::string lastRequestUUID_;
 
     Analytics analytics_;
 

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -60,6 +60,16 @@ void BaseModel::SetValidationError(const std::string &value) {
     SetDirty();
 }
 
+std::string BaseModel::SyncType() const {
+    if (NeedsPOST())
+        return "create";
+    else if (NeedsPUT())
+        return "update";
+    else if (NeedsDELETE())
+        return "delete";
+    return {};
+}
+
 void BaseModel::SetUpdatedAtString(const std::string &value) {
     SetUpdatedAt(Formatter::Parse8601(value));
 }

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -96,9 +96,12 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual std::string ModelURL() const = 0;
 
     virtual void LoadFromJSON(Json::Value value) {}
-    virtual Json::Value SaveToJSON() const {
+    virtual Json::Value SaveToJSON(int apiVersion = 8) const {
         return 0;
     }
+    virtual std::string SyncType() const;
+    virtual Json::Value SyncMetadata() const { return {}; }
+    virtual Json::Value SyncPayload() const { return {}; }
 
     virtual bool DuplicateResource(const toggl::error &err) const {
         return false;

--- a/src/model/client.h
+++ b/src/model/client.h
@@ -30,7 +30,9 @@ class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
     std::string ModelName() const override;
     std::string ModelURL() const override;
     void LoadFromJSON(Json::Value value) override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
+    Json::Value SyncMetadata() const override;
+    Json::Value SyncPayload() const override;
     bool ResolveError(const toggl::error &err) override;
     bool ResourceCannotBeCreated(const toggl::error &err) const override;
 

--- a/src/model/obm_action.cc
+++ b/src/model/obm_action.cc
@@ -47,7 +47,7 @@ std::string ObmAction::ModelURL() const {
     return "/api/v9/obm/actions";
 }
 
-Json::Value ObmAction::SaveToJSON() const {
+Json::Value ObmAction::SaveToJSON(int) const {
     Json::Value n;
     n["experiment_id"] = Json::UInt64(ExperimentID());
     n["key"] = Formatter::EscapeJSONString(Key());

--- a/src/model/obm_action.h
+++ b/src/model/obm_action.h
@@ -29,7 +29,7 @@ class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
 };
 
 class TOGGL_INTERNAL_EXPORT ObmExperiment : public BaseModel {

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -47,14 +47,16 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
     std::string ModelName() const override;
     std::string ModelURL() const override;
     void LoadFromJSON(Json::Value value) override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
+    Json::Value SyncMetadata() const override;
+    Json::Value SyncPayload() const override;
     bool DuplicateResource(const toggl::error &err) const override;
     bool ResourceCannotBeCreated(const toggl::error &err) const override;
     bool ResolveError(const toggl::error &err) override;
 
     static std::vector<std::string> ColorCodes;
 
- private:
+private:
     bool clientIsInAnotherWorkspace(const toggl::error &err) const;
     bool onlyAdminsCanChangeProjectVisibility(const toggl::error &err) const;
 };

--- a/src/model/settings.cc
+++ b/src/model/settings.cc
@@ -6,7 +6,7 @@
 
 namespace toggl {
 
-Json::Value Settings::SaveToJSON() const {
+Json::Value Settings::SaveToJSON(int) const {
     Json::Value json;
     json["use_idle_detection"] = use_idle_detection;
     json["menubar_timer"] = menubar_timer;

--- a/src/model/settings.h
+++ b/src/model/settings.h
@@ -90,7 +90,7 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
 };
 
 }  // namespace toggl

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -88,7 +88,9 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string String() const override;
     virtual bool ResolveError(const error &err) override;
     void LoadFromJSON(Json::Value value) override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
+    Json::Value SyncMetadata() const override;
+    Json::Value SyncPayload() const override;
 
     // Implement TimedEvent
     virtual const Poco::Int64 &Start() const {

--- a/src/model/timeline_event.cc
+++ b/src/model/timeline_event.cc
@@ -79,7 +79,7 @@ void TimelineEvent::SetUploaded(bool value) {
     }
 }
 
-Json::Value TimelineEvent::SaveToJSON() const {
+Json::Value TimelineEvent::SaveToJSON(int) const {
     Json::Value n;
     n["guid"] = GUID();
     n["filename"] = Filename();

--- a/src/model/timeline_event.h
+++ b/src/model/timeline_event.h
@@ -52,7 +52,7 @@ class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent 
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    Json::Value SaveToJSON() const override;
+    Json::Value SaveToJSON(int apiVersion = 8) const override;
 
  private:
 

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -663,7 +663,7 @@ void User::loadUserUpdateFromJSON(
     } else if (kModelTag == model) {
         loadUserTagFromJSON(data);
     } else if (kModelUser == model) {
-        loadUserAndRelatedDataFromJSON(data, false);
+        LoadUserAndRelatedDataFromJSON(data, false);
     }
 }
 
@@ -714,7 +714,7 @@ error User::LoadUserAndRelatedDataFromJSONString(const std::string &json,
         return error("Failed to LoadUserAndRelatedDataFromJSONString");
     }
 
-    loadUserAndRelatedDataFromJSON(root, including_related_data);
+    LoadUserAndRelatedDataFromJSON(root, including_related_data);
     return noError;
 }
 
@@ -802,7 +802,7 @@ void User::loadObmExperimentFromJson(Json::Value const &obm) {
     model->SetActions(obm["actions"].asString());
 }
 
-void User::loadUserAndRelatedDataFromJSON(
+void User::LoadUserAndRelatedDataFromJSON(
     const Json::Value &root,
     bool including_related_data) {
 
@@ -1110,33 +1110,6 @@ void User::loadUserProjectFromJSON(
     }
     model->SetUID(ID());
     model->LoadFromJSON(data);
-}
-
-bool User::SetTimeEntryID(
-    Poco::UInt64 id,
-    TimeEntry* timeEntry) {
-
-    poco_check_ptr(timeEntry);
-
-    {
-        Poco::Mutex::ScopedLock lock(loadTimeEntries_m_);
-        auto otherTimeEntry = related.TimeEntryByID(id);
-        if (otherTimeEntry) {
-            // this means that somehow we already have a time entry with the ID
-            // that was just returned from a response to time entry creation request
-            logger().error("There is already a newer version of this entry");
-
-            // clearing the GUID to make sure there's no GUID conflict
-            timeEntry->SetGUID("");
-
-            // deleting the duplicate entry
-            // this entry has no ID so the corresponding server entry will not be deleted
-            timeEntry->Delete();
-            return false;
-        }
-        timeEntry->SetID(id);
-        return true;
-    }
 }
 
 void User::loadUserTimeEntryFromJSON(

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -716,4 +716,28 @@ T *modelByID(const Poco::UInt64 id, std::vector<T *> const *list) {
     return nullptr;
 }
 
+template<>
+TimeEntry *toggl::RelatedData::ModelByLocalID<TimeEntry>(Poco::Int64 id) {
+    auto it = std::find_if(TimeEntries.begin(), TimeEntries.end(), [id](auto &item){ return item->LocalID() == id; });
+    if (it != TimeEntries.end())
+        return *it;
+    return nullptr;
+}
+
+template<>
+Project *toggl::RelatedData::ModelByLocalID<Project>(Poco::Int64 id) {
+    auto it = std::find_if(Projects.begin(), Projects.end(), [id](auto &item){ return item->LocalID() == id; });
+    if (it != Projects.end())
+        return *it;
+    return nullptr;
+}
+
+template<>
+Client *toggl::RelatedData::ModelByLocalID<Client>(Poco::Int64 id) {
+    auto it = std::find_if(Clients.begin(), Clients.end(), [id](auto &item){ return item->LocalID() == id; });
+    if (it != Clients.end())
+        return *it;
+    return nullptr;
+}
+
 }   // namespace toggl

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -59,6 +59,9 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
     Workspace *WorkspaceByID(const Poco::UInt64 id) const;
     TimeEntry *TimeEntryByID(const Poco::UInt64 id) const;
 
+    template <class T> T *ModelByID(Poco::UInt64 id);
+    template <class T> T *ModelByLocalID(Poco::Int64 id);
+
     void TagList(
         std::vector<std::string> *result,
         const Poco::UInt64 wid) const;
@@ -135,6 +138,14 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
         std::vector<view::Autocomplete> *result,
         std::map<std::string, std::vector<view::Autocomplete> > *items) const;
 };
+
+template<> inline TimeEntry *RelatedData::ModelByID<TimeEntry>(Poco::UInt64 id) { return TimeEntryByID(id); }
+template<> inline Project *RelatedData::ModelByID<Project>(Poco::UInt64 id) { return ProjectByID(id); }
+template<> inline Client *RelatedData::ModelByID<Client>(Poco::UInt64 id) { return ClientByID(id); }
+
+template<> TimeEntry *RelatedData::ModelByLocalID<TimeEntry>(Poco::Int64 id);
+template<> Project *RelatedData::ModelByLocalID<Project>(Poco::Int64 id);
+template<> Client *RelatedData::ModelByLocalID<Client>(Poco::Int64 id);
 
 template<typename T>
 void clearList(std::vector<T *> *list);

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -2024,8 +2024,10 @@ TEST(Sync, LegacyFormat) {
     ASSERT_EQ(user.related.TimeEntries[0]->Description(), "time entry");
     ASSERT_EQ(user.related.TimeEntries[0]->WID(), 2817276);
     ASSERT_EQ(user.related.TimeEntries[0]->UID(), 4187712);
+
     ASSERT_EQ(user.related.TimeEntries[0]->StartTime(), 1590593622);
     ASSERT_EQ(user.related.TimeEntries[0]->StopTime(), 1590594037);
+
     ASSERT_EQ(user.related.TimeEntries[0]->Duration(), 415);
 
     ASSERT_EQ(user.related.Workspaces[0]->ID(), 2817276);
@@ -2070,8 +2072,10 @@ TEST(Sync, BatchedFormat) {
     ASSERT_EQ(user.related.TimeEntries[0]->Description(), "time entry");
     ASSERT_EQ(user.related.TimeEntries[0]->WID(), 2817276);
     ASSERT_EQ(user.related.TimeEntries[0]->UID(), 4187712);
+
     ASSERT_EQ(user.related.TimeEntries[0]->StartTime(), 1590593622);
     ASSERT_EQ(user.related.TimeEntries[0]->StopTime(), 1590594037);
+
     ASSERT_EQ(user.related.TimeEntries[0]->Duration(), 415);
 
     ASSERT_EQ(user.related.Workspaces[0]->ID(), 2817276);


### PR DESCRIPTION
### 📒 Description
As outlined in today's meeting, this PR implements push to the sync server. The branch is called per-property-update but that will come on a later day. This pushes and updates full entities.

The way the final JSON is composed is now included in the `SyncType()`, `SyncMetadata()` and `SyncPayload()` methods in `BaseModel` (overriden only in `Client`, `Project` and `TimeEntry`). For "remote IDs" (for instance, `PID` in `TimeEntry) these methods return the `GUID` field but that is later "translated" to negative `LocalID` for server identification as per the Sync specs.

That's basically the one main difference from the current V8 sync as we have had it up until now.

I already outlined the gist of this patch in the meeting and describing it in detail here would be really confusing so please ask if there is something still not clear.


### 🕶️ Types of changes
 - **New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Part of the Sync team efforts

### 🔎 Review hints
Everything should work the same if you enable the `dekstop_sync_client` for your account in Backffice (or use the compile time define).

