### PR TITLE
Fix project autocomplete not displaying the right text (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -132,11 +132,11 @@ void AutocompleteComboBox::onDropdownSelected(AutocompleteView *item) {
         case 1:
             emit projectSelected(item->ProjectLabel, item->ProjectID, item->ProjectColor, item->TaskLabel, item->TaskID);
             emit billableChanged(item->Billable);
-            setCurrentText(QString());
+            setCurrentText(item->ProjectLabel + (item->ClientLabel.isEmpty() ? "" : ". " + item->ClientLabel));
             break;
         case 2:
             emit projectSelected(item->Text, item->ProjectID, item->ProjectColor, QString(), 0);
-            setCurrentText(QString());
+            setCurrentText(item->ProjectLabel + (item->ClientLabel.isEmpty() ? "" : ". " + item->ClientLabel));
             break;
         default:
             break;

--- a/src/ui/linux/TogglDesktop/autocompletelistmodel.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletelistmodel.cpp
@@ -47,7 +47,7 @@ QVariant AutocompleteListModel::data(const QModelIndex &index, int role) const {
         if (view->Type == displayItem) {
             switch (displayItem) {
             case 2:
-                return view->ProjectLabel;
+                return view->ProjectLabel + (view->ClientLabel.isEmpty() ? "" : ". " + view->ClientLabel);
             case 1:
                 return view->TaskLabel;
             default:


### PR DESCRIPTION
### 📒 Description
This fixes the selection of projects in the autocomplete in the time entry editor. There was a bug when selecting the project, the text was not displayed right (and sometimes not stored properly as well).

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue) 

### 👫 Relationships
Closes #3714

### 🔎 Review hints
Check if project selection works right now.

