### PR TITLE
Add a HTTP header for the Switching board

### DIFF
--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -379,6 +379,9 @@ HTTPResponse HTTPClient::makeHttpRequest(
         // Request gzip unless downloading files
         poco_req.set("Accept-Encoding", "gzip");
 
+        // Set the Switching board header for Sync server requests
+        poco_req.set("X-Toggl-Client", "desktop");
+
         if (!req.form) {
             std::istringstream requestStream(req.payload);
 


### PR DESCRIPTION
### 📒 Description
This PR adds a new HTTP header as mentioned in #4163. It adds it to all requests but it'll get ignored. It's not the cleanest solution in the world but doing it properly would require a substantial change to the `HTTPClient` class.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4163

### 🔎 Review hints
The outgoing HTTP requests should have the header. 

