### PR TITLE
Refactoring Timer

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
@@ -27,7 +27,7 @@
             <converters:EnumEqualToVisibilityConverter x:Key="EnumEqualToVisibilityConverter" />
             <converters:AndConverter x:Key="AndConverter" />
             <converters:PopupAlignmentAwareConverter x:Key="PopupAlignmentAwareConverter"/>
-
+            <converters:BooleanInvertToVisibilityConverter x:Key="BooleanInvertToVisibilityConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -242,6 +242,7 @@
       <DependentUpon>TrayToolTipControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="ui\Converters\AndConverter.cs" />
+    <Compile Include="ui\Converters\BooleanInvertToVisibilityConverter.cs" />
     <Compile Include="ui\Converters\CapitalizeConverter.cs" />
     <Compile Include="ui\Converters\EmptyStringToCollapsedConverter.cs" />
     <Compile Include="ui\Converters\IsSelectableItemConverter.cs" />
@@ -332,6 +333,7 @@
     <Compile Include="ui\ViewModels\TimeEntryCellViewModel.cs" />
     <Compile Include="ui\ViewModels\TimeEntryLabelViewModel.cs" />
     <Compile Include="ui\ViewModels\TimeEntryListViewModel.cs" />
+    <Compile Include="ui\ViewModels\TimerViewModel.cs" />
     <Compile Include="ui\ViewModels\ViewModelExtensions.cs" />
     <Compile Include="ui\views\IMainView.cs" />
     <Compile Include="ui\Experiments\ExperimentManager.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BooleanInvertToVisibilityConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BooleanInvertToVisibilityConverter.cs
@@ -2,7 +2,7 @@
 using System.Windows;
 using System.Windows.Data;
 
-namespace TogglDesktop.ui.Converters
+namespace TogglDesktop.Converters
 {
     public class BooleanInvertToVisibilityConverter : IValueConverter
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BooleanInvertToVisibilityConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BooleanInvertToVisibilityConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Data;
+
+namespace TogglDesktop.ui.Converters
+{
+    public class BooleanInvertToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var input = (value is bool)
+                ? !(bool)value 
+                : false;
+            return input ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
@@ -15,7 +15,7 @@ namespace TogglDesktop.ui.ViewModels
         private readonly DispatcherTimer secondsTimer = new DispatcherTimer();
         private Toggl.TogglTimeEntryView runningTimeEntry;
         private bool acceptNextUpdate;
-        private bool isMiniTimer;
+        private readonly bool isMiniTimer;
         private Toggl.TogglAutocompleteView completedProject;
 
         public TimerViewModel(bool isMiniTimer)
@@ -24,7 +24,6 @@ namespace TogglDesktop.ui.ViewModels
             StartStopCommand = ReactiveCommand.Create(startStop);
             CancelProjectSelectionCommand = ReactiveCommand.Create(clearSelectedProject);
             ManualAddButtonCommand = ReactiveCommand.Create(AddNewTimeEntry);
-            TryOpenEditView = ReactiveCommand.Create<string>(s => tryOpenEditViewIfRunning(s));
 
             setupSecondsTimer();
 
@@ -61,8 +60,6 @@ namespace TogglDesktop.ui.ViewModels
 
         public ReactiveCommand<Unit, Unit> ManualAddButtonCommand { get; }
 
-        public ReactiveCommand<string, Unit> TryOpenEditView { get; }
-
         private void setupSecondsTimer()
         {
             secondsTimer.Interval = TimeSpan.FromSeconds(1);
@@ -79,7 +76,6 @@ namespace TogglDesktop.ui.ViewModels
         {
             using (Performance.Measure("timer responding to OnRunningTimerState"))
             {
-                
                 SetRunningTimeEntry(te);
                 secondsTimer.IsEnabled = true;
             }
@@ -147,6 +143,7 @@ namespace TogglDesktop.ui.ViewModels
 
         private void start()
         {
+            var durationString = DurationText;
             using (Performance.Measure("starting time entry from timer"))
             {
                 var guid = Toggl.Start(
@@ -158,9 +155,9 @@ namespace TogglDesktop.ui.ViewModels
                     completedProject.Tags,
                     isMiniTimer
                     );
-                if (isMiniTimer && !string.IsNullOrEmpty(guid) && !string.IsNullOrEmpty(DurationText))
+                if (isMiniTimer && !string.IsNullOrEmpty(guid) && !string.IsNullOrEmpty(durationString))
                 {
-                    Toggl.SetTimeEntryDuration(guid, DurationText);
+                    Toggl.SetTimeEntryDuration(guid, durationString);
                 }
                 if (completedProject.Billable)
                 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
@@ -1,0 +1,209 @@
+﻿using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using System;
+using System.Reactive;
+using System.Windows;
+using System.Windows.Threading;
+using TogglDesktop.AutoCompletion.Items;
+using TogglDesktop.Diagnostics;
+using TogglDesktop.ViewModels;
+
+namespace TogglDesktop.ui.ViewModels
+{
+    public class TimerViewModel : ReactiveObject
+    {
+        private readonly DispatcherTimer secondsTimer = new DispatcherTimer();
+        private Toggl.TogglTimeEntryView runningTimeEntry;
+        private bool acceptNextUpdate;
+        private bool isMiniTimer;
+        private Toggl.TogglAutocompleteView completedProject;
+
+        public TimerViewModel(bool isMiniTimer)
+        {
+            this.isMiniTimer = isMiniTimer;
+            StartStopCommand = ReactiveCommand.Create(() => startStop());
+            CancelProjectSelectionCommand = ReactiveCommand.Create(() => clearSelectedProject());
+            ManualAddButtonCommand = ReactiveCommand.Create(() => AddNewTimeEntry());
+            DescriptionAutoCompleteConfirmCommand = ReactiveCommand.Create<RoutedEventArgs>(e => {
+                DescriptionAutoCompleteConfirm(e);
+            });
+            TryOpenEditView = ReactiveCommand.Create<string>(s => tryOpenEditViewIfRunning(s));
+
+            setupSecondsTimer();
+
+            Toggl.OnRunningTimerState += onRunningTimerState;
+            Toggl.OnStoppedTimerState += onStoppedTimerState;
+
+            ResetRunningTimeEntry(false, true);
+        }
+
+        [Reactive]
+        public bool IsRunning { get; set; }
+
+        [Reactive]
+        public string DurationText { get; set; }
+
+        [Reactive]
+        public string Description { get; set; }
+
+        [Reactive]
+        public string DurationPanelToolTip { get; private set; }
+
+        [Reactive]
+        public TimeEntryLabelViewModel TimeEntryLabelViewModel { get; private set; }
+
+        [Reactive]
+        public ProjectLabelViewModel ProjectLabelViewModel { get; private set; }
+
+        public ReactiveCommand<Unit, Unit> StartStopCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> CancelProjectSelectionCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> ManualAddButtonCommand { get; }
+
+        public ReactiveCommand<RoutedEventArgs, Unit> DescriptionAutoCompleteConfirmCommand { get; }
+
+        public ReactiveCommand<string, Unit> TryOpenEditView { get; }
+
+        private void setupSecondsTimer()
+        {
+            secondsTimer.Interval = TimeSpan.FromSeconds(1);
+            secondsTimer.Tick += (sender, args) =>
+            {
+                if (!IsRunning)
+                    return;
+
+                DurationText = Toggl.FormatDurationInSecondsHHMMSS(runningTimeEntry.DurationInSeconds);
+            };
+        }
+
+        private void onRunningTimerState(Toggl.TogglTimeEntryView te)
+        {
+            using (Performance.Measure("timer responding to OnRunningTimerState"))
+            {
+                
+                SetRunningTimeEntry(te);
+                secondsTimer.IsEnabled = true;
+            }
+        }
+
+        private void SetRunningTimeEntry(Toggl.TogglTimeEntryView item)
+        {
+            ResetRunningTimeEntry(true);
+            runningTimeEntry = item;
+            TimeEntryLabelViewModel = item.ToTimeEntryLabelViewModel();
+            DurationText = Toggl.FormatDurationInSecondsHHMMSS(item.DurationInSeconds);
+            DurationPanelToolTip = "started at " + item.StartTimeString;
+        }
+
+        private void ResetRunningTimeEntry(bool running, bool forceUpdate = false)
+        {
+            var changedState = IsRunning != running;
+
+            if (!(changedState || forceUpdate || this.acceptNextUpdate))
+                return;
+
+            acceptNextUpdate = false;
+
+            IsRunning = running;
+            Description = "";
+            DurationText = "";
+        }
+
+        private void onStoppedTimerState()
+        {
+            using (Performance.Measure("timer responding to OnStoppedTimerState"))
+            {
+                secondsTimer.IsEnabled = false;
+                ResetRunningTimeEntry(false);
+                runningTimeEntry = default(Toggl.TogglTimeEntryView);
+            }
+        }
+
+        #region controlling
+
+        public void startStop()
+        {
+            this.acceptNextUpdate = true;
+
+            if (IsRunning)
+            {
+                this.stop();
+            }
+            else
+            {
+                this.start();
+            }
+        }
+
+        public void tryOpenEditViewIfRunning(string focusedField)
+        {
+            if (IsRunning)
+            {
+                using (Performance.Measure("opening edit view from timer, focussing " + focusedField))
+                {
+                    Toggl.Edit(this.runningTimeEntry.GUID, false, focusedField);
+                }
+            }
+        }
+
+        private void start()
+        {
+            using (Performance.Measure("starting time entry from timer"))
+            {
+                var guid = Toggl.Start(
+                    Description,
+                    "",
+                    completedProject.TaskID,
+                    completedProject.ProjectID,
+                    "",
+                    completedProject.Tags,
+                    isMiniTimer
+                    );
+
+                if (completedProject.Billable)
+                {
+                    Toggl.SetTimeEntryBillable(guid, true);
+                }
+
+                this.clearSelectedProject();
+            }
+        }
+
+        private void stop()
+        {
+            using (Performance.Measure("stopping time entry from timer"))
+            {
+                Toggl.Stop(isMiniTimer);
+            }
+        }
+
+        #endregion
+
+        public void clearSelectedProject()
+        {
+            ProjectLabelViewModel = null;
+            completedProject = default;
+        }
+
+        public void DescriptionAutoCompleteConfirm(object e)
+        {
+            var asItem = e as IModelItem<Toggl.TogglAutocompleteView>;
+            if (asItem == null)
+                return;
+
+            var item = asItem.Model;
+
+            Description = item.Description;
+
+            ProjectLabelViewModel = item.ToProjectLabelViewModel();
+            completedProject = item;
+        }
+
+        private void AddNewTimeEntry()
+        {
+            var guid = Toggl.Start("", "0", 0, 0, "", "", isMiniTimer);
+            Toggl.Edit(guid, false, Toggl.Duration);
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
@@ -103,6 +103,7 @@ namespace TogglDesktop.ui.ViewModels
 
             acceptNextUpdate = false;
 
+            IsRunning = running;
             SetDescription("");
             DurationText = "";
         }
@@ -121,10 +122,9 @@ namespace TogglDesktop.ui.ViewModels
 
         public void startStop()
         {
-            IsRunning = !IsRunning;
             this.acceptNextUpdate = true;
 
-            if (IsRunning)
+            if (!IsRunning)
             {
                 start();
             }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ExtendedTextBox.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ExtendedTextBox.cs
@@ -1,11 +1,20 @@
-﻿using System.Windows.Controls;
+﻿using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace TogglDesktop
 {
     class ExtendedTextBox : TextBox
     {
-        public bool IsTextChangingProgrammatically { get; private set; }
+        public static readonly DependencyProperty IsTextChangingProgrammaticallyProperty =
+            DependencyProperty.Register(
+            "IsTextChangingProgrammatically", typeof(bool),
+            typeof(ExtendedTextBox));
+        public bool IsTextChangingProgrammatically 
+        { 
+            get => (bool)GetValue(IsTextChangingProgrammaticallyProperty);
+            set { SetValue(IsTextChangingProgrammaticallyProperty, value); }
+        }
 
         public bool SelectAllOnKeyboardFocus { get; set; }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
@@ -143,7 +143,7 @@
                                        MaxHeight="44"
                                        Style="{StaticResource Toggl.Timer.DescriptionTextBox}"
                                        Visibility="{Binding IsRunning, Converter={StaticResource BooleanInvertToVisibilityConverter}}"
-                                       Text="{Binding Description}"/>
+                                       Text="{Binding Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             </DockPanel>
 
             <Grid x:Name="durationPanel" x:FieldModifier="private"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:toggl="clr-namespace:TogglDesktop"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:conv="clr-namespace:TogglDesktop.ui.Converters"
              mc:Ignorable="d" 
              d:DesignWidth="500"
              MinHeight="46"
@@ -63,6 +64,7 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+            <conv:BooleanInvertToVisibilityConverter x:Key="BooleanInvertToVisibilityConverter"/>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -70,7 +72,7 @@
               Margin="13 0 12 0">
             <Button Name="manualAddButton" x:FieldModifier="private"
                     Style="{StaticResource Toggl.AddTimeEntryButton}"
-                    Click="onManualAddButtonClick">
+                    Command="{Binding ManualAddButtonCommand}">
                 <StackPanel Orientation="Horizontal">
                     <Canvas Width="24" Height="24" Margin="4 -3 4 0">
                         <Path Fill="White" Data="M12.5 6v5.5H18v1h-5.5V18h-1v-5.5H6v-1h5.5V6h1z" />
@@ -81,8 +83,11 @@
         </Grid>
         <Grid Name="timerPanel" x:FieldModifier="private"  Visibility="Visible"
               MouseLeftButtonDown="onGridMouseDown"
-              KeyDown="onGridKeyDown"
               Background="Transparent">
+            <Grid.InputBindings>
+                <KeyBinding Key="Enter" Command="{Binding StartStopCommand}"/>
+                <KeyBinding Key="Esc" Command="{Binding CancelProjectSelectionCommand}"/>
+            </Grid.InputBindings>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition Width="Auto"/>
@@ -95,12 +100,15 @@
                                   CompactDescription="True"
                                   DescriptionLabelMouseDown="onDescriptionLabelMouseDown"
                                   ProjectLabelMouseDown="onProjectLabelMouseDown"
-                                  IconsPanelBackground="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=Background}"/>
+                                  IconsPanelBackground="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=Background}"
+                                  Visibility="{Binding DataContext.IsRunning, Converter={StaticResource BooleanToVisibilityConverter}, ElementName=timerPanel}"
+                                  DataContext="{Binding TimeEntryLabelViewModel}"/>
 
             <DockPanel Grid.Column="0" Name="editModeGrid" x:FieldModifier="private">
                 <Grid x:Name="editProjectPanel" x:FieldModifier="private"
                       DockPanel.Dock="Bottom"
-                      Background="{DynamicResource Toggl.SelectionElements.Disabled.Background}">
+                      Background="{DynamicResource Toggl.SelectionElements.Disabled.Background}"
+                      Visibility="{Binding ProjectLabelViewModel.HasProject, FallbackValue=Collapsed, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition />
                         <ColumnDefinition Width="8"/>
@@ -108,7 +116,8 @@
                     </Grid.ColumnDefinitions>
                     <toggl:ProjectLabel x:Name="editModeProjectLabel" x:FieldModifier="private"
                                         Grid.ColumnSpan="2"
-                                        Margin="8 0 0 0"/>
+                                        Margin="8 0 0 0"
+                                        DataContext="{Binding ProjectLabelViewModel}"/>
                     <Grid Grid.Column="1" ColumnSpan="2">
                         <Grid.Background>
                             <LinearGradientBrush StartPoint="0 0.5" EndPoint="1 0.5">
@@ -119,7 +128,8 @@
                         <Button Style="{DynamicResource Toggl.CrossButton}"
                                 Width="24" Height="24"
                                 HorizontalAlignment="Right"
-                                IsTabStop="False" Click="cancelProjectSelectionButtonClick"/>
+                                IsTabStop="False"
+                                Command="{Binding CancelProjectSelectionCommand}"/>
                     </Grid>
                 </Grid>
                 <toggl:AutoCompletionPopup x:Name="descriptionAutoComplete" x:FieldModifier="private"
@@ -131,19 +141,23 @@
                                        Height="Auto"
                                        MinHeight="28"
                                        MaxHeight="44"
-                                       Style="{StaticResource Toggl.Timer.DescriptionTextBox}"/>
+                                       Style="{StaticResource Toggl.Timer.DescriptionTextBox}"
+                                       Visibility="{Binding IsRunning, Converter={StaticResource BooleanInvertToVisibilityConverter}}"
+                                       Text="{Binding Description}"/>
             </DockPanel>
 
             <Grid x:Name="durationPanel" x:FieldModifier="private"
                     Grid.Column="1"
                     Background="Transparent"
                     Width="88"
-                    MouseLeftButtonDown="onTimeLabelMouseDown">
+                    MouseLeftButtonDown="onTimeLabelMouseDown"
+                    ToolTip="{Binding DurationPanelToolTip}">
                 <TextBlock Name="durationLabel" x:FieldModifier="private"
                            Style="{StaticResource Toggl.TimerDurationText}"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"
-                           Text="00:00:00" />
+                           Text="{Binding DurationText}"
+                           Visibility="{Binding IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 <TextBox x:Name="durationTextBox" x:FieldModifier="private"
                          Style="{StaticResource Toggl.Timer.DescriptionTextBox}"
                          mah:TextBoxHelper.Watermark="00:00:00"
@@ -151,13 +165,15 @@
                          FontWeight="SemiBold"
                          FontSize="18"
                          Height="Auto"
-                         Padding="3 1"/>
+                         Padding="3 1"
+                         Visibility="{Binding IsRunning, Converter={StaticResource BooleanInvertToVisibilityConverter}}"/>
             </Grid>
             <!-- start/stop button -->
             <ToggleButton Name="startStopButton" x:FieldModifier="private"
                           Grid.Column="2"
                           Style="{StaticResource Toggl.StartStopButton}"
-                          Click="startStopButtonOnClick"/>
+                          IsChecked="{Binding IsRunning, Mode=OneWay}"
+                          Command="{Binding StartStopCommand}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:toggl="clr-namespace:TogglDesktop"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
-             xmlns:conv="clr-namespace:TogglDesktop.ui.Converters"
+             xmlns:vm="clr-namespace:TogglDesktop.ui.ViewModels"
              mc:Ignorable="d" 
              d:DesignWidth="500"
              MinHeight="46"
              MaxHeight="52"
              Focusable="True"
              Background="{DynamicResource Toggl.CardBackground}"
+             d:DataContext="{d:DesignInstance vm:TimerViewModel, IsDesignTimeCreatable=False}"
              PreviewMouseDown="MiniTimer_OnPreviewMouseDown">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -64,7 +65,6 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            <conv:BooleanInvertToVisibilityConverter x:Key="BooleanInvertToVisibilityConverter"/>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -86,7 +86,7 @@
               Background="Transparent">
             <Grid.InputBindings>
                 <KeyBinding Key="Enter" Command="{Binding StartStopCommand}"/>
-                <KeyBinding Key="Esc" Command="{Binding CancelProjectSelectionCommand}"/>
+                <KeyBinding Key="Escape" Command="{Binding CancelProjectSelectionCommand}"/>
             </Grid.InputBindings>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
@@ -143,7 +143,8 @@
                                        MaxHeight="44"
                                        Style="{StaticResource Toggl.Timer.DescriptionTextBox}"
                                        Visibility="{Binding IsRunning, Converter={StaticResource BooleanInvertToVisibilityConverter}}"
-                                       Text="{Binding Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                       Text="{Binding Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                       IsTextChangingProgrammatically="{Binding IsDescriptionChangedNotByUser}"/>
             </DockPanel>
 
             <Grid x:Name="durationPanel" x:FieldModifier="private"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
@@ -167,6 +167,7 @@
                          FontSize="18"
                          Height="Auto"
                          Padding="3 1"
+                         Text="{Binding DurationText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          Visibility="{Binding IsRunning, Converter={StaticResource BooleanInvertToVisibilityConverter}}"/>
             </Grid>
             <!-- start/stop button -->

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml.cs
@@ -1,80 +1,37 @@
-﻿using System;
+﻿using DynamicData.Binding;
+using System;
 using System.Collections.Generic;
-using System.Windows;
 using System.Windows.Input;
-using System.Windows.Threading;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.AutoCompletion.Items;
 using TogglDesktop.Diagnostics;
-using TogglDesktop.ViewModels;
+using TogglDesktop.ui.ViewModels;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 
 namespace TogglDesktop
 {
     public partial class MiniTimer
     {
-        private readonly DispatcherTimer secondsTimer = new DispatcherTimer();
-        private Toggl.TogglTimeEntryView runningTimeEntry;
-        private bool isRunning;
-        private bool acceptNextUpdate;
-        private Toggl.TogglAutocompleteView completedProject;
+        public TimerViewModel ViewModel
+        {
+            get => (TimerViewModel)DataContext;
+            set => DataContext = value;
+        }
 
         public MiniTimer()
         {
             this.InitializeComponent();
-
-            this.setupSecondsTimer();
+            ViewModel = new TimerViewModel(true);
+            ViewModel.WhenValueChanged(x => x.IsRunning).Subscribe(x => { if (!x) FocusFirstInput(); });
 
             Toggl.OnMinitimerAutocomplete += this.onMiniTimerAutocomplete;
-            Toggl.OnRunningTimerState += this.onRunningTimerState;
-            Toggl.OnStoppedTimerState += this.onStoppedTimerState;
-
-            this.resetUIState(false, true);
         }
 
         public event MouseButtonEventHandler MouseCaptured;
 
-        private static bool IsMiniTimer => true;
-
-        private void setupSecondsTimer()
-        {
-            this.secondsTimer.Interval = TimeSpan.FromSeconds(1);
-            this.secondsTimer.Tick += (sender, args) =>
-            {
-                if (!this.isRunning)
-                    return;
-
-                var s = Toggl.FormatDurationInSecondsHHMMSS(this.runningTimeEntry.DurationInSeconds);
-                durationLabel.Text = s;
-            };
-        }
+       
 
         #region toggl events
-
-        private void onStoppedTimerState()
-        {
-            if (this.TryBeginInvoke(this.onStoppedTimerState))
-                return;
-
-            using (Performance.Measure("timer responding to OnStoppedTimerState"))
-            {
-                this.secondsTimer.IsEnabled = false;
-                this.resetUIState(false);
-                this.runningTimeEntry = default(Toggl.TogglTimeEntryView);
-            }
-        }
-
-        private void onRunningTimerState(Toggl.TogglTimeEntryView te)
-        {
-            if (this.TryBeginInvoke(this.onRunningTimerState, te))
-                return;
-
-            using (Performance.Measure("timer responding to OnRunningTimerState"))
-            {
-                this.runningTimeEntry = te;
-                this.setUIToRunningState(te);
-                this.secondsTimer.IsEnabled = true;
-            }
-        }
 
         private void onMiniTimerAutocomplete(List<Toggl.TogglAutocompleteView> list)
         {
@@ -91,88 +48,51 @@ namespace TogglDesktop
 
         #region ui events
 
-        private void startStopButtonOnClick(object sender, RoutedEventArgs e)
-        {
-            this.startStop();
-        }
-
-        private void onGridKeyDown(object sender, KeyEventArgs e)
-        {
-            switch (e.Key)
-            {
-                case Key.Enter:
-                {
-                    this.startStopButton.IsChecked = !this.startStopButton.IsChecked;
-                    this.startStop();
-                    e.Handled = true;
-                    return;
-                }
-                case Key.Escape:
-                {
-                    if (this.isRunning || this.editModeProjectLabel.ViewModel?.HasProject != true)
-                        return;
-                    this.clearSelectedProject();
-                    e.Handled = true;
-                    return;
-                }
-            }
-        }
-
         private void onProjectLabelMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, Toggl.Project);
+            TryOpenEditViewIfRunning(e, Toggl.Project);
         }
 
         private void onDescriptionLabelMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, Toggl.Description);
+            TryOpenEditViewIfRunning(e, Toggl.Description);
         }
 
         private void onTimeLabelMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, Toggl.Duration);
+            TryOpenEditViewIfRunning(e, Toggl.Duration);
         }
 
         private void onGridMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, "");
+            TryOpenEditViewIfRunning(e, "");
+        }
+
+        private void TryOpenEditViewIfRunning(MouseButtonEventArgs e, string focusedField)
+        {
+            if (e.ClickCount == 2)
+            {
+                ViewModel.tryOpenEditViewIfRunning(focusedField);
+                e.Handled = true;
+            }
         }
 
         private void descriptionAutoComplete_OnConfirmCompletion(object sender, IAutoCompleteItem e)
         {
-            if (e is IModelItem<Toggl.TogglAutocompleteView> asItem)
-            {
-                var item = asItem.Model;
-
-                this.descriptionTextBox.SetText(item.Description);
-                this.descriptionTextBox.CaretIndex = this.descriptionTextBox.Text.Length;
-
-                this.editProjectPanel.ShowOnlyIf(item.ProjectID != 0);
-                this.editModeProjectLabel.ViewModel = item.ToProjectLabelViewModel();
-                completedProject = item;
-            }
-        }
-
-        private void cancelProjectSelectionButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.clearSelectedProject();
-        }
-
-        private void clearSelectedProject()
-        {
-            this.editProjectPanel.Visibility = Visibility.Collapsed;
-            this.editModeProjectLabel.ViewModel = null;
-            completedProject = default;
-        }
-
-        private void onManualAddButtonClick(object sender, RoutedEventArgs e)
-        {
-            var guid = Toggl.Start("", "0", 0, 0, "", "", IsMiniTimer);
-            Toggl.Edit(guid, false, Toggl.Duration);
+            ViewModel.DescriptionAutoCompleteConfirm(e);
+            descriptionTextBox.CaretIndex = descriptionTextBox.Text.Length;
         }
 
         protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
         {
+            FocusFirstInput();
+        }
+
+        private void FocusFirstInput()
+        {
+            if (this.TryBeginInvoke(FocusFirstInput))
+                return;
+
             if (!this.IsKeyboardFocused)
                 return;
 
@@ -184,114 +104,6 @@ namespace TogglDesktop
             {
                 this.descriptionTextBox.Focus();
             }
-            else
-            {
-                this.startStopButton.Focus();
-            }
-        }
-
-        #endregion
-
-        #region controlling
-
-        private void startStop()
-        {
-            this.acceptNextUpdate = true;
-
-            if (this.isRunning)
-            {
-                this.stop();
-            }
-            else
-            {
-                this.start();
-            }
-        }
-
-        private void tryOpenEditViewIfRunning(MouseButtonEventArgs e, string focusedField)
-        {
-            if (this.isRunning)
-            {
-                if (e.ClickCount == 2)
-                {
-                    using (Performance.Measure("opening edit view from timer, focussing " + focusedField))
-                    {
-                        Toggl.Edit(this.runningTimeEntry.GUID, false, focusedField);
-                    }
-
-                    e.Handled = true;
-                }
-            }
-        }
-
-        private void start()
-        {
-            var durationString = durationTextBox.Text;
-            using (Performance.Measure("starting time entry from timer"))
-            {
-                var guid = Toggl.Start(
-                    this.descriptionTextBox.Text,
-                    "",
-                    completedProject.TaskID,
-                    completedProject.ProjectID,
-                    "",
-                    completedProject.Tags,
-                    IsMiniTimer
-                );
-
-                if (!string.IsNullOrEmpty(guid) && !string.IsNullOrEmpty(durationString))
-                {
-                    Toggl.SetTimeEntryDuration(guid, durationString);
-                }
-
-                if (completedProject.Billable)
-                {
-                    Toggl.SetTimeEntryBillable(guid, true);
-                }
-
-                this.clearSelectedProject();
-            }
-        }
-
-        private void stop()
-        {
-            using (Performance.Measure("stopping time entry from timer"))
-            {
-                Toggl.Stop(IsMiniTimer);
-            }
-        }
-
-        #endregion
-
-        #region updating ui
-
-        private void setUIToRunningState(Toggl.TogglTimeEntryView item)
-        {
-            this.resetUIState(true);
-            this.timeEntryLabel.ViewModel = item.ToTimeEntryLabelViewModel();
-            this.durationLabel.Text = Toggl.FormatDurationInSecondsHHMMSS(item.DurationInSeconds);
-            this.durationPanel.ToolTip = "started at " + item.StartTimeString;
-        }
-
-        private void resetUIState(bool running, bool forceUpdate = false)
-        {
-            var changedState = this.isRunning != running;
-
-            if (!(changedState || forceUpdate || this.acceptNextUpdate))
-                return;
-
-            this.acceptNextUpdate = false;
-
-            this.isRunning = running;
-            this.startStopButton.IsChecked = running;
-            this.descriptionTextBox.SetText("");
-            this.descriptionTextBox.ShowOnlyIf(!running);
-            this.durationTextBox.Text = "";
-            this.durationTextBox.ShowOnlyIf(!running);
-            this.timeEntryLabel.ShowOnlyIf(running);
-            this.durationLabel.ShowOnlyIf(running);
-            this.editProjectPanel.Visibility = Visibility.Collapsed;
-            this.editModeProjectLabel.ViewModel = null;
         }
 
         #endregion

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -205,6 +205,9 @@ namespace TogglDesktop
 
         private void durationUpdateTimerTick(object sender, string s)
         {
+            if (this.TryBeginInvoke(durationUpdateTimerTick, sender, s))
+                return;
+
             if (!this.hasTimeEntry() || this.timeEntry.DurationInSeconds >= 0)
                 return;
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using DynamicData.Binding;
 using MahApps.Metro.Controls;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.AutoCompletion.Items;
@@ -823,7 +824,7 @@ namespace TogglDesktop
 
         public void SetTimer(Timer timer)
         {
-            timer.RunningTimeEntrySecondPulse += this.durationUpdateTimerTick;
+            timer.ViewModel.WhenValueChanged(x => x.DurationText).Subscribe(x => durationUpdateTimerTick(this, x));
         }
 
         public void FocusField(string focusedFieldName)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
@@ -4,15 +4,15 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:toggl="clr-namespace:TogglDesktop"
-             xmlns:conv="clr-namespace:TogglDesktop.ui.Converters"
-             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+             xmlns:vm="clr-namespace:TogglDesktop.ui.ViewModels"
              mc:Ignorable="d" 
              d:DesignWidth="500"
              MinWidth="300"
              Height="{StaticResource TimerHeight}"
              Focusable="True"
              FocusVisualStyle="{x:Null}"
-             Background="{DynamicResource Toggl.CardBackground}">
+             Background="{DynamicResource Toggl.CardBackground}"
+             d:DataContext="{d:DesignInstance vm:TimerViewModel, IsDesignTimeCreatable=False}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -70,7 +70,6 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            <conv:BooleanInvertToVisibilityConverter x:Key="BooleanInvertToVisibilityConverter"/>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -93,7 +92,7 @@
               Background="Transparent">
             <Grid.InputBindings>
                 <KeyBinding Key="Enter" Command="{Binding StartStopCommand}"/>
-                <KeyBinding Key="Esc" Command="{Binding CancelProjectSelectionCommand}"/>
+                <KeyBinding Key="Escape" Command="{Binding CancelProjectSelectionCommand}"/>
             </Grid.InputBindings>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
@@ -125,7 +124,8 @@
                                        MaxHeight="32"
                                        Style="{StaticResource Toggl.Timer.DescriptionTextBox}"
                                        Visibility="{Binding IsRunning, Converter={StaticResource BooleanInvertToVisibilityConverter}}"
-                                       Text="{Binding Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                       Text="{Binding Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                       IsTextChangingProgrammatically="{Binding IsDescriptionChangedNotByUser}">
                 </toggl:ExtendedTextBox>
                 <toggl:AutoCompletionPopup x:Name="descriptionAutoComplete" x:FieldModifier="private"
                                            Grid.Row="0"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
@@ -4,6 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:toggl="clr-namespace:TogglDesktop"
+             xmlns:conv="clr-namespace:TogglDesktop.ui.Converters"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" 
              d:DesignWidth="500"
              MinWidth="300"
@@ -68,6 +70,7 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+            <conv:BooleanInvertToVisibilityConverter x:Key="BooleanInvertToVisibilityConverter"/>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -75,7 +78,7 @@
               Margin="13 13 12 11">
             <Button Name="manualAddButton" x:FieldModifier="private"
                     Style="{StaticResource Toggl.AddTimeEntryButton}"
-                    Click="onManualAddButtonClick">
+                    Command="{Binding ManualAddButtonCommand}">
                 <StackPanel Orientation="Horizontal">
                     <Canvas Width="24" Height="24" Margin="4 -3 4 0">
                         <Path Fill="White" Data="M12.5 6v5.5H18v1h-5.5V18h-1v-5.5H6v-1h5.5V6h1z" />
@@ -87,8 +90,11 @@
         <Grid Name="timerPanel" x:FieldModifier="private"  Visibility="Visible"
               Margin="0 14 0 13"
               MouseLeftButtonDown="onGridMouseDown"
-              KeyDown="onGridKeyDown"
               Background="Transparent">
+            <Grid.InputBindings>
+                <KeyBinding Key="Enter" Command="{Binding StartStopCommand}"/>
+                <KeyBinding Key="Esc" Command="{Binding CancelProjectSelectionCommand}"/>
+            </Grid.InputBindings>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition Width="Auto"/>
@@ -100,7 +106,9 @@
                                   VerticalPadding="2"
                                   DescriptionLabelMouseDown="onDescriptionLabelMouseDown"
                                   ProjectLabelMouseDown="onProjectLabelMouseDown"
-                                  IconsPanelBackground="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=Background}"/>
+                                  IconsPanelBackground="{Binding RelativeSource={RelativeSource AncestorType=UserControl}, Path=Background}"
+                                  Visibility="{Binding DataContext.IsRunning, Converter={StaticResource BooleanToVisibilityConverter}, ElementName=timerPanel}"
+                                  DataContext="{Binding TimeEntryLabelViewModel}"/>
 
             <Grid Grid.Column="0" Grid.ColumnSpan="2" Name="editModeGrid" x:FieldModifier="private"
                   Margin="16 -16 0 -14">
@@ -116,15 +124,19 @@
                                        MinHeight="28"
                                        MaxHeight="32"
                                        Style="{StaticResource Toggl.Timer.DescriptionTextBox}"
-                                       TextChanged="onDescriptionTextBoxTextChanged"/>
+                                       Visibility="{Binding IsRunning, Converter={StaticResource BooleanInvertToVisibilityConverter}}"
+                                       Text="{Binding Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                </toggl:ExtendedTextBox>
                 <toggl:AutoCompletionPopup x:Name="descriptionAutoComplete" x:FieldModifier="private"
                                            Grid.Row="0"
                                            TextBox="{Binding ElementName=descriptionTextBox}"
                                            Target="{Binding ElementName=descriptionTextBox}"
-                                           ConfirmCompletion="descriptionAutoComplete_OnConfirmCompletion"/>
+                                           ConfirmCompletion="descriptionAutoComplete_OnConfirmCompletion">
+                </toggl:AutoCompletionPopup>
                 <Grid Grid.Row="1" x:Name="editProjectPanel" x:FieldModifier="private"
                            Margin="0 -2 0 6"
-                           Background="{DynamicResource Toggl.SelectionElements.Disabled.Background}">
+                           Background="{DynamicResource Toggl.SelectionElements.Disabled.Background}"
+                           Visibility="{Binding ProjectLabelViewModel.HasProject, FallbackValue=Collapsed, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition />
                         <ColumnDefinition Width="8"/>
@@ -132,7 +144,8 @@
                     </Grid.ColumnDefinitions>
                     <toggl:ProjectLabel x:Name="editModeProjectLabel" x:FieldModifier="private"
                                         Grid.ColumnSpan="2"
-                                        Margin="8 0 0 0"/>
+                                        Margin="8 0 0 0"
+                                        DataContext="{Binding ProjectLabelViewModel}"/>
                     <Grid Grid.Column="1" ColumnSpan="2">
                         <Grid.Background>
                             <LinearGradientBrush StartPoint="0 0.5" EndPoint="1 0.5">
@@ -143,7 +156,8 @@
                         <Button Style="{DynamicResource Toggl.CrossButton}"
                                 Width="24" Height="24"
                                 HorizontalAlignment="Right"
-                                IsTabStop="False" Click="cancelProjectSelectionButtonClick"/>
+                                IsTabStop="False"
+                                Command="{Binding CancelProjectSelectionCommand}"/>
                     </Grid>
                 </Grid>
             </Grid>
@@ -153,12 +167,15 @@
                     Background="Transparent"
                     Width="80"
                     Margin="3 0 0 0"
-                    MouseLeftButtonDown="onTimeLabelMouseDown">
+                    MouseLeftButtonDown="onTimeLabelMouseDown"
+                    Visibility="{Binding IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    ToolTip="{Binding DurationPanelToolTip}">
+
                 <TextBlock Name="durationLabel" x:FieldModifier="private"
                            Style="{StaticResource Toggl.TimerDurationText}"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"
-                           Text="00:00:00" />
+                           Text="{Binding DurationText}"/>
             </Border>
 
             <!-- start/stop button -->
@@ -166,8 +183,9 @@
                           Grid.Column="2"
                           Style="{StaticResource Toggl.StartStopButton}"
                           Margin="8 0 12 0"
-                          Click="startStopButtonOnClick"
-                          Focusable="False"/>
+                          Focusable="False"
+                          IsChecked="{Binding IsRunning, Mode=OneWay}"
+                          Command="{Binding StartStopCommand}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
@@ -185,7 +185,8 @@
                           Margin="8 0 12 0"
                           Focusable="False"
                           IsChecked="{Binding IsRunning, Mode=OneWay}"
-                          Command="{Binding StartStopCommand}"/>
+                          Command="{Binding StartStopCommand}"
+                          Click="startStopButton_Click"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using DynamicData.Binding;
 using System;
 using System.Collections.Generic;
+using System.Reactive.Linq;
 using System.Windows.Controls;
 using System.Windows.Input;
 using TogglDesktop.AutoCompletion;
@@ -18,8 +19,6 @@ namespace TogglDesktop
             set => DataContext = value;
         }
 
-        public event EventHandler StartStopClick;
-        public event EventHandler<string> RunningTimeEntrySecondPulse;
         public event EventHandler FocusTimeEntryList;
         public event EventHandler<string> DescriptionTextBoxTextChanged;
 
@@ -27,10 +26,7 @@ namespace TogglDesktop
         {
             this.InitializeComponent();
             ViewModel = new TimerViewModel(false);
-            ViewModel.WhenValueChanged(x => x.IsRunning).Subscribe(_ => StartStopClick?.Invoke(this, EventArgs.Empty));
-            ViewModel.WhenValueChanged(x => x.DurationText).Subscribe(e => RunningTimeEntrySecondPulse?.Invoke(this, e));
-            ViewModel.WhenValueChanged(x => x.IsRunning).Subscribe(x => { if (!x) FocusFirstInput(); });
-
+            ViewModel.WhenValueChanged(x => x.IsRunning).Where(isRunning => !isRunning).Subscribe(_ => FocusFirstInput());
             Toggl.OnMinitimerAutocomplete += this.onMiniTimerAutocomplete;
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
@@ -123,5 +123,11 @@ namespace TogglDesktop
         {
             DescriptionTextBoxTextChanged?.Invoke(sender, this.descriptionTextBox.Text);
         }
+
+        public event Action StartStopButtonClicked;
+        private void startStopButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            StartStopButtonClicked?.Invoke();
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml.cs
@@ -1,23 +1,22 @@
-﻿using System;
+﻿using DynamicData.Binding;
+using System;
 using System.Collections.Generic;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Threading;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.AutoCompletion.Items;
 using TogglDesktop.Diagnostics;
-using TogglDesktop.ViewModels;
+using TogglDesktop.ui.ViewModels;
 
 namespace TogglDesktop
 {
     public partial class Timer
     {
-        private readonly DispatcherTimer secondsTimer = new DispatcherTimer();
-        private Toggl.TogglTimeEntryView runningTimeEntry;
-        private bool isRunning;
-        private bool acceptNextUpdate;
-        private Toggl.TogglAutocompleteView completedProject;
+        public TimerViewModel ViewModel
+        {
+            get => (TimerViewModel)DataContext;
+            set => DataContext = value;
+        }
 
         public event EventHandler StartStopClick;
         public event EventHandler<string> RunningTimeEntrySecondPulse;
@@ -27,63 +26,15 @@ namespace TogglDesktop
         public Timer()
         {
             this.InitializeComponent();
-
-            this.setupSecondsTimer();
+            ViewModel = new TimerViewModel(false);
+            ViewModel.WhenValueChanged(x => x.IsRunning).Subscribe(_ => StartStopClick?.Invoke(this, EventArgs.Empty));
+            ViewModel.WhenValueChanged(x => x.DurationText).Subscribe(e => RunningTimeEntrySecondPulse?.Invoke(this, e));
+            ViewModel.WhenValueChanged(x => x.IsRunning).Subscribe(x => { if (!x) FocusFirstInput(); });
 
             Toggl.OnMinitimerAutocomplete += this.onMiniTimerAutocomplete;
-            Toggl.OnRunningTimerState += this.onRunningTimerState;
-            Toggl.OnStoppedTimerState += this.onStoppedTimerState;
-
-            this.RunningTimeEntrySecondPulse += this.timerTick;
-
-            this.resetUIState(false, true);
-        }
-
-        private static bool IsMiniTimer => false;
-
-        private void setupSecondsTimer()
-        {
-            this.secondsTimer.Interval = TimeSpan.FromSeconds(1);
-            this.secondsTimer.Tick += (sender, args) =>
-            {
-                if (!this.isRunning)
-                    return;
-
-                var s = Toggl.FormatDurationInSecondsHHMMSS(this.runningTimeEntry.DurationInSeconds);
-
-                if (this.RunningTimeEntrySecondPulse != null)
-                    this.RunningTimeEntrySecondPulse(this, s);
-            };
         }
 
         #region toggl events
-
-        private void onStoppedTimerState()
-        {
-            if (this.TryBeginInvoke(this.onStoppedTimerState))
-                return;
-
-            using (Performance.Measure("timer responding to OnStoppedTimerState"))
-            {
-                this.secondsTimer.IsEnabled = false;
-                this.resetUIState(false);
-                this.runningTimeEntry = default(Toggl.TogglTimeEntryView);
-                FocusFirstInput();
-            }
-        }
-
-        private void onRunningTimerState(Toggl.TogglTimeEntryView te)
-        {
-            if (this.TryBeginInvoke(this.onRunningTimerState, te))
-                return;
-
-            using (Performance.Measure("timer responding to OnRunningTimerState"))
-            {
-                this.runningTimeEntry = te;
-                this.setUIToRunningState(te);
-                this.secondsTimer.IsEnabled = true;
-            }
-        }
 
         private void onMiniTimerAutocomplete(List<Toggl.TogglAutocompleteView> list)
         {
@@ -100,90 +51,36 @@ namespace TogglDesktop
 
         #region ui events
 
-        private void timerTick(object sender, string t)
-        {
-            this.durationLabel.Text = t;
-        }
-
-        private void startStopButtonOnClick(object sender, RoutedEventArgs e)
-        {
-            this.startStop();
-        }
-
-        private void onGridKeyDown(object sender, KeyEventArgs e)
-        {
-            switch (e.Key)
-            {
-                case Key.Enter:
-                {
-                    this.startStopButton.IsChecked = !this.startStopButton.IsChecked;
-                    this.startStop();
-                    e.Handled = true;
-                    return;
-                }
-                case Key.Escape:
-                {
-                    if (this.isRunning || this.editModeProjectLabel.ViewModel?.HasProject != true)
-                        return;
-                    this.clearSelectedProject();
-                    e.Handled = true;
-                    return;
-                }
-            }
-        }
-
         private void onProjectLabelMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, Toggl.Project);
+            TryOpenEditViewIfRunning(e, Toggl.Project);
         }
 
         private void onDescriptionLabelMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, Toggl.Description);
+            TryOpenEditViewIfRunning(e, Toggl.Description);
         }
 
         private void onTimeLabelMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, Toggl.Duration);
+            TryOpenEditViewIfRunning(e, Toggl.Duration);
         }
 
         private void onGridMouseDown(object sender, MouseButtonEventArgs e)
         {
-            this.tryOpenEditViewIfRunning(e, "");
+            TryOpenEditViewIfRunning(e, "");
+        }
+
+        private void TryOpenEditViewIfRunning(MouseButtonEventArgs e, string focusedField)
+        {
+            ViewModel.tryOpenEditViewIfRunning(focusedField);
+            e.Handled = true;
         }
 
         private void descriptionAutoComplete_OnConfirmCompletion(object sender, IAutoCompleteItem e)
         {
-            var asItem = e as IModelItem<Toggl.TogglAutocompleteView>;
-            if (asItem == null)
-                return;
-
-            var item = asItem.Model;
-
-            this.descriptionTextBox.SetText(item.Description);
-            this.descriptionTextBox.CaretIndex = this.descriptionTextBox.Text.Length;
-
-            this.editProjectPanel.ShowOnlyIf(item.ProjectID != 0);
-            this.editModeProjectLabel.ViewModel = item.ToProjectLabelViewModel();
-            completedProject = item;
-        }
-
-        private void cancelProjectSelectionButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.clearSelectedProject();
-        }
-
-        private void clearSelectedProject()
-        {
-            this.editProjectPanel.Visibility = Visibility.Collapsed;
-            this.editModeProjectLabel.ViewModel = null;
-            completedProject = default;
-        }
-
-        private void onManualAddButtonClick(object sender, RoutedEventArgs e)
-        {
-            var guid = Toggl.Start("", "0", 0, 0, "", "", IsMiniTimer);
-            Toggl.Edit(guid, false, Toggl.Duration);
+            ViewModel.DescriptionAutoCompleteConfirm(e);
+            descriptionTextBox.CaretIndex = descriptionTextBox.Text.Length;
         }
 
         protected override void OnPreviewKeyDown(KeyEventArgs e)
@@ -216,101 +113,6 @@ namespace TogglDesktop
             {
                 this.descriptionTextBox.Focus();
             }
-        }
-
-        #endregion
-
-        #region controlling
-
-        private void startStop()
-        {
-            if (this.StartStopClick != null)
-                this.StartStopClick(this, EventArgs.Empty);
-
-            this.acceptNextUpdate = true;
-
-            if (this.isRunning)
-            {
-                this.stop();
-            }
-            else
-            {
-                this.start();
-            }
-        }
-
-        private void tryOpenEditViewIfRunning(MouseButtonEventArgs e, string focusedField)
-        {
-            if (this.isRunning)
-            {
-                using (Performance.Measure("opening edit view from timer, focussing " + focusedField))
-                {
-                    Toggl.Edit(this.runningTimeEntry.GUID, false, focusedField);
-                }
-                e.Handled = true;
-            }
-        }
-
-        private void start()
-        {
-            using (Performance.Measure("starting time entry from timer"))
-            {
-                var guid = Toggl.Start(
-                    this.descriptionTextBox.Text,
-                    "",
-                    completedProject.TaskID,
-                    completedProject.ProjectID,
-                    "",
-                    completedProject.Tags,
-                    IsMiniTimer
-                    );
-
-                if (completedProject.Billable)
-                {
-                    Toggl.SetTimeEntryBillable(guid, true);
-                }
-
-                this.clearSelectedProject();
-            }
-        }
-
-        private void stop()
-        {
-            using (Performance.Measure("stopping time entry from timer"))
-            {
-                Toggl.Stop(IsMiniTimer);
-            }
-        }
-
-        #endregion 
-
-        #region updating ui
-
-        private void setUIToRunningState(Toggl.TogglTimeEntryView item)
-        {
-            this.resetUIState(true);
-            this.timeEntryLabel.ViewModel = item.ToTimeEntryLabelViewModel();
-            this.durationLabel.Text = Toggl.FormatDurationInSecondsHHMMSS(item.DurationInSeconds);
-            this.durationPanel.ToolTip = "started at " + item.StartTimeString;
-        }
-
-        private void resetUIState(bool running, bool forceUpdate = false)
-        {
-            var changedState = this.isRunning != running;
-
-            if (!(changedState || forceUpdate || this.acceptNextUpdate))
-                return;
-
-            this.acceptNextUpdate = false;
-
-            this.isRunning = running;
-            this.startStopButton.IsChecked = running;
-            this.descriptionTextBox.SetText("");
-            this.descriptionTextBox.ShowOnlyIf(!running);
-            this.timeEntryLabel.ShowOnlyIf(running);
-            this.durationPanel.ShowOnlyIf(running);
-            this.editProjectPanel.Visibility = Visibility.Collapsed;
-            this.editModeProjectLabel.ViewModel = null;
         }
 
         #endregion

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Threading;
 using TogglDesktop.Diagnostics;
+using TogglDesktop.ui.ViewModels;
 using TogglDesktop.ViewModels;
 
 namespace TogglDesktop

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using DynamicData.Binding;
 using Microsoft.Win32;
 using NHotkey;
 using NHotkey.Wpf;
@@ -192,8 +193,8 @@ namespace TogglDesktop
             this.idleNotificationWindow = new IdleNotificationWindow();
 
             this.editPopup.EditView.SetTimer(this.timerEntryListView.Timer);
-            this.timerEntryListView.Timer.RunningTimeEntrySecondPulse += this.updateTaskbarTooltip;
-            this.timerEntryListView.Timer.StartStopClick += (sender, args) => this.closeEditPopup(true);
+            this.timerEntryListView.Timer.ViewModel.WhenValueChanged(x => x.DurationText).Subscribe(x => updateTaskbarTooltip(this, x));
+            this.timerEntryListView.Timer.ViewModel.WhenValueChanged(x => x.IsRunning).Subscribe( x => closeEditPopup(true));
             this.timerEntryListView.Entries.SetEditPopup(this.editPopup);
             this.timerEntryListView.Entries.CloseEditPopup += (sender, args) => this.closeEditPopup(true);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -194,7 +194,7 @@ namespace TogglDesktop
 
             this.editPopup.EditView.SetTimer(this.timerEntryListView.Timer);
             this.timerEntryListView.Timer.ViewModel.WhenValueChanged(x => x.DurationText).Subscribe(x => updateTaskbarTooltip(this, x));
-            this.timerEntryListView.Timer.ViewModel.WhenValueChanged(x => x.IsRunning).Subscribe( x => closeEditPopup(true));
+            this.timerEntryListView.Timer.StartStopButtonClicked += ()  => closeEditPopup(true);
             this.timerEntryListView.Entries.SetEditPopup(this.editPopup);
             this.timerEntryListView.Entries.CloseEditPopup += (sender, args) => this.closeEditPopup(true);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -581,6 +581,9 @@ namespace TogglDesktop
 
         private void updateTaskbarTooltip(object sender, string s)
         {
+            if (this.TryBeginInvoke(updateTaskbarTooltip, sender, s))
+                return;
+
             this.trayToolTip.SetDuration(s);
         }
 
@@ -790,6 +793,9 @@ namespace TogglDesktop
 
         private void closeEditPopup(bool focusTimeEntryList = false, bool skipAnimation = false)
         {
+            if (this.TryBeginInvoke(this.closeEditPopup, focusTimeEntryList, skipAnimation))
+                return;
+
             if (this.editPopup != null && this.editPopup.IsVisible)
             {
                 // TODO: consider saving popup open state and restoring when window is shown


### PR DESCRIPTION
### 📒 Description
Timer.xaml.cs and MiniTimer.xaml.cs contain almost the same code. This removes most of the duplication and places the common code into the view model.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

Bug fix** (non-breaking change which fixes an issue) 
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
Timer
MiniTimer

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3730 

### 🔎 Review hints
What is left:
1. Some duplication in the code behind which refers directly to other wpf controls. This can't be placed into view model. Probably we can do a common xaml control for timer and mini Timer and just style it differently.
2. Some strange logic with auto complete popup. I noticed this only a few hours ago. It should not open when text in the description box is changed programmacaly. This logic was lost because of binding.

