### PR TITLE
Increase the font size of time entry description and project

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Typography.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Typography.xaml
@@ -44,6 +44,9 @@
     <Style TargetType="TextBlock" x:Key="Toggl.BodyText" BasedOn="{StaticResource Toggl.Text}">
         <Setter Property="FontSize" Value="14" />
     </Style>
+    <Style TargetType="TextBlock" x:Key="Toggl.BodyGrayishText" BasedOn="{StaticResource Toggl.BodyText}">
+        <Setter Property="Foreground" Value="{DynamicResource Toggl.DisabledTextBrush}" />
+    </Style>
     <Style TargetType="TextBlock" x:Key="Toggl.TimerDurationText" BasedOn="{StaticResource Toggl.Text}">
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="FontSize" Value="18" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimeEntryCellStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimeEntryCellStyles.xaml
@@ -4,7 +4,7 @@
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
     xmlns:toggl="clr-namespace:TogglDesktop">
 
-    <sys:Double x:Key="TimeEntryHeight">60</sys:Double>
+    <sys:Double x:Key="TimeEntryHeight">62</sys:Double>
     <sys:Double x:Key="TimeEntryDayHeaderHeight">32</sys:Double>
 
     <ContextMenu x:Key="TimeEntryContextMenu">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
@@ -22,7 +22,7 @@
                             <Grid>
                                 <Rectangle Name="BackgroundRectangle"
                                            Fill="{DynamicResource Toggl.AccentBrush}"
-                                           Width="44"/>
+                                           Width="47"/>
                                 <Path Name="StartButton"
                                       Width="36"
                                       Height="36"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/MiniTimer.xaml
@@ -7,7 +7,7 @@
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              mc:Ignorable="d" 
              d:DesignWidth="500"
-             MinHeight="44"
+             MinHeight="46"
              MaxHeight="52"
              Focusable="True"
              Background="{DynamicResource Toggl.CardBackground}"
@@ -22,7 +22,7 @@
                             <Grid>
                                 <Rectangle Name="BackgroundRectangle"
                                            Fill="{DynamicResource Toggl.AccentBrush}"
-                                           Width="47"/>
+                                           Width="46"/>
                                 <Path Name="StartButton"
                                       Width="36"
                                       Height="36"
@@ -35,7 +35,7 @@
                                       Fill="White"
                                       Data="{StaticResource StopButtonGeometry}"/>
                                 <Rectangle Name="OverlayRectangle"
-                                         Width="44"
+                                         Width="46"
                                          Fill="Transparent" />
                             </Grid>
                             <ControlTemplate.Triggers>
@@ -90,7 +90,7 @@
             </Grid.ColumnDefinitions>
 
             <toggl:TimeEntryLabel x:Name="timeEntryLabel" x:FieldModifier="private"
-                                  Margin="16 4 0 6"
+                                  Margin="16 3 0 5"
                                   VerticalPadding="1"
                                   CompactDescription="True"
                                   DescriptionLabelMouseDown="onDescriptionLabelMouseDown"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ProjectLabel.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ProjectLabel.xaml
@@ -9,7 +9,7 @@
              d:DesignHeight="300" d:DesignWidth="300"
              d:DataContext="{d:DesignInstance viewModels:ProjectLabelViewModel}">
     <UserControl.Resources>
-        <Style TargetType="TextBlock" BasedOn="{StaticResource Toggl.CaptionBlackText}">
+        <Style TargetType="TextBlock" BasedOn="{StaticResource Toggl.BodyText}">
             <Setter Property="VerticalAlignment" Value="Center" />
             <Setter Property="TextWrapping" Value="NoWrap" />
         </Style>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml
@@ -60,7 +60,7 @@
                 Margin="3 0 0 0"
                 MouseLeftButtonDown="labelDuration_MouseDown">
             <TextBlock Name="durationLabel" x:FieldModifier="private"
-                       Style="{StaticResource Toggl.CaptionBlackText}"
+                       Style="{StaticResource Toggl.BodyText}"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Center"
                        Text="00:00:00" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCellDayHeader.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCellDayHeader.xaml
@@ -41,7 +41,7 @@
                                HorizontalAlignment="Left"
                                Text="{Binding DateHeader}"/>
                     <TextBlock DockPanel.Dock="Right"
-                               Style="{StaticResource Toggl.CaptionSemiBoldText}"
+                               Style="{StaticResource Toggl.BaseText}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Right"
                                Text="{Binding DateDuration}"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryLabel.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryLabel.xaml
@@ -23,7 +23,7 @@
                    ToolTip="{Binding Description}">
         </TextBlock>
         <TextBlock Grid.Row="0" Name="addDescriptionLabel" x:FieldModifier="private"
-                   Style="{StaticResource Toggl.CaptionGrayishText}"
+                   Style="{StaticResource Toggl.BodyGrayishText}"
                    TextWrapping="NoWrap"
                    Text="{Binding AddDescriptionLabelText}"
                    VerticalAlignment="Center"
@@ -37,7 +37,7 @@
                             Visibility="{Binding ProjectName, Converter={StaticResource EmptyStringToCollapsedConverter}}" />
 
         <TextBlock Grid.Row="1"
-                   Style="{DynamicResource Toggl.CaptionGrayishText}"
+                   Style="{StaticResource Toggl.BodyGrayishText}"
                    Text="+ Add project"
                    TextWrapping="NoWrap"
                    MouseLeftButtonDown="onProjectLabelMouseDown"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timer.xaml
@@ -85,7 +85,7 @@
             </Button>
         </Grid>
         <Grid Name="timerPanel" x:FieldModifier="private"  Visibility="Visible"
-              Margin="0 16 0 14"
+              Margin="0 14 0 13"
               MouseLeftButtonDown="onGridMouseDown"
               KeyDown="onGridKeyDown"
               Background="Transparent">


### PR DESCRIPTION
### 📒 Description
Increase the font size of time entry description and project from 12 to 14 (as discussed with Janika).
This is especially helpful in the Dark mode for "+Add description/project/details" text where the contrast between gray and black is not that large.

### 🕶️ Types of changes
- **Improvement** (non-breaking change which fixes an issue) 

### 🤯 List of changes
Increased the font size of description, project/task/client, and "+Add description/project/details" labels in
- Timer
- Time entry list
- Mini timer

### 🔎 Review hints
Check different states of Timer, Mini Timer, and time entries in the Time entry list.
Check the light and dark modes.
Check different letters in the names of description/project/etc to ensure the letters like "y", "p", "j" do not get cut off from the bottom.
See if subjectively anything looks odd for you as a user.

