### PR TITLE
Sync: Three-way merge Push

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -3239,6 +3239,10 @@ error Context::updateTimeEntryProject(
         p = user_->related.ProjectByGUID(project_guid);
     }
 
+    if (isUsingSyncServer() && p && p->WID() != te->WID()) {
+        return displayError("This version of Toggl Desktop does not support changing time entry workspaces.");
+    }
+
     if (p && !canChangeProjectTo(te, p)) {
         return displayError(error(
             "Cannot change project: would end up with locked time entry"));
@@ -4933,6 +4937,10 @@ void Context::syncerActivityWrapper() {
                         }
                     }
                 }
+                if (state == BATCHED)
+                    is_using_sync_server_ = true;
+                else
+                    is_using_sync_server_ = false;
             }
             // it is a HTTP error in disguise which means the server is alive, fallback to LEGACY
             else if (resp.err == HTTPClient::StatusCodeToError(resp.status_code)) {
@@ -6826,6 +6834,10 @@ bool Context::checkIfSkipPomodoro(TimeEntry *te) {
         }
     }
     return false;
+}
+
+bool Context::isUsingSyncServer() const {
+    return is_using_sync_server_;
 }
 
 void Context::TrackTimelineMenuContext(const TimelineMenuContextType type) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -3250,13 +3250,13 @@ error Context::updateTimeEntryProject(
         // billable, // then selected the same project again).
         if (p->ID() != te->PID()
                 || (!project_guid.empty() && p->GUID().compare(te->ProjectGUID()) != 0)) {
-            te->SetBillable(p->Billable(), false);
+            te->SetBillable(p->Billable(), true);
         }
         te->SetWID(p->WID());
     }
-    te->SetTID(task_id, false);
-    te->SetPID(project_id, false);
-    te->SetProjectGUID(project_guid, false);
+    te->SetTID(task_id, true);
+    te->SetPID(project_id, true);
+    te->SetProjectGUID(project_guid, true);
     return noError;
 }
 

--- a/src/context.h
+++ b/src/context.h
@@ -833,6 +833,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     TimeEntry *pomodoro_break_entry_;
 
+    bool is_using_sync_server_;
+
     // To cache grouped entries open/close status
     std::map<std::string, bool_t> entry_groups;
 
@@ -855,6 +857,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     Poco::Mutex onboarding_service_m_;
 
     bool checkIfSkipPomodoro(TimeEntry *te);
+
+    bool isUsingSyncServer() const;
 };
 void on_websocket_message(
     void *context,

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -1903,6 +1903,14 @@ error Database::loadTimeEntriesFromSQLStatement(
             bool more = rs.moveFirst();
             while (more) {
                 TimeEntry *model = new TimeEntry();
+
+                if (rs[10].isEmpty()) {
+                    model->SetUIModifiedAt(0);
+                } else {
+                    model->SetUIModifiedAt(rs[10].convert<Poco::Int64>());
+                }
+                bool userModified = model->UIModifiedAt();
+
                 model->SetLocalID(rs[0].convert<Poco::Int64>());
                 if (rs[1].isEmpty()) {
                     model->SetID(0);
@@ -1911,40 +1919,36 @@ error Database::loadTimeEntriesFromSQLStatement(
                 }
                 model->SetUID(rs[2].convert<Poco::UInt64>());
                 if (rs[3].isEmpty()) {
-                    model->SetDescription("");
+                    model->SetDescription("", userModified);
                 } else {
-                    model->SetDescription(rs[3].convert<std::string>());
+                    model->SetDescription(rs[3].convert<std::string>(), userModified);
                 }
                 model->SetWID(rs[4].convert<Poco::UInt64>());
                 model->SetGUID(rs[5].convert<std::string>());
                 if (rs[6].isEmpty()) {
-                    model->SetPID(0);
+                    model->SetPID(0, userModified);
                 } else {
-                    model->SetPID(rs[6].convert<Poco::UInt64>());
+                    model->SetPID(rs[6].convert<Poco::UInt64>(), userModified);
                 }
                 if (rs[7].isEmpty()) {
-                    model->SetTID(0);
+                    model->SetTID(0, userModified);
                 } else {
-                    model->SetTID(rs[7].convert<Poco::UInt64>());
+                    model->SetTID(rs[7].convert<Poco::UInt64>(), userModified);
                 }
-                model->SetBillable(rs[8].convert<bool>());
+                model->SetBillable(rs[8].convert<bool>(), userModified);
                 model->SetDurOnly(rs[9].convert<bool>());
-                if (rs[10].isEmpty()) {
-                    model->SetUIModifiedAt(0);
-                } else {
-                    model->SetUIModifiedAt(rs[10].convert<Poco::Int64>());
-                }
-                model->SetStartTime(rs[11].convert<Poco::Int64>());
+                // 10 is UIUpdatedAt
+                model->SetStartTime(rs[11].convert<Poco::Int64>(), userModified);
                 if (rs[12].isEmpty()) {
-                    model->SetStopTime(0);
+                    model->SetStopTime(0, userModified);
                 } else {
-                    model->SetStopTime(rs[12].convert<Poco::Int64>());
+                    model->SetStopTime(rs[12].convert<Poco::Int64>(), userModified);
                 }
-                model->SetDurationInSeconds(rs[13].convert<Poco::Int64>());
+                model->SetDurationInSeconds(rs[13].convert<Poco::Int64>(), userModified);
                 if (rs[14].isEmpty()) {
-                    model->SetTags("");
+                    model->SetTags("", userModified);
                 } else {
-                    model->SetTags(rs[14].convert<std::string>());
+                    model->SetTags(rs[14].convert<std::string>(), userModified);
                 }
                 if (rs[15].isEmpty()) {
                     model->SetCreatedWith("");
@@ -1962,9 +1966,9 @@ error Database::loadTimeEntriesFromSQLStatement(
                     model->SetUpdatedAt(rs[17].convert<Poco::Int64>());
                 }
                 if (rs[18].isEmpty()) {
-                    model->SetProjectGUID("");
+                    model->SetProjectGUID("", userModified);
                 } else {
-                    model->SetProjectGUID(rs[18].convert<std::string>());
+                    model->SetProjectGUID(rs[18].convert<std::string>(), userModified);
                 }
                 if (rs[19].isEmpty()) {
                     model->SetValidationError("");

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -85,7 +85,7 @@ Json::Value Client::SyncMetadata() const {
 Json::Value Client::SyncPayload() const {
     Json::Value result;
     if (NeedsPOST()) {
-        result["id"] = Json::Int64(ID());
+        result["id"] = Json::Int64(-LocalID());
         result["wid"] = Json::Int64(WID());
     }
     if (NeedsPOST() || NeedsPUT()) {

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -194,7 +194,7 @@ Json::Value Project::SyncMetadata() const {
 Json::Value Project::SyncPayload() const {
     Json::Value result;
     if (NeedsPOST()) {
-        result["id"] = Json::Int64(ID());
+        result["id"] = Json::Int64(-LocalID());
         result["workspace_id"] = Json::Int64(WID());
     }
     if (NeedsPOST() || NeedsPUT()) {

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -569,7 +569,7 @@ Json::Value TimeEntry::SyncMetadata() const {
 Json::Value TimeEntry::SyncPayload() const {
     Json::Value result;
     if (NeedsPOST()) {
-        result["id"] = Json::Int64(ID());
+        result["id"] = Json::Int64(-ID());
         result["workspace_id"] = Json::Int64(WID());
     }
     if (NeedsPOST() || NeedsPUT()) {

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -34,30 +34,30 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     Property<bool> DurOnly { false };
     Property<bool> SkipPomodoro { false };
 
-    void SetDescription(const std::string &value);
+    void SetDescription(const std::string &value, bool userModified);
     void SetCreatedWith(const std::string &value);
-    void SetProjectGUID(const std::string &value);
+    void SetProjectGUID(const std::string &value, bool userModified);
 
     const std::string Tags() const;
-    void SetTags(const std::string &tags);
+    void SetTags(const std::string &tags, bool userModified);
     const std::string TagsHash() const;
 
     void SetWID(Poco::UInt64 value);
-    void SetPID(Poco::UInt64 value);
-    void SetTID(Poco::UInt64 value);
+    void SetPID(Poco::UInt64 value, bool userModified);
+    void SetTID(Poco::UInt64 value, bool userModified);
 
     std::string StartString() const;
-    void SetStartString(const std::string &value);
-    void SetStartTime(Poco::Int64 value);
+    void SetStartString(const std::string &value, bool userModified);
+    void SetStartTime(Poco::Int64 value, bool userModified);
 
     std::string StopString() const;
-    void SetStopString(const std::string &value);
-    void SetStopTime(Poco::Int64 value);
+    void SetStopString(const std::string &value, bool userModified);
+    void SetStopTime(Poco::Int64 value, bool userModified);
 
-    void SetDurationInSeconds(const Poco::Int64 value);
+    void SetDurationInSeconds(const Poco::Int64 value, bool userModified);
     void SetLastStartAt(Poco::Int64 value);
 
-    void SetBillable(bool value);
+    void SetBillable(bool value, bool userModified);
     void SetDurOnly(bool value);
     void SetSkipPomodoro(bool value);
 
@@ -73,7 +73,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     void DiscardAt(const Poco::Int64);
     void StopTracking();
 
-    bool isNotFound(const error &err) const;
+    static bool isNotFound(const error &err);
 
     const std::string GroupHash() const;
 

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -36,6 +36,59 @@
 
 namespace toggl {
 
+template<class T>
+void deleteZombies(
+    const std::vector<T> &list,
+    const std::set<Poco::UInt64> &alive) {
+    for (size_t i = 0; i < list.size(); ++i) {
+        BaseModel *model = list[i];
+        if (!model->ID()) {
+            // If model has no server-assigned ID, it's not even
+            // pushed to server. So actually we don't know if it's
+            // a zombie or not. Ignore:
+            continue;
+        }
+        if (alive.end() == alive.find(model->ID())) {
+            model->MarkAsDeletedOnServer();
+        }
+    }
+}
+
+template <typename T>
+void deleteRelatedModelsWithWorkspace(Poco::UInt64 wid,
+                                      std::vector<T *> *list) {
+    typedef typename std::vector<T *>::iterator iterator;
+    for (iterator it = list->begin(); it != list->end(); ++it) {
+        T *model = *it;
+        if (model->WID() == wid) {
+            model->MarkAsDeletedOnServer();
+        }
+    }
+}
+
+template <>
+void removeProjectFromRelatedModels(Poco::UInt64 pid,
+                                    std::vector<TimeEntry *> *list) {
+    for (auto it = list->begin(); it != list->end(); ++it) {
+        TimeEntry *model = *it;
+        if (model->PID() == pid) {
+            model->SetPID(0, true);
+        }
+    }
+}
+
+template <typename T>
+void removeProjectFromRelatedModels(Poco::UInt64 pid,
+                                    std::vector<T *> *list) {
+    for (auto it = list->begin(); it != list->end(); ++it) {
+        T *model = *it;
+        if (model->PID() == pid) {
+            model->SetPID(0);
+        }
+    }
+}
+
+
 User::~User() {
     related.Clear();
 }
@@ -178,29 +231,29 @@ TimeEntry *User::Start(
 
     TimeEntry *te = new TimeEntry();
     te->SetCreatedWith(HTTPClient::Config.UserAgent());
-    te->SetDescription(description);
+    te->SetDescription(description, false);
     te->SetUID(ID());
-    te->SetPID(project_id);
-    te->SetProjectGUID(project_guid);
-    te->SetTID(task_id);
-    te->SetTags(tags);
+    te->SetPID(project_id, false);
+    te->SetProjectGUID(project_guid, false);
+    te->SetTID(task_id, false);
+    te->SetTags(tags, false);
 
     if (started == 0 && ended == 0) {
         if (!duration.empty()) {
             int seconds = Formatter::ParseDurationString(duration);
-            te->SetDurationInSeconds(seconds);
-            te->SetStopTime(now);
-            te->SetStartTime(te->StopTime() - te->DurationInSeconds());
+            te->SetDurationInSeconds(seconds, false);
+            te->SetStopTime(now, false);
+            te->SetStartTime(te->StopTime() - te->DurationInSeconds(), false);
         } else {
-            te->SetDurationInSeconds(-now);
+            te->SetDurationInSeconds(-now, false);
             // dont set Stop, TE is running
-            te->SetStartTime(now);
+            te->SetStartTime(now, false);
         }
     } else {
         int seconds = int(ended - started);
-        te->SetDurationInSeconds(seconds);
-        te->SetStopTime(ended);
-        te->SetStartTime(started);
+        te->SetDurationInSeconds(seconds, false);
+        te->SetStopTime(ended, false);
+        te->SetStartTime(started, false);
     }
 
     // Try to set workspace ID from project
@@ -212,7 +265,7 @@ TimeEntry *User::Start(
     }
     if (p) {
         te->SetWID(p->WID());
-        te->SetBillable(p->Billable());
+        te->SetBillable(p->Billable(), false);
     }
 
     // Try to set workspace ID from task
@@ -261,22 +314,22 @@ TimeEntry *User::Continue(
       p = related.ProjectByGUID(existing->ProjectGUID());
     }
     if (p && p->Active()) {
-      result->SetPID(existing->PID());
-      result->SetProjectGUID(existing->ProjectGUID());
-      result->SetTID(existing->TID());
+      result->SetPID(existing->PID(), false);
+      result->SetProjectGUID(existing->ProjectGUID(), false);
+      result->SetTID(existing->TID(), false);
     }
 
     // Set all time entry values
     result->SetCreatedWith(HTTPClient::Config.UserAgent());
-    result->SetDescription(existing->Description());
+    result->SetDescription(existing->Description(), false);
     result->SetWID(existing->WID());
-    result->SetBillable(existing->Billable());
-    result->SetTags(existing->Tags());
+    result->SetBillable(existing->Billable(), false);
+    result->SetTags(existing->Tags(), false);
     result->SetUID(ID());
-    result->SetStartTime(now);
+    result->SetStartTime(now, false);
 
     if (!manual_mode) {
-        result->SetDurationInSeconds(-now);
+        result->SetDurationInSeconds(-now, false);
     }
 
     result->SetCreatedWith(HTTPClient::Config.UserAgent());
@@ -468,8 +521,8 @@ TimeEntry *User::DiscardTimeAt(
         TimeEntry *split = new TimeEntry();
         split->SetCreatedWith(HTTPClient::Config.UserAgent());
         split->SetUID(ID());
-        split->SetStartTime(at);
-        split->SetDurationInSeconds(-at);
+        split->SetStartTime(at, false);
+        split->SetDurationInSeconds(-at, false);
         split->SetUIModified();
         split->SetWID(te->WID());
         related.pushBackTimeEntry(split);
@@ -545,7 +598,7 @@ void User::RemoveProjectFromRelatedModels(Poco::UInt64 pid) {
 void User::RemoveTaskFromRelatedModels(Poco::UInt64 tid) {
     related.forEachTimeEntries([&](TimeEntry *model) {
         if (model->TID() == tid) {
-            model->SetTID(0);
+            model->SetTID(0, false);
         }
     });
 }
@@ -1515,48 +1568,6 @@ std::string User::ModelName() const {
 
 std::string User::ModelURL() const {
     return "/api/v9/me";
-}
-
-template<class T>
-void deleteZombies(
-    const std::vector<T> &list,
-    const std::set<Poco::UInt64> &alive) {
-    for (size_t i = 0; i < list.size(); ++i) {
-        BaseModel *model = list[i];
-        if (!model->ID()) {
-            // If model has no server-assigned ID, it's not even
-            // pushed to server. So actually we don't know if it's
-            // a zombie or not. Ignore:
-            continue;
-        }
-        if (alive.end() == alive.find(model->ID())) {
-            model->MarkAsDeletedOnServer();
-        }
-    }
-}
-
-template <typename T>
-void deleteRelatedModelsWithWorkspace(Poco::UInt64 wid,
-                                      std::vector<T *> *list) {
-    typedef typename std::vector<T *>::iterator iterator;
-    for (iterator it = list->begin(); it != list->end(); ++it) {
-        T *model = *it;
-        if (model->WID() == wid) {
-            model->MarkAsDeletedOnServer();
-        }
-    }
-}
-
-template <typename T>
-void removeProjectFromRelatedModels(Poco::UInt64 pid,
-                                    std::vector<T *> *list) {
-    typedef typename std::vector<T *>::iterator iterator;
-    for (iterator it = list->begin(); it != list->end(); ++it) {
-        T *model = *it;
-        if (model->PID() == pid) {
-            model->SetPID(0);
-        }
-    }
 }
 
 }  // namespace toggl

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -62,7 +62,7 @@ class Database {
 
 TEST(TimeEntry, TimeEntryReturnsTags) {
     TimeEntry te;
-    te.SetTags("alfa|beeta");
+    te.SetTags("alfa|beeta", false);
     ASSERT_EQ(std::string("alfa|beeta"), te.Tags());
 }
 
@@ -412,7 +412,7 @@ TEST(User, UpdatesTimeEntryFromFullUserJSON) {
     size_t n = json.find("Important things");
     ASSERT_TRUE(n);
 
-    te->SetDescription("Even more important!");
+    te->SetDescription("Even more important!", false);
 
     ASSERT_EQ(noError,
               user.LoadUserAndRelatedDataFromJSONString(json, true));
@@ -979,269 +979,269 @@ TEST(TimeEntry, ParsesDurationLikeOnTheWeb) {
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("00:23:15");
     ASSERT_EQ("0:23:15",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("12:34:56");
     ASSERT_EQ("12:34:56",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0:1");
     ASSERT_EQ("0:01:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1:2");
     ASSERT_EQ("1:02:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1:0");
     ASSERT_EQ("1:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("05:22 min");
     ASSERT_EQ("0:05:22",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("00:22 min");
     ASSERT_EQ("0:00:22",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0 hours");
     ASSERT_EQ("0:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0.5 hours");
     ASSERT_EQ("0:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0,5 hours");
     ASSERT_EQ("0:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1 hour");
     ASSERT_EQ("1:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1 hr");
     ASSERT_EQ("1:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1,5 hours");
     ASSERT_EQ("1:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1.5 hours");
     ASSERT_EQ("1:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("24 hours");
     ASSERT_EQ(86400, te.DurationInSeconds());
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0 minutes");
     ASSERT_EQ("0:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0 min");
     ASSERT_EQ("0:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("5 minutes");
     ASSERT_EQ("0:05:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("5minutes");
     ASSERT_EQ("0:05:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0,5 minutes");
     ASSERT_EQ("0:00:30",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1 minute");
     ASSERT_EQ("0:01:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1,5 minutes");
     ASSERT_EQ("0:01:30",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1.5 minutes");
     ASSERT_EQ("0:01:30",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("15");
     ASSERT_EQ("0:15:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0 seconds");
     ASSERT_EQ("0:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1 second");
     ASSERT_EQ("0:00:01",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1.5h");
     ASSERT_EQ("1:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1.5 h");
     ASSERT_EQ("1:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("3h");
     ASSERT_EQ("3:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("3 h");
     ASSERT_EQ("3:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("15m");
     ASSERT_EQ("0:15:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("15 m");
     ASSERT_EQ("0:15:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("25s");
     ASSERT_EQ("0:00:25",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("25 s");
     ASSERT_EQ("0:00:25",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1.5");
     ASSERT_EQ("1:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1,5");
     ASSERT_EQ("1:30:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0.25");
     ASSERT_EQ("0:15:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("0.025");
     ASSERT_EQ("0:01:30",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("2h45");
     ASSERT_EQ("2:45:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("2h");
     ASSERT_EQ("2:00:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("2h 18m");
     ASSERT_EQ("2:18:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("2h 18m 50s");
     ASSERT_EQ("2:18:50",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1hr 25min 30sec");
     ASSERT_EQ("1:25:30",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1 hours 25 minutes 30 seconds");
     ASSERT_EQ("1:25:30",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
                       toggl::Format::Improved));
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("1 hour 1 minute 1 second");
     ASSERT_EQ("1:01:01",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
@@ -1251,7 +1251,7 @@ TEST(TimeEntry, ParsesDurationLikeOnTheWeb) {
 TEST(TimeEntry, ParseDurationLargerThan24Hours) {
     TimeEntry te;
 
-    te.SetDurationInSeconds(0);
+    te.SetDurationInSeconds(0, false);
     te.SetDurationUserInput("90:10:00");
     ASSERT_EQ("90:10:00",
               toggl::Formatter::FormatDuration(te.DurationInSeconds(),
@@ -1262,11 +1262,11 @@ TEST(TimeEntry, InterpretsCrazyStartAndStopAsMissingValues) {
     TimeEntry te;
 
     ASSERT_EQ(Poco::UInt64(0), te.StartTime());
-    te.SetStartString("0003-03-16T-7:-19:-24Z");
+    te.SetStartString("0003-03-16T-7:-19:-24Z", false);
     ASSERT_EQ(Poco::UInt64(0), te.StartTime());
 
     ASSERT_EQ(Poco::UInt64(0), te.StopTime());
-    te.SetStopString("0003-03-16T-5:-52:-51Z");
+    te.SetStopString("0003-03-16T-5:-52:-51Z", false);
     ASSERT_EQ(Poco::UInt64(0), te.StopTime());
 }
 
@@ -1795,7 +1795,7 @@ TEST(BaseModel, BatchUpdateJSONForPut) {
     TimeEntry t;
     t.EnsureGUID();
     t.SetID(123);
-    t.SetDescription("test");
+    t.SetDescription("test", false);
     Json::Value v;
     error err = t.BatchUpdateJSON(&v);
     ASSERT_EQ(noError, err);

--- a/src/test/toggl_api_test.cc
+++ b/src/test/toggl_api_test.cc
@@ -171,10 +171,10 @@ void on_time_entry_list(
         TimeEntry te;
         te.SetGUID(to_string(it->GUID));
         te.SetID(it->ID);
-        te.SetDurationInSeconds(it->DurationInSeconds);
-        te.SetDescription(to_string(it->Description));
-        te.SetStartTime(it->Started);
-        te.SetStopTime(it->Ended);
+        te.SetDurationInSeconds(it->DurationInSeconds, false);
+        te.SetDescription(to_string(it->Description), false);
+        te.SetStartTime(it->Started, false);
+        te.SetStopTime(it->Ended, false);
         testing::testresult::time_entries.push_back(te);
         it = reinterpret_cast<TogglTimeEntryView *>(it->Next);
     }
@@ -286,17 +286,17 @@ void on_display_timer_state(TogglTimeEntryView *te) {
     testing::testresult::timer_state = TimeEntry();
     if (te) {
         testing::testresult::timer_state.SetID(te->ID);
-        testing::testresult::timer_state.SetStartTime(te->Started);
+        testing::testresult::timer_state.SetStartTime(te->Started, false);
         testing::testresult::timer_state.SetGUID(to_string(te->GUID));
         testing::testresult::timer_state.SetDurationInSeconds(
-            te->DurationInSeconds);
-        testing::testresult::timer_state.SetDescription(to_string(te->Description));
+            te->DurationInSeconds, false);
+        testing::testresult::timer_state.SetDescription(to_string(te->Description), false);
         if (te->Tags) {
-            testing::testresult::timer_state.SetTags(to_string(te->Tags));
+            testing::testresult::timer_state.SetTags(to_string(te->Tags), false);
         }
-        testing::testresult::timer_state.SetBillable(te->Billable);
-        testing::testresult::timer_state.SetPID(te->PID);
-        testing::testresult::timer_state.SetTID(te->TID);
+        testing::testresult::timer_state.SetBillable(te->Billable, false);
+        testing::testresult::timer_state.SetPID(te->PID, false);
+        testing::testresult::timer_state.SetTID(te->TID, false);
     }
 }
 

--- a/src/util/property.h
+++ b/src/util/property.h
@@ -15,6 +15,8 @@ namespace toggl {
 template <class T>
 class Property {
 public:
+    typedef T value_type;
+
     Property(const T& value) {
         current_ = value;
         previous_ = value;


### PR DESCRIPTION
### 📒 Description
After rewriting this PR a few times, I settled upon a solution that will only work for time entries (Desktop doesn't support editing clients or projects anyway) and in as simple way as possible.
This is a base implementation that I will build upon in a (hopefully final) followup. For now, it supports only pushing updates and will probably barf (and by that I mean overwrite server changes) if you try to edit something in two clients at the same time.

Notable changes in the library:
 * Some `TimeEntry` setters now take the `userModified` boolean flag to denote if the change is coming from the user or from backend.
 * Template implementations in `User` were moved to the top of the file where they belong
 * The `Property<T>` class now provides the `value_type` typedef for usage with `std::decltype`

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
When used with the sync server, pushing, pulling and updating of entities should work as expected. You can watch the sync server JSON traffic in `stderr`.

