### PR TITLE
Allow release builds to connect to Staging

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -94,10 +94,6 @@ Context::Context(const std::string &app_name, const std::string &app_version)
         Poco::Net::HTTPSStreamFactory::registerFactory();
     }
 
-#ifndef TOGGL_PRODUCTION_BUILD
-    urls::SetUseStagingAsBackend(true);
-#endif
-
     Poco::ErrorHandler::set(&error_handler_);
     Poco::Net::initializeSSL();
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -5649,7 +5649,7 @@ error Context::pushProjects(
 }
 
 error Context::updateProjectClients(const std::vector<Client *> &clients,
-                                     const std::vector<Project *> &projects) {
+                                    const std::vector<Project *> &projects) {
     for (auto it = projects.cbegin(); it != projects.cend(); ++it) {
         if (!(*it)->CID() && !(*it)->ClientGUID().empty()) {
             // Find client id

--- a/src/context.h
+++ b/src/context.h
@@ -682,7 +682,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error syncHandleResponse(Json::Value &array, const std::vector<T*> &source);
 
     error pushBatchedChanges(
-            bool *had_something_to_push);
+        bool *had_something_to_push);
     error pushChanges(
         bool *had_something_to_push);
     error pushClients(
@@ -728,9 +728,9 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
                     std::string *user_data,
                     const Poco::Int64 since);
     static error syncPull(const std::string &email,
-                         const std::string &password,
-                         std::string *user_data,
-                         const Poco::Int64 since);
+                          const std::string &password,
+                          std::string *user_data,
+                          const Poco::Int64 since);
 
     bool isTimeEntryLocked(TimeEntry* te);
     bool isTimeLockedInWorkspace(time_t t, Workspace* ws);

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -411,7 +411,7 @@ void toggl_set_log_level(const char_t *level) {
     Poco::Logger::get("").setLevel(to_string(level));
 }
 
-void toggl_set_staging_override(bool value) {
+void toggl_set_staging_override(bool_t value) {
     toggl::urls::SetUseStagingAsBackend(value);
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -23,6 +23,7 @@
 #include "websocket_client.h"
 #include "window_change_recorder.h"
 #include "color_convert.h"
+#include "urls.h"
 
 #include <Poco/Bugcheck.h>
 #include <Poco/Path.h>
@@ -408,6 +409,10 @@ void toggl_set_log_path(const char_t *path) {
 
 void toggl_set_log_level(const char_t *level) {
     Poco::Logger::get("").setLevel(to_string(level));
+}
+
+void toggl_set_staging_override(bool value) {
+    toggl::urls::SetUseStagingAsBackend(value);
 }
 
 void toggl_show_app(

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -322,7 +322,7 @@ extern "C" {
         TogglTimeEntryView *te);
 
     typedef void (*TogglContinueSignIn)(
-        );
+    );
 
     typedef void (*TogglDisplayIdleNotification)(
         const char_t *guid,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include <time.h>
 
@@ -420,6 +421,11 @@ extern "C" {
 
     TOGGL_EXPORT void toggl_set_log_level(
         const char_t *level);
+
+    // Allow overriding the server in production
+
+    TOGGL_EXPORT void toggl_set_staging_override(
+        bool value);
 
     // Various parts of UI can tell the app to show itself.
 

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -425,7 +425,7 @@ extern "C" {
     // Allow overriding the server in production
 
     TOGGL_EXPORT void toggl_set_staging_override(
-        bool value);
+        bool_t value);
 
     // Various parts of UI can tell the app to show itself.
 

--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -21,6 +21,7 @@
 #include "./genericview.h"
 #include "./mainwindowcontroller.h"
 #include "./toggl.h"
+#include "./urls.h"
 
 MainWindowController *w = nullptr;
 
@@ -93,12 +94,21 @@ int main(int argc, char *argv[]) try {
         "path");
     parser.addOption(scriptPathOption);
 
+    QCommandLineOption forceStagingOption(
+        QStringList() << "staging",
+        "Force connecting to the staging server");
+    parser.addOption(forceStagingOption);
+
     // A boolean option with multiple names (-b, --background)
     QCommandLineOption forceOption(QStringList() << "b" << "background",
                                    QCoreApplication::translate("main", "Start app in background."));
     parser.addOption(forceOption);
 
     parser.process(a);
+
+    if (parser.isSet(forceStagingOption)) {
+        toggl::urls::SetUseStagingAsBackend(true);
+    }
 
     w = new MainWindowController(nullptr,
                                  parser.value(logPathOption),

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -83,6 +83,9 @@
 // For testing crash reporter
 @property (nonatomic, assign) BOOL forceCrash;
 
+// For connecting to staging in production builds
+@property (nonatomic, assign) BOOL forceStaging;
+
 // Avoid doing stuff when app is already shutting down
 @property (nonatomic, assign) BOOL willTerminate;
 
@@ -1206,6 +1209,12 @@ const NSString *appName = @"osx_native_app";
 			NSLog(@"log level overriden with '%@'", self.log_level);
 			continue;
 		}
+        if ([argument rangeOfString:@"staging"].location != NSNotFound)
+        {
+            NSLog(@"forcing staging");
+            self.forceStaging = YES;
+            continue;
+        }
 	}
 }
 
@@ -1239,6 +1248,7 @@ const NSString *appName = @"osx_native_app";
 	self.db_path = [self.app_path stringByAppendingPathComponent:@"toggldesktop.db"];
 	self.log_path = [self.app_path stringByAppendingPathComponent:@"toggl_desktop.log"];
 	self.log_level = @"debug";
+	self.forceStaging = NO;
 	self.systemService = [[SystemService alloc] init];
 	self.isAddedTouchBar = NO;
 
@@ -1257,6 +1267,11 @@ const NSString *appName = @"osx_native_app";
 
 	toggl_set_log_path([self.log_path UTF8String]);
 	toggl_set_log_level([self.log_level UTF8String]);
+
+	if (self.forceStaging)
+	{
+		toggl_set_staging_override(self.forceStaging);
+	}
 
 	ctx = toggl_context_init([appName UTF8String], [self.version UTF8String]);
 

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1209,7 +1209,7 @@ const NSString *appName = @"osx_native_app";
 			NSLog(@"log level overriden with '%@'", self.log_level);
 			continue;
 		}
-        if ([argument rangeOfString:@"staging"].location != NSNotFound)
+        if ([argument isEqualToString:@"--staging"])
         {
             NSLog(@"forcing staging");
             self.forceStaging = YES;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1088,6 +1088,10 @@ public static partial class Toggl
                 Env = args[i + 1];
                 Console.WriteLine("Environment = {0}", Env);
             }
+            else if (args[i].Contains("--staging"))
+            {
+                toggl_set_staging_override(true);
+            }
         }
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -663,6 +663,13 @@ public static partial class Toggl
         [MarshalAs(UnmanagedType.LPWStr)]
         string level);
 
+    // Allow overriding the server in production
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void toggl_set_staging_override(
+        [MarshalAs(UnmanagedType.I1)]
+        bool value);
+
     // Various parts of UI can tell the app to show itself.
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
@@ -1475,6 +1482,27 @@ public static partial class Toggl
     [return:MarshalAs(UnmanagedType.I1)]
     private static extern bool toggl_clear_cache(
         IntPtr context);
+
+    // returns GUID of the started time entry. you must free() the result
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern string toggl_start_with_current_running(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string description,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string duration,
+        UInt64 task_id,
+        UInt64 project_id,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string project_guid,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string tags,
+        [MarshalAs(UnmanagedType.I1)]
+        bool prevent_on_app,
+        UInt64 started,
+        UInt64 ended,
+        [MarshalAs(UnmanagedType.I1)]
+        bool stop_current_running);
 
     // returns GUID of the started time entry. you must free() the result
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]

--- a/src/urls.cc
+++ b/src/urls.cc
@@ -7,7 +7,12 @@ namespace toggl {
 namespace urls {
 
 // Whether requests are sent to staging backend
+
+#ifndef TOGGL_PRODUCTION_BUILD
+static bool use_staging_as_backend = true;
+#else
 static bool use_staging_as_backend = false;
+#endif
 
 // Whether requests are allowed to Toggl backend
 static bool im_a_teapot_ = false;

--- a/src/urls.cc
+++ b/src/urls.cc
@@ -37,7 +37,7 @@ std::string Main() {
 
 std::string API() {
     if (use_staging_as_backend) {
-        return "https://toggl.space";
+        return "https://desktop.toggl.space";
     }
     return "https://desktop.toggl.com";
 }


### PR DESCRIPTION
### 📒 Description
Allow release builds to connect to the Staging environment. This is #3979 + Windows support.

### 🕶️ Types of changes
 - **New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
- [x] New API method `toggl_set_staging_override`
- [x] Support `--staging` argument on Windows and Linux, and `staging` argument on macOS (does this need to be fixed?)

### 👫 Relationships
Closes #3407

### 🔎 Review hints
Build the app in Release mode and run with `--staging` argument.
The app should connect to the Staging environment instead of Production.
Test on macOS, Windows, and Linux.