### PR TITLE
Sync server: Per property pull / three way merge

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LIBRARY_SOURCE_FILES
     util/logger.cc
     util/random.cc
     util/rectangle.cc
+    util/json.cc
 
     database/database.cc
     database/migrations.cc

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -2135,7 +2135,17 @@ error Database::saveModel(
                           "deleted_at = :deleted_at, "
                           "updated_at = :updated_at, "
                           "project_guid = :project_guid, "
-                          "validation_error = :validation_error "
+                          "validation_error = :validation_error, "
+                          "previous_pid = :previous_pid, "
+                          "previous_project_guid = :previous_project_guid, "
+                          "previous_tid = :previous_tid, "
+                          "previous_billable = :previous_billable, "
+                          "previous_start = :previous_start, "
+                          "previous_stop = :previous_stop, "
+                          "previous_duration = :previous_duration, "
+                          "previous_description = :previous_description, "
+                          "previous_created_with = :previous_created_with, "
+                          "previous_tags = :previous_tags "
                           "where local_id = :local_id",
                           useRef(model->ID()),
                           useRef(model->UID()),
@@ -2156,6 +2166,16 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->PID.GetPrevious()),
+                          useRef(model->ProjectGUID.GetPrevious()),
+                          useRef(model->TID.GetPrevious()),
+                          useRef(model->Billable.GetPrevious()),
+                          useRef(model->StartTime.GetPrevious()),
+                          useRef(model->StopTime.GetPrevious()),
+                          useRef(model->DurationInSeconds.GetPrevious()),
+                          useRef(model->Description.GetPrevious()),
+                          useRef(model->CreatedWith.GetPrevious()),
+                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           useRef(model->LocalID()),
                           now;
             } else {
@@ -2171,7 +2191,17 @@ error Database::saveModel(
                           "deleted_at = :deleted_at, "
                           "updated_at = :updated_at, "
                           "project_guid = :project_guid, "
-                          "validation_error = :validation_error "
+                          "validation_error = :validation_error, "
+                          "previous_pid = :previous_pid, "
+                          "previous_project_guid = :previous_project_guid, "
+                          "previous_tid = :previous_tid, "
+                          "previous_billable = :previous_billable, "
+                          "previous_start = :previous_start, "
+                          "previous_stop = :previous_stop, "
+                          "previous_duration = :previous_duration, "
+                          "previous_description = :previous_description, "
+                          "previous_created_with = :previous_created_with, "
+                          "previous_tags = :previous_tags "
                           "where local_id = :local_id",
                           useRef(model->UID()),
                           useRef(model->Description()),
@@ -2191,6 +2221,16 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->PID.GetPrevious()),
+                          useRef(model->ProjectGUID.GetPrevious()),
+                          useRef(model->TID.GetPrevious()),
+                          useRef(model->Billable.GetPrevious()),
+                          useRef(model->StartTime.GetPrevious()),
+                          useRef(model->StopTime.GetPrevious()),
+                          useRef(model->DurationInSeconds.GetPrevious()),
+                          useRef(model->Description.GetPrevious()),
+                          useRef(model->CreatedWith.GetPrevious()),
+                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           useRef(model->LocalID()),
                           now;
             }
@@ -2220,13 +2260,17 @@ error Database::saveModel(
                           "duronly, ui_modified_at, "
                           "start, stop, duration, "
                           "tags, created_with, deleted_at, updated_at, "
-                          "project_guid, validation_error) "
-                          "values(:id, :uid, :description, :wid, "
+                          "project_guid, validation_error, "
+                          "previous_pid, previous_project_guid, previous_tid, previous_billable, previous_start, previous_stop, previous_duration, previous_description, previous_created_with, previous_tags"
+                          ") values ("
+                          ":id, :uid, :description, :wid, "
                           ":guid, :pid, :tid, :billable, "
                           ":duronly, :ui_modified_at, "
                           ":start, :stop, :duration, "
                           ":tags, :created_with, :deleted_at, :updated_at, "
-                          ":project_guid, :validation_error)",
+                          ":project_guid, :validation_error, "
+                          ":previous_pid, :previous_project_guid, :previous_tid, :previous_billable, :previous_start, :previous_stop, :previous_duration, :previous_description, :previous_created_with, :previous_tags "
+                          ")",
                           useRef(model->ID()),
                           useRef(model->UID()),
                           useRef(model->Description()),
@@ -2246,6 +2290,16 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->PID.GetPrevious()),
+                          useRef(model->ProjectGUID.GetPrevious()),
+                          useRef(model->TID.GetPrevious()),
+                          useRef(model->Billable.GetPrevious()),
+                          useRef(model->StartTime.GetPrevious()),
+                          useRef(model->StopTime.GetPrevious()),
+                          useRef(model->DurationInSeconds.GetPrevious()),
+                          useRef(model->Description.GetPrevious()),
+                          useRef(model->CreatedWith.GetPrevious()),
+                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           now;
             } else {
                 *session_ <<
@@ -2254,14 +2308,17 @@ error Database::saveModel(
                           "duronly, ui_modified_at, "
                           "start, stop, duration, "
                           "tags, created_with, deleted_at, updated_at, "
-                          "project_guid, validation_error "
+                          "project_guid, validation_error, "
+                          "previous_pid, previous_project_guid, previous_tid, previous_billable, previous_start, previous_stop, previous_duration, previous_description, previous_created_with, previous_tags"
                           ") values ("
                           ":uid, :description, :wid, "
                           ":guid, :pid, :tid, :billable, "
                           ":duronly, :ui_modified_at, "
                           ":start, :stop, :duration, "
                           ":tags, :created_with, :deleted_at, :updated_at, "
-                          ":project_guid, :validation_error)",
+                          ":project_guid, :validation_error, "
+                          ":previous_pid, :previous_project_guid, :previous_tid, :previous_billable, :previous_start, :previous_stop, :previous_duration, :previous_description, :previous_created_with, :previous_tags "
+                          ")",
                           useRef(model->UID()),
                           useRef(model->Description()),
                           useRef(model->WID()),
@@ -2280,6 +2337,16 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->PID.GetPrevious()),
+                          useRef(model->ProjectGUID.GetPrevious()),
+                          useRef(model->TID.GetPrevious()),
+                          useRef(model->Billable.GetPrevious()),
+                          useRef(model->StartTime.GetPrevious()),
+                          useRef(model->StopTime.GetPrevious()),
+                          useRef(model->DurationInSeconds.GetPrevious()),
+                          useRef(model->Description.GetPrevious()),
+                          useRef(model->CreatedWith.GetPrevious()),
+                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           now;
             }
             error err = last_error("saveTimeEntry");

--- a/src/database/migrations.cc
+++ b/src/database/migrations.cc
@@ -815,6 +815,43 @@ error Migrations::migrateTimeEntries() {
         return err;
     }
 
+    err = db_->Migrate(
+        "time_entries.sync_spec",
+
+        "ALTER TABLE time_entries ADD COLUMN previous_pid integer;"
+        "UPDATE time_entries SET previous_pid = pid;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_project_guid integer;"
+        "UPDATE time_entries SET previous_project_guid = project_guid;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_tid integer;"
+        "UPDATE time_entries SET previous_tid = tid;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_billable integer;"
+        "UPDATE time_entries SET previous_billable = billable;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_start integer;"
+        "UPDATE time_entries SET previous_start = start;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_stop integer;"
+        "UPDATE time_entries SET previous_stop = stop;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_duration integer;"
+        "UPDATE time_entries SET previous_duration = duration;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_description varchar;"
+        "UPDATE time_entries SET previous_description = description;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_created_with varchar;"
+        "UPDATE time_entries SET previous_created_with = created_with;"
+
+        "ALTER TABLE time_entries ADD COLUMN previous_tags text;"
+        "UPDATE time_entries SET previous_tags = tags;"
+        );
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		74AA947A18091AE10000539F /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74AA947918091AE10000539F /* WebKit.framework */; };
 		74CAAD0318185A9B001B77BB /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74CAAD0218185A9B001B77BB /* Carbon.framework */; };
+		B890837624AE388100E40C38 /* json.cc in Sources */ = {isa = PBXBuildFile; fileRef = B890837324AE388100E40C38 /* json.cc */; };
+		B890837724AE388100E40C38 /* property.h in Headers */ = {isa = PBXBuildFile; fileRef = B890837424AE388100E40C38 /* property.h */; };
+		B890837824AE388100E40C38 /* json.h in Headers */ = {isa = PBXBuildFile; fileRef = B890837524AE388100E40C38 /* json.h */; };
 		B8B6EC65244616B10008FA32 /* netconf.h in Headers */ = {isa = PBXBuildFile; fileRef = B8B6EC35244616AE0008FA32 /* netconf.h */; };
 		B8B6EC66244616B10008FA32 /* timeline_notifications.h in Headers */ = {isa = PBXBuildFile; fileRef = B8B6EC36244616AE0008FA32 /* timeline_notifications.h */; };
 		B8B6EC67244616B10008FA32 /* timeline_uploader.h in Headers */ = {isa = PBXBuildFile; fileRef = B8B6EC37244616AE0008FA32 /* timeline_uploader.h */; };
@@ -100,11 +103,11 @@
 		BA43B33323F680B00007DD99 /* libPocoNetSSL.60.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BA43B32423F680B00007DD99 /* libPocoNetSSL.60.dylib */; };
 		BA43B33523F680B00007DD99 /* libPocoUtil.60.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BA43B32523F680B00007DD99 /* libPocoUtil.60.dylib */; };
 		BA43B33723F680B00007DD99 /* libPocoXML.60.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BA43B32623F680B00007DD99 /* libPocoXML.60.dylib */; };
-		BAA2C31B2477AF23005FBBE9 /* color_convert.cc in Sources */ = {isa = PBXBuildFile; fileRef = BAA2C3192477AF23005FBBE9 /* color_convert.cc */; };
-		BAA2C31C2477AF23005FBBE9 /* color_convert.h in Headers */ = {isa = PBXBuildFile; fileRef = BAA2C31A2477AF23005FBBE9 /* color_convert.h */; };
 		BA71F4F6246D242900DB2D97 /* onboarding_service.h in Headers */ = {isa = PBXBuildFile; fileRef = BA71F4F4246D242800DB2D97 /* onboarding_service.h */; };
 		BA71F4F7246D242900DB2D97 /* onboarding_service.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BA71F4F5246D242900DB2D97 /* onboarding_service.cpp */; };
 		BA71F4FA246D255500DB2D97 /* cpptime.h in Headers */ = {isa = PBXBuildFile; fileRef = BA71F4F9246D255500DB2D97 /* cpptime.h */; };
+		BAA2C31B2477AF23005FBBE9 /* color_convert.cc in Sources */ = {isa = PBXBuildFile; fileRef = BAA2C3192477AF23005FBBE9 /* color_convert.cc */; };
+		BAA2C31C2477AF23005FBBE9 /* color_convert.h in Headers */ = {isa = PBXBuildFile; fileRef = BAA2C31A2477AF23005FBBE9 /* color_convert.h */; };
 		BAA842252403D99800BCCB67 /* libPocoCrypto.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA43B31E23F680B00007DD99 /* libPocoCrypto.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BAA842262403D99800BCCB67 /* libPocoData.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA43B31F23F680B00007DD99 /* libPocoData.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BAA842272403D99800BCCB67 /* libPocoDataSQLite.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA43B32023F680B00007DD99 /* libPocoDataSQLite.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -146,6 +149,9 @@
 /* Begin PBXFileReference section */
 		74AA947918091AE10000539F /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		74CAAD0218185A9B001B77BB /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
+		B890837324AE388100E40C38 /* json.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = json.cc; sourceTree = "<group>"; };
+		B890837424AE388100E40C38 /* property.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = property.h; sourceTree = "<group>"; };
+		B890837524AE388100E40C38 /* json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json.h; sourceTree = "<group>"; };
 		B8B6EC35244616AE0008FA32 /* netconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = netconf.h; sourceTree = "<group>"; };
 		B8B6EC36244616AE0008FA32 /* timeline_notifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timeline_notifications.h; sourceTree = "<group>"; };
 		B8B6EC37244616AE0008FA32 /* timeline_uploader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timeline_uploader.h; sourceTree = "<group>"; };
@@ -240,11 +246,11 @@
 		BA43B34B23F681CF0007DD99 /* libcrypto.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcrypto.a; path = ../../ui/osx/TogglDesktop/Library/openssl/libcrypto.a; sourceTree = "<group>"; };
 		BA43B34C23F681CF0007DD99 /* libssl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libssl.a; path = ../../ui/osx/TogglDesktop/Library/openssl/libssl.a; sourceTree = "<group>"; };
 		BA43B34F23F681D60007DD99 /* liblua.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liblua.a; path = ../../ui/osx/TogglDesktop/Library/lua/liblua.a; sourceTree = "<group>"; };
-		BAA2C3192477AF23005FBBE9 /* color_convert.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = color_convert.cc; sourceTree = "<group>"; };
-		BAA2C31A2477AF23005FBBE9 /* color_convert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = color_convert.h; sourceTree = "<group>"; };
 		BA71F4F4246D242800DB2D97 /* onboarding_service.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onboarding_service.h; sourceTree = "<group>"; };
 		BA71F4F5246D242900DB2D97 /* onboarding_service.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = onboarding_service.cpp; sourceTree = "<group>"; };
 		BA71F4F9246D255500DB2D97 /* cpptime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpptime.h; sourceTree = "<group>"; };
+		BAA2C3192477AF23005FBBE9 /* color_convert.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = color_convert.cc; sourceTree = "<group>"; };
+		BAA2C31A2477AF23005FBBE9 /* color_convert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = color_convert.h; sourceTree = "<group>"; };
 		BAA8422E2403DAE000BCCB67 /* libcrypto.1.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcrypto.1.1.dylib; path = ../../ui/osx/TogglDesktop/Library/openssl/libcrypto.1.1.dylib; sourceTree = "<group>"; };
 		BAA8422F2403DAE000BCCB67 /* libssl.1.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libssl.1.1.dylib; path = ../../ui/osx/TogglDesktop/Library/openssl/libssl.1.1.dylib; sourceTree = "<group>"; };
 		BAD233DA21D60A4D0039C742 /* libPocoNet.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoNet.dylib; path = ../../../third_party/poco/lib/Darwin/x86_64/libPocoNet.dylib; sourceTree = "<group>"; };
@@ -289,6 +295,9 @@
 		B8B6EC34244616040008FA32 /* util */ = {
 			isa = PBXGroup;
 			children = (
+				B890837324AE388100E40C38 /* json.cc */,
+				B890837524AE388100E40C38 /* json.h */,
+				B890837424AE388100E40C38 /* property.h */,
 				B8B6ECCE2446170C0008FA32 /* custom_error_handler.cc */,
 				B8B6ECC82446170C0008FA32 /* custom_error_handler.h */,
 				B8B6ECCA2446170C0008FA32 /* formatter.cc */,
@@ -486,6 +495,7 @@
 				B8B6ECE12446173A0008FA32 /* migrations.h in Headers */,
 				B8B6ECAE244617000008FA32 /* project.h in Headers */,
 				B8B6ECBC244617000008FA32 /* autotracker.h in Headers */,
+				B890837824AE388100E40C38 /* json.h in Headers */,
 				B8B6EC87244616B10008FA32 /* related_data.h in Headers */,
 				B8B6ECD02446170C0008FA32 /* logger.h in Headers */,
 				B8B6ECB8244617000008FA32 /* user.h in Headers */,
@@ -525,6 +535,7 @@
 				BA71F4F6246D242900DB2D97 /* onboarding_service.h in Headers */,
 				B8B6EC88244616B10008FA32 /* error.h in Headers */,
 				B8B6EC8D244616B10008FA32 /* const.h in Headers */,
+				B890837724AE388100E40C38 /* property.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -632,6 +643,7 @@
 				B8B6ECBB244617000008FA32 /* workspace.cc in Sources */,
 				B8B6EC84244616B10008FA32 /* timeline_uploader.cc in Sources */,
 				B8B6EC75244616B10008FA32 /* websocket_client.cc in Sources */,
+				B890837624AE388100E40C38 /* json.cc in Sources */,
 				B8B6ECDF2446173A0008FA32 /* database.cc in Sources */,
 				B8B6ECC0244617000008FA32 /* task.cc in Sources */,
 				B8B6ECB0244617000008FA32 /* obm_action.cc in Sources */,

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -455,6 +455,7 @@
     <ClInclude Include="..\..\..\database\migrations.h" />
     <ClInclude Include="..\..\..\netconf.h" />
     <ClInclude Include="..\..\..\model\obm_action.h" />
+    <ClInclude Include="..\..\..\util\json.h" />
     <ClInclude Include="..\..\..\util\property.h" />
     <ClInclude Include="..\..\..\util\random.h" />
     <ClInclude Include="..\..\..\util\rectangle.h" />
@@ -501,6 +502,7 @@
     <ClCompile Include="..\..\..\database\migrations.cc" />
     <ClCompile Include="..\..\..\netconf.cc" />
     <ClCompile Include="..\..\..\model\obm_action.cc" />
+    <ClCompile Include="..\..\..\util\json.cc" />
     <ClCompile Include="..\..\..\util\random.cc" />
     <ClCompile Include="..\..\..\util\rectangle.cc" />
     <ClCompile Include="..\..\..\model\settings.cc" />

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
@@ -168,6 +168,9 @@
     <ClInclude Include="..\..\..\util\property.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\util\json.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -298,6 +301,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\color_convert.cc">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\util\json.cc">
+      <Filter>Source Files\util</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -78,16 +78,6 @@ void BaseModel::MarkAsDeletedOnServer() {
         SetDirty();
 }
 
-error BaseModel::LoadFromDataString(const std::string &data_string) {
-    Json::Value root;
-    Json::Reader reader;
-    if (!reader.parse(data_string, root)) {
-        return error("Failed to parse data string");
-    }
-    LoadFromJSON(root["data"]);
-    return noError;
-}
-
 void BaseModel::Delete() {
     SetDeletedAt(time(nullptr));
     SetUIModified();

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -93,7 +93,6 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual std::string ModelName() const = 0;
     virtual std::string ModelURL() const = 0;
 
-    virtual void LoadFromJSON(Json::Value value) {}
     virtual Json::Value SaveToJSON(int apiVersion = 8) const {
         return 0;
     }
@@ -110,8 +109,6 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
     virtual bool ResolveError(const toggl::error &err) {
         return false;
     }
-
-    error LoadFromDataString(const std::string &);
 
     void Delete();
 

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -14,6 +14,7 @@
 #include "types.h"
 #include "util/logger.h"
 #include "util/property.h"
+#include "util/json.h"
 
 #include <Poco/Types.h>
 

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -41,7 +41,7 @@ void Client::SetWID(Poco::UInt64 value) {
         SetDirty();
 }
 
-void Client::LoadFromJSON(Json::Value data) {
+void Client::LoadFromJSON(const Json::Value &data) {
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
     if (data.isMember("wid"))

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -41,7 +41,7 @@ void Client::SetWID(Poco::UInt64 value) {
         SetDirty();
 }
 
-void Client::LoadFromJSON(const Json::Value &data) {
+void Client::LoadFromJSON(const Json::Value &data, bool) {
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
     if (data.isMember("wid"))

--- a/src/model/client.h
+++ b/src/model/client.h
@@ -29,7 +29,7 @@ class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    void LoadFromJSON(const Json::Value &value);
+    void LoadFromJSON(const Json::Value &value, bool);
     Json::Value SaveToJSON(int apiVersion = 8) const override;
     Json::Value SyncMetadata() const override;
     Json::Value SyncPayload() const override;

--- a/src/model/client.h
+++ b/src/model/client.h
@@ -29,7 +29,7 @@ class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    void LoadFromJSON(Json::Value value) override;
+    void LoadFromJSON(const Json::Value &value);
     Json::Value SaveToJSON(int apiVersion = 8) const override;
     Json::Value SyncMetadata() const override;
     Json::Value SyncPayload() const override;

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -106,7 +106,7 @@ void Project::SetClientName(const std::string &value) {
         SetDirty();
 }
 
-void Project::LoadFromJSON(const Json::Value &data) {
+void Project::LoadFromJSON(const Json::Value &data, bool) {
     if (data.isMember("hex_color")) {
         SetColor(data["hex_color"].asString());
     } else {

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -106,7 +106,7 @@ void Project::SetClientName(const std::string &value) {
         SetDirty();
 }
 
-void Project::LoadFromJSON(Json::Value data) {
+void Project::LoadFromJSON(const Json::Value &data) {
     if (data.isMember("hex_color")) {
         SetColor(data["hex_color"].asString());
     } else {

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -46,7 +46,7 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    void LoadFromJSON(Json::Value value) override;
+    void LoadFromJSON(const Json::Value &value);
     Json::Value SaveToJSON(int apiVersion = 8) const override;
     Json::Value SyncMetadata() const override;
     Json::Value SyncPayload() const override;

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -46,7 +46,7 @@ class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    void LoadFromJSON(const Json::Value &value);
+    void LoadFromJSON(const Json::Value &value, bool);
     Json::Value SaveToJSON(int apiVersion = 8) const override;
     Json::Value SyncMetadata() const override;
     Json::Value SyncPayload() const override;

--- a/src/model/tag.cc
+++ b/src/model/tag.cc
@@ -28,7 +28,7 @@ void Tag::SetName(const std::string &value) {
         SetDirty();
 }
 
-void Tag::LoadFromJSON(Json::Value data) {
+void Tag::LoadFromJSON(const Json::Value &data) {
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
     if (data.isMember("wid"))

--- a/src/model/tag.h
+++ b/src/model/tag.h
@@ -25,7 +25,7 @@ class TOGGL_INTERNAL_EXPORT Tag : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    void LoadFromJSON(Json::Value data) override;
+    void LoadFromJSON(const Json::Value &data);
 };
 
 }  // namespace toggl

--- a/src/model/task.cc
+++ b/src/model/task.cc
@@ -36,7 +36,7 @@ void Task::SetActive(bool value) {
         SetDirty();
 }
 
-void Task::LoadFromJSON(Json::Value data) {
+void Task::LoadFromJSON(const Json::Value &data) {
     SetID(data["id"].asUInt64());
     SetName(data["name"].asString());
     if (data.isMember("pid"))

--- a/src/model/task.h
+++ b/src/model/task.h
@@ -31,7 +31,7 @@ class TOGGL_INTERNAL_EXPORT Task : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    void LoadFromJSON(Json::Value value) override;
+    void LoadFromJSON(const Json::Value &value);
 };
 
 }  // namespace toggl

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -346,7 +346,8 @@ std::vector<std::string> TimeEntry::TagsStringToVector(const std::string &str) {
         while (ss.good()) {
             std::string tag;
             getline(ss, tag, kTagSeparator);
-            tmp.push_back(tag);
+            if (!tag.empty())
+                tmp.push_back(tag);
         }
     }
     return tmp;

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -322,8 +322,8 @@ void TimeEntry::SetProjectGUID(const std::string &value, bool userModified) {
         SetDirty();
 }
 
-const std::string TimeEntry::Tags() const {
-    return std::string(TagsVectorToString(TagNames()));
+const std::string &TimeEntry::Tags() const {
+    return TagsVectorToString(TagNames());
 }
 
 const std::string TimeEntry::TagsHash() const {
@@ -354,14 +354,12 @@ std::vector<std::string> TimeEntry::TagsStringToVector(const std::string &str) {
 
 const std::string &TimeEntry::TagsVectorToString(const std::vector<std::string> &vec) {
     static thread_local std::string cache;
-    std::stringstream ss;
     for (auto it = vec.begin(); it != vec.end(); ++it) {
         if (it != vec.begin()) {
-            ss << kTagSeparator;
+            cache += kTagSeparator;
         }
-        ss << *it;
+        cache += *it;
     }
-    cache = ss.str();
     return cache;
 }
 

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -395,7 +395,7 @@ bool TimeEntry::IsToday() const {
            today.day() == datetime.day();
 }
 
-void TimeEntry::LoadFromJSON(Json::Value data) {
+void TimeEntry::LoadFromJSON(const Json::Value &data) {
     // No ui_modified_at in server responses.
     // Compare updated_at with ui_modified_at to see if ui has been changed
     Json::Value at = data["at"];

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -346,6 +346,19 @@ const std::string TimeEntry::TagsHash() const {
     return ss.str();
 }
 
+std::vector<std::string> TimeEntry::TagsStringToVector(const std::string &str) {
+    std::vector<std::string> tmp;
+    if (!str.empty()) {
+        std::stringstream ss(str);
+        while (ss.good()) {
+            std::string tag;
+            getline(ss, tag, kTagSeparator);
+            tmp.push_back(tag);
+        }
+    }
+    return tmp;
+}
+
 std::string TimeEntry::StopString() const {
     return Formatter::Format8601(StopTime());
 }

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -323,14 +323,7 @@ void TimeEntry::SetProjectGUID(const std::string &value, bool userModified) {
 }
 
 const std::string TimeEntry::Tags() const {
-    std::stringstream ss;
-    for (auto it = TagNames->begin(); it != TagNames->end(); ++it) {
-        if (it != TagNames->begin()) {
-            ss << kTagSeparator;
-        }
-        ss << *it;
-    }
-    return ss.str();
+    return std::string(TagsVectorToString(TagNames()));
 }
 
 const std::string TimeEntry::TagsHash() const {
@@ -357,6 +350,19 @@ std::vector<std::string> TimeEntry::TagsStringToVector(const std::string &str) {
         }
     }
     return tmp;
+}
+
+const std::string &TimeEntry::TagsVectorToString(const std::vector<std::string> &vec) {
+    static thread_local std::string cache;
+    std::stringstream ss;
+    for (auto it = vec.begin(); it != vec.end(); ++it) {
+        if (it != vec.begin()) {
+            ss << kTagSeparator;
+        }
+        ss << *it;
+    }
+    cache = ss.str();
+    return cache;
 }
 
 std::string TimeEntry::StopString() const {

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -354,6 +354,7 @@ std::vector<std::string> TimeEntry::TagsStringToVector(const std::string &str) {
 
 const std::string &TimeEntry::TagsVectorToString(const std::vector<std::string> &vec) {
     static thread_local std::string cache;
+    cache.clear();
     for (auto it = vec.begin(); it != vec.end(); ++it) {
         if (it != vec.begin()) {
             cache += kTagSeparator;

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -395,7 +395,7 @@ bool TimeEntry::IsToday() const {
            today.day() == datetime.day();
 }
 
-void TimeEntry::LoadFromJSON(const Json::Value &data) {
+void TimeEntry::LoadFromJSON(const Json::Value &data, bool syncServer) {
     // No ui_modified_at in server responses.
     // Compare updated_at with ui_modified_at to see if ui has been changed
     Json::Value at = data["at"];

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -41,6 +41,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     const std::string Tags() const;
     void SetTags(const std::string &tags, bool userModified);
     const std::string TagsHash() const;
+    static std::vector<std::string> TagsStringToVector(const std::string &str);
 
     void SetWID(Poco::UInt64 value);
     void SetPID(Poco::UInt64 value, bool userModified);

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -38,7 +38,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     void SetCreatedWith(const std::string &value);
     void SetProjectGUID(const std::string &value, bool userModified);
 
-    const std::string Tags() const;
+    const std::string &Tags() const;
     void SetTags(const std::string &tags, bool userModified);
     const std::string TagsHash() const;
 

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -90,7 +90,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string ModelURL() const override;
     std::string String() const override;
     virtual bool ResolveError(const error &err) override;
-    void LoadFromJSON(const Json::Value &value);
+    void LoadFromJSON(const Json::Value &value, bool syncServer);
     Json::Value SaveToJSON(int apiVersion = 8) const override;
     Json::Value SyncMetadata() const override;
     Json::Value SyncPayload() const override;

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -41,7 +41,9 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     const std::string Tags() const;
     void SetTags(const std::string &tags, bool userModified);
     const std::string TagsHash() const;
+
     static std::vector<std::string> TagsStringToVector(const std::string &str);
+    static const std::string &TagsVectorToString(const std::vector<std::string> &vec);
 
     void SetWID(Poco::UInt64 value);
     void SetPID(Poco::UInt64 value, bool userModified);

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -90,7 +90,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     std::string ModelURL() const override;
     std::string String() const override;
     virtual bool ResolveError(const error &err) override;
-    void LoadFromJSON(Json::Value value) override;
+    void LoadFromJSON(const Json::Value &value);
     Json::Value SaveToJSON(int apiVersion = 8) const override;
     Json::Value SyncMetadata() const override;
     Json::Value SyncPayload() const override;

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -863,12 +863,15 @@ void User::LoadUserAndRelatedDataFromJSON(
 
 error User::loadUserFromJSON(const Json::Value &data) {
 
-    if (!data["id"].asUInt64()) {
+    if (!data["id"].asUInt64() && !data["user_id"].asUInt64()) {
         logger().error("Backend is sending invalid data: ignoring update without an ID");
         return kBackendIsSendingInvalidData;
     }
 
-    SetID(data["id"].asUInt64());
+    if (data["id"].asUInt64())
+        SetID(data["id"].asUInt64());
+    else
+        SetID(data["user_id"].asUInt64());
     SetDefaultWID(data["default_wid"].asUInt64());
     SetAPIToken(data["api_token"].asString());
     SetEmail(data["email"].asString());

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -138,13 +138,12 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     error LoadUserUpdateFromJSONString(const std::string &json);
 
-    error LoadUserAndRelatedDataFromJSONString(
-        const std::string &json,
-        bool including_related_data);
+    error LoadUserAndRelatedDataFromJSONString(const std::string &json,
+        bool including_related_data, bool syncServer);
 
-    void LoadUserAndRelatedDataFromJSON(
-        const Json::Value &root,
-        bool including_related_data);
+    void LoadUserAndRelatedDataFromJSON(const Json::Value &root,
+        bool including_related_data,
+        bool syncServer);
 
     error LoadWorkspacesFromJSONString(const std::string & json);
 
@@ -216,20 +215,22 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     error loadUserFromJSON(
         const Json::Value &node);
 
-    error loadRelatedDataFromJSON(
-        const Json::Value &node,
-        bool including_related_data);
+    error loadRelatedDataFromJSON(const Json::Value &node,
+        bool including_related_data,
+        bool syncServer);
 
     void loadUserUpdateFromJSON(
         Json::Value list);
 
     void loadUserProjectFromJSON(
         Json::Value data,
-        std::set<Poco::UInt64> *alive = nullptr);
+        std::set<Poco::UInt64> *alive = nullptr,
+        bool syncServer = false);
 
     void loadUserProjectFromSyncJSON(
         Json::Value data,
-        std::set<Poco::UInt64> *alive = nullptr);
+        std::set<Poco::UInt64> *alive = nullptr,
+        bool syncServer = false);
 
     void loadUserWorkspaceFromJSON(
         Json::Value data,
@@ -237,11 +238,13 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     void loadUserClientFromJSON(
         Json::Value data,
-        std::set<Poco::UInt64> *alive = nullptr);
+        std::set<Poco::UInt64> *alive = nullptr,
+        bool syncServer = false);
 
     void loadUserClientFromSyncJSON(
         Json::Value data,
-        std::set<Poco::UInt64> *alive = nullptr);
+        std::set<Poco::UInt64> *alive = nullptr,
+        bool syncServer = false);
 
     void loadUserTaskFromJSON(
         Json::Value data,
@@ -249,7 +252,8 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     void loadUserTimeEntryFromJSON(
         Json::Value data,
-        std::set<Poco::UInt64> *alive = nullptr);
+        std::set<Poco::UInt64> *alive = nullptr,
+        bool syncServer = false);
 
     std::string dirtyObjectsJSON(std::vector<TimeEntry *> * const) const;
 

--- a/src/model/workspace.cc
+++ b/src/model/workspace.cc
@@ -50,7 +50,7 @@ void Workspace::SetLockedTime(time_t value) {
         SetDirty();
 }
 
-void Workspace::LoadFromJSON(Json::Value n) {
+void Workspace::LoadFromJSON(const Json::Value &n) {
     SetID(n["id"].asUInt64());
     SetName(n["name"].asString());
     SetPremium(n["premium"].asBool());

--- a/src/model/workspace.h
+++ b/src/model/workspace.h
@@ -35,7 +35,7 @@ class TOGGL_INTERNAL_EXPORT Workspace : public BaseModel {
     std::string String() const override;
     std::string ModelName() const override;
     std::string ModelURL() const override;
-    void LoadFromJSON(Json::Value value) override;
+    void LoadFromJSON(const Json::Value &value);
 
     void LoadSettingsFromJson(Json::Value value);
 };

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -92,6 +92,28 @@ TEST(TimeEntry, SetDurationUserInput) {
     ASSERT_TRUE(te.UIModifiedAt());
 }
 
+TEST(TimeEntry, TagSplitter) {
+    std::vector<std::string> expectedSplit {
+        "a",
+        "b",
+        "c"
+    };
+    std::string expectedJoined {
+        "a" "\t"
+        "b" "\t"
+        "c"
+    };
+    auto split = toggl::TimeEntry::TagsStringToVector(expectedJoined);
+    auto joined = toggl::TimeEntry::TagsVectorToString(expectedSplit);
+    auto joinedsplit = toggl::TimeEntry::TagsVectorToString(split);
+    auto splitjoined = toggl::TimeEntry::TagsStringToVector(joined);
+
+    ASSERT_EQ(expectedSplit, split);
+    ASSERT_EQ(expectedSplit, splitjoined);
+    ASSERT_EQ(expectedJoined, joined);
+    ASSERT_EQ(expectedJoined, joinedsplit);
+}
+
 TEST(Project, ProjectsHaveColorCodes) {
     Project p;
     p.SetColor("1");

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -115,7 +115,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
     Poco::UInt64 user_id = user.ID();
 
     std::vector<ModelChange> changes;
@@ -309,20 +309,20 @@ TEST(User, Since) {
 TEST(User, UpdatesTimeEntryFromJSON) {
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     TimeEntry *te = user.related.TimeEntryByID(89818605);
     ASSERT_TRUE(te);
 
     std::string json = "{\"id\":89818605,\"description\":\"Changed\"}";
-    te->LoadFromJSON(jsonStringToValue(json));
+    te->LoadFromJSON(jsonStringToValue(json), false);
     ASSERT_EQ("Changed", te->Description());
 }
 
 TEST(User, DeletesZombies) {
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     TimeEntry *te = user.related.TimeEntryByID(89818605);
     ASSERT_TRUE(te);
@@ -332,7 +332,7 @@ TEST(User, DeletesZombies) {
         loadTestDataFile(std::string("../testdata/me_without_time_entries.json"));
 
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(json, true));
+              user.LoadUserAndRelatedDataFromJSONString(json, true, false));
 
     te = user.related.TimeEntryByID(89818605);
     ASSERT_TRUE(te);
@@ -344,7 +344,7 @@ TEST(Database, LoadUserByEmail) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     std::vector<ModelChange> changes;
     ASSERT_EQ(noError, db.instance()->SaveUser(&user, true, &changes));
@@ -375,7 +375,7 @@ TEST(Database, AllowsSameEmail) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     std::vector<ModelChange> changes;
     ASSERT_EQ(noError, db.instance()->SaveUser(&user, true, &changes));
@@ -383,7 +383,7 @@ TEST(Database, AllowsSameEmail) {
     User user2;
     std::string json = loadTestDataFile(std::string("../testdata/same_email.json"));
     ASSERT_EQ(noError,
-              user2.LoadUserAndRelatedDataFromJSONString(json, true));
+              user2.LoadUserAndRelatedDataFromJSONString(json, true, false));
 
     ASSERT_EQ(noError, db.instance()->SaveUser(&user2, true, &changes));
 
@@ -404,7 +404,7 @@ TEST(User, UpdatesTimeEntryFromFullUserJSON) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     TimeEntry *te = user.related.TimeEntryByID(89818605);
     ASSERT_TRUE(te);
@@ -415,7 +415,7 @@ TEST(User, UpdatesTimeEntryFromFullUserJSON) {
     te->SetDescription("Even more important!", false);
 
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(json, true));
+              user.LoadUserAndRelatedDataFromJSONString(json, true, false));
     te = user.related.TimeEntryByID(89818605);
     ASSERT_TRUE(te);
     ASSERT_EQ("Even more important!", te->Description());
@@ -426,7 +426,7 @@ TEST(Database, SavesAndLoadsUserFields) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     ASSERT_TRUE(user.StoreStartAndStopTime());
     // Change fields
@@ -455,7 +455,7 @@ TEST(Database, SavesAndLoadsObmExperiments) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     std::string json = loadTestDataFile(std::string("../testdata/obm_response.json"));
     Json::Value data = jsonStringToValue(json);
@@ -487,7 +487,7 @@ TEST(Database, SavesAndLoadsObmExperimentsArray) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     std::string json = loadTestDataFile(std::string("../testdata/obm_response_array.json"));
     Json::Value data = jsonStringToValue(json);
@@ -520,7 +520,7 @@ TEST(Database, SavesModelsAndKnowsToUpdateWithSameUserInstance) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     Poco::UInt64 n;
     ASSERT_EQ(noError, db.instance()->UInt("select count(1) from users", &n));
@@ -569,7 +569,7 @@ TEST(Database,
 
     User user1;
     ASSERT_EQ(noError,
-              user1.LoadUserAndRelatedDataFromJSONString(json, true));
+              user1.LoadUserAndRelatedDataFromJSONString(json, true, false));
 
     std::vector<ModelChange> changes;
     ASSERT_EQ(noError, db.instance()->SaveUser(&user1, true, &changes));
@@ -619,7 +619,7 @@ TEST(Database,
               user2.related.TimeEntries.size());
 
     ASSERT_EQ(noError,
-              user2.LoadUserAndRelatedDataFromJSONString(json, true));
+              user2.LoadUserAndRelatedDataFromJSONString(json, true, false));
 
     ASSERT_EQ(noError, db.instance()->SaveUser(&user2, true, &changes));
 
@@ -654,7 +654,7 @@ TEST(User, TestStartTimeEntryWithDuration) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     size_t count = user.related.TimeEntries.size();
 
@@ -672,7 +672,7 @@ TEST(User, TestStartTimeEntryWithoutDuration) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     user.Start("Old work", "", 0, 0, "", "", 0, 0, true);
 
@@ -686,7 +686,7 @@ TEST(User, TestDeletionSteps) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     // first, mark time entry as deleted
     user.Start("My new time entry", "", 0, 0, "", "", 0, 0, true);
@@ -720,7 +720,7 @@ TEST(User, TestDeletionSteps) {
 TEST(Database, SavesModels) {
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     testing::Database db;
 
@@ -736,7 +736,7 @@ TEST(Database, AssignsGUID) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(json, true));
+              user.LoadUserAndRelatedDataFromJSONString(json, true, false));
 
     ASSERT_EQ(uint(5), user.related.TimeEntries.size());
     TimeEntry *te = user.related.TimeEntryByID(89837445);
@@ -758,7 +758,7 @@ TEST(User, ParsesAndSavesData) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(json, true));
+              user.LoadUserAndRelatedDataFromJSONString(json, true, false));
     ASSERT_EQ(Poco::UInt64(1379068550), user.Since());
     ASSERT_EQ(Poco::UInt64(10471231), user.ID());
     ASSERT_EQ(Poco::UInt64(123456788), user.DefaultWID());
@@ -1275,7 +1275,7 @@ TEST(User, Continue) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true));
+              user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
     TimeEntry *te = user.related.TimeEntryByID(89818605);
     ASSERT_TRUE(te);
@@ -1291,7 +1291,7 @@ TEST(TimeEntry, SetDurationOnRunningTimeEntryWithDurOnlySetting) {
 
     User user;
     ASSERT_EQ(noError,
-              user.LoadUserAndRelatedDataFromJSONString(json, true));
+              user.LoadUserAndRelatedDataFromJSONString(json, true, false));
 
     TimeEntry *te = user.related.TimeEntryByID(164891639);
     ASSERT_TRUE(te);
@@ -1652,14 +1652,14 @@ TEST(JSON, Project) {
     std::string json("{\"id\":2598323,\"guid\":\"2f0b8f11-f898-d992-3e1a-6bc261fc41ef\",\"wid\":123456789,\"name\":\"A deleted project\",\"billable\":true,\"is_private\":false,\"active\":false,\"template\":false,\"at\":\"2013-05-13T10:19:24+00:00\",\"color\":\"21\",\"auto_estimates\":true,\"server_deleted_at\":\"2013-08-22T09:05:31+00:00\"}");  // NOLINT
 
     Project p;
-    p.LoadFromJSON(jsonStringToValue(json));
+    p.LoadFromJSON(jsonStringToValue(json), false);
     ASSERT_EQ(Poco::UInt64(2598323), p.ID());
     ASSERT_EQ("A deleted project", p.Name());
     ASSERT_EQ(Poco::UInt64(123456789), p.WID());
     //ASSERT_EQ("2f0b8f11-f898-d992-3e1a-6bc261fc41ef", p.GUID());
 
     Project p2;
-    p2.LoadFromJSON(p.SaveToJSON());
+    p2.LoadFromJSON(p.SaveToJSON(), false);
     ASSERT_EQ(p.ID(), p2.ID());
     ASSERT_EQ(p.Name(), p2.Name());
     ASSERT_EQ(p.WID(), p2.WID());
@@ -1674,14 +1674,14 @@ TEST(JSON, Client) {
     std::string json("{\"id\":878318,\"guid\":\"59b464cd-0f8e-e601-ff44-f135225a6738\",\"wid\":123456789,\"name\":\"Big Client\",\"at\":\"2013-03-27T13:17:18+00:00\"}");  // NOLINT
 
     Client c;
-    c.LoadFromJSON(jsonStringToValue(json));
+    c.LoadFromJSON(jsonStringToValue(json), false);
     ASSERT_EQ(Poco::UInt64(878318), c.ID());
     ASSERT_EQ("Big Client", c.Name());
     ASSERT_EQ(Poco::UInt64(123456789), c.WID());
     //ASSERT_EQ("59b464cd-0f8e-e601-ff44-f135225a6738", c.GUID());
 
     Client c2;
-    c2.LoadFromJSON(c.SaveToJSON());
+    c2.LoadFromJSON(c.SaveToJSON(), false);
     ASSERT_EQ(c.ID(), c2.ID());
     ASSERT_EQ(c.Name(), c2.Name());
     ASSERT_EQ(c.WID(), c2.WID());
@@ -1692,7 +1692,7 @@ TEST(JSON, TimeEntry) {
     std::string json("{\"id\":89818612,\"guid\":\"07fba193-91c4-0ec8-2345-820df0548123\",\"wid\":123456789,\"pid\":2567324,\"billable\":true,\"start\":\"2013-09-05T06:33:50+00:00\",\"stop\":\"2013-09-05T08:19:46+00:00\",\"duration\":6356,\"description\":\"A deleted time entry\",\"tags\":[\"ahaa\"],\"duronly\":false,\"at\":\"2013-09-05T08:19:45+00:00\",\"server_deleted_at\":\"2013-08-22T09:05:31+00:00\"}");  // NOLINT
 
     TimeEntry t;
-    t.LoadFromJSON(jsonStringToValue(json));
+    t.LoadFromJSON(jsonStringToValue(json), false);
     ASSERT_EQ(Poco::UInt64(0), t.ID()); // ID can only be updated from User class
     ASSERT_EQ(Poco::UInt64(2567324), t.PID());
     ASSERT_EQ(Poco::UInt64(123456789), t.WID());
@@ -1706,7 +1706,7 @@ TEST(JSON, TimeEntry) {
     ASSERT_FALSE(t.DurOnly());
 
     TimeEntry t2;
-    t2.LoadFromJSON(t.SaveToJSON());
+    t2.LoadFromJSON(t.SaveToJSON(), false);
     ASSERT_EQ(t.ID(), t2.ID());
     ASSERT_EQ(t.PID(), t2.PID());
     ASSERT_EQ(t.WID(), t2.WID());
@@ -1928,7 +1928,7 @@ TEST(Sync, LegacyFormat) {
     testing::Database db;
     std::string json { "{\"data\" : {\"achievements_enabled\" : true,\"api_token\" : \"token\",\"at\" : \"2019-04-08T11:08:37+00:00\",\"beginning_of_week\" : 1,\"clients\" : [{\"at\" : \"2018-11-07T20:52:31+00:00\",\"id\" : 43289164,\"name\" : \"client\",\"wid\" : 2817276}],\"created_at\" : \"2018-06-24T17:56:16+00:00\",\"date_format\" : \"MM/DD/YYYY\",\"default_wid\" : 2817276,\"duration_format\" : \"improved\",\"email\" : \"m@rtinbriza.cz\",\"fullname\" : \"M\",\"id\" : 4187712,\"image_url\" : \"https://assets.toggl.space/images/profile.png\",\"invitation\" : {},\"jquery_date_format\" : \"m/d/Y\",\"jquery_timeofday_format\" : \"h:i A\",\"language\" : \"en_US\",\"last_blog_entry\" : \"\",\"new_blog_post\" : {},\"openid_email\" : \"m@rtinbriza.cz\",\"openid_enabled\" : true,\"projects\" : [{\"active\" : true,\"actual_hours\" : 362,\"at\" : \"2019-09-18T12:31:25+00:00\",\"auto_estimates\" : false,\"billable\" : false,\"cid\" : 43289164,\"color\" : \"0\",\"created_at\" : \"2019-09-18T12:31:25+00:00\",\"hex_color\" : \"#06aaf5\",\"id\" : 154073509,\"is_private\" : true,\"name\" : \"project\",\"template\" : false,\"wid\" : 2817276}],\"record_timeline\" : true,\"render_timeline\" : true,\"retention\" : 9,\"send_product_emails\" : true,\"send_timer_notifications\" : true,\"send_weekly_report\" : true,\"should_upgrade\" : true,\"sidebar_piechart\" : true,\"store_start_and_stop_time\" : true,\"tags\" : [{\"at\" : \"2019-10-18T10:08:01+00:00\",\"id\" : 6892625,\"name\" : \"tag\",\"wid\" : 2817276}],\"time_entries\": [{\"at\" : \"2020-05-27T15:40:37+00:00\",\"billable\" : false,\"description\" : \"time entry\",\"duration\" : 415,\"duronly\" : false,\"guid\" : \"a28b9092ec9055edea7af710fcd72459\",\"id\" : 1563187599,\"pid\" : 154073509,\"start\" : \"2020-05-27T15:33:42+00:00\",\"stop\" : \"2020-05-27T15:40:37+00:00\",\"uid\" : 4187712,\"wid\" : 2817276}],\"timeline_enabled\" : true,\"timeline_experiment\" : false,\"timeofday_format\" : \"h:mm A\",\"timezone\" : \"Europe/Warsaw\",\"workspaces\" : [{\"admin\" : true,\"api_token\" : \"token\",\"at\" : \"2018-09-01T08:27:56+00:00\",\"default_currency\" : \"USD\",\"default_hourly_rate\" : 0,\"ical_enabled\" : true,\"id\" : 2817276,\"name\" : \"workspace\",\"only_admins_may_create_projects\" : false,\"only_admins_see_billable_rates\" : false,\"only_admins_see_team_dashboard\" : false,\"premium\" : true,\"profile\" : 0,\"projects_billable_by_default\" : true,\"rounding\" : 1,\"rounding_minutes\" : 0}]},\"since\" : 1590592101}" };
     User user;
-    error err = user.LoadUserAndRelatedDataFromJSONString(json, false);
+    error err = user.LoadUserAndRelatedDataFromJSONString(json, false, false);
     ASSERT_EQ(err, noError);
 
     ASSERT_EQ(user.Email(), "m@rtinbriza.cz");
@@ -1976,7 +1976,7 @@ TEST(Sync, BatchedFormat) {
     testing::Database db;
     std::string json { "{\"clients\" : [{\"at\" : \"2018-11-07T20:52:31+00:00\",\"id\" : 43289164,\"name\" : \"client\",\"wid\" : 2817276}],\"flags\" : {\"badges.master_seen\" : \"2019-10-21T08:53:51.051Z\",\"has_seen_toggl_master_campaign\" : true,\"notifications.snowball_weekly_report_rollout\" : true,\"shopify_discount_enabled\" : false,\"snowball_detailed_report_rollout\" : true,\"snowball_summary_report_rollout\" : true},\"preferences\" : {\"CollapseTimeEntries\" : true,\"alpha_features\" : [{\"code\" : \"snowball_projects_list\",\"enabled\" : true},{\"code\" : \"snowball_teams\",\"enabled\" : true},{\"code\" : \"snowball_project_teams\",\"enabled\" : true},{\"code\" : \"snowball_saved_reports\",\"enabled\" : true},{\"code\" : \"snowball_workspace_settings_general\",\"enabled\" : true},{\"code\" : \"snowball_workspace_settings_owner\",\"enabled\" : true},{\"code\" : \"snowball_workspace_settings_alerts\",\"enabled\" : true},{\"code\" : \"snowball_workspace_settings_reminders\",\"enabled\" : true},{\"code\" : \"snowball_workspace_creation\",\"enabled\" : true},{\"code\" : \"snowball_view_shared_report\",\"enabled\" : true},{\"code\" : \"snowball_project_edit\",\"enabled\" : true},{\"code\" : \"snowball_settings\",\"enabled\" : true},{\"code\" : \"snowball_weekly_report\",\"enabled\" : true},{\"code\" : \"snowball_workspace_settings_integrations\",\"enabled\" : false},{\"code\" : \"snowball_detailed_report\",\"enabled\" : false},{\"code\" : \"snowball_clients\",\"enabled\" : true},{\"code\" : \"snowball_workspace_settings_import\",\"enabled\" : false},{\"code\" : \"snowball_profile\",\"enabled\" : true},{\"code\" : \"mobile_sync_client\",\"enabled\" : false},{\"code\" : \"snowball_dashboard\",\"enabled\" : false},{\"code\" : \"new_react_router\",\"enabled\" : false},{\"code\" : \"web_sync_client\",\"enabled\" : false},{\"code\" : \"alpha_program\",\"enabled\" : false},{\"code\" : \"dekstop_sync_client\",\"enabled\" : false},{\"code\" : \"snowball_tags\",\"enabled\" : true},{\"code\" : \"single_sign_on\",\"enabled\" : false},{\"code\" : \"calendar_view\",\"enabled\" : false},{\"code\" : \"snowball_project_tasks\",\"enabled\" : true},{\"code\" : \"snowball_i18n\",\"enabled\" : false}],\"date_format\" : \"MM/DD/YYYY\",\"duration_format\" : \"improved\",\"record_timeline\" : true,\"send_product_emails\" : true,\"send_timer_notifications\" : true,\"send_weekly_report\" : true,\"timeofday_format\" : \"h:mm A\"},\"projects\" : [{\"active\" : true,\"actual_hours\" : 362,\"at\" : \"2019-09-18T12:31:25+00:00\",\"auto_estimates\" : null,\"billable\" : null,\"cid\" : 43289164,\"client_id\" : 43289164,\"color\" : \"#06aaf5\",\"created_at\" : \"2019-09-18T12:31:25+00:00\",\"currency\" : null,\"estimated_hours\" : null,\"id\" : 154073509,\"is_private\" : true,\"name\" : \"project\",\"rate\" : null,\"server_deleted_at\" : null,\"template\" : null,\"wid\" : 2817276,\"workspace_id\" : 2817276}],\"server_time\" : 1590592101,\"tags\" : [{\"at\" : \"2019-10-18T10:08:01.693372Z\",\"id\" : 6892625,\"name\" : \"tag\",\"workspace_id\" : 2817276}],\"tasks\" : [],\"time_entries\" : [{\"at\" : \"2020-05-27T15:40:37+00:00\",\"billable\" : false,\"description\" : \"time entry\",\"duration\" : 415,\"duronly\" : false,\"id\" : 1563187599,\"project_id\" : null,\"server_deleted_at\" : null,\"start\" : \"2020-05-27T15:33:42+00:00\",\"stop\" : \"2020-05-27T15:40:37.000000Z\",\"tag_ids\" : null,\"tags\" : null,\"task_id\" : null,\"uid\" : 4187712,\"user_id\" : 4187712,\"wid\" : 2817276,\"workspace_id\" : 2817276}],\"user\" : {\"api_token\" : \"token\",\"at\" : \"2020-05-27T15:08:21.468625Z\",\"beginning_of_week\" : 1,\"country_id\" : 59,\"created_at\" : \"2018-06-24T17:56:16.075815Z\",\"default_workspace_id\" : 2817276,\"email\" : \"m@rtinbriza.cz\",\"fullname\" : \"M\",\"has_password\" : true,\"id\" : 4187712,\"image_url\" : \"https://assets.toggl.com/images/profile.png\",\"intercom_hash\" : \"33ad107c55cc9f8e89b0b1940812194b9441f742771f0f3be14bf329f41f8f9b\",\"oauth_providers\" : [ \"google\" ],\"openid_email\" : \"m@rtinbriza.cz\",\"openid_enabled\" : true,\"timezone\" : \"Europe/Warsaw\",\"updated_at\" : \"2019-04-08T11:08:37.90838Z\"},\"workspace_features\" : [{\"features\" : [{\"enabled\" : true,\"feature_id\" : 0,\"name\" : \"free\"},{\"enabled\" : false,\"feature_id\" : 13,\"name\" : \"pro\"},{\"enabled\" : false,\"feature_id\" : 15,\"name\" : \"business\"},{\"enabled\" : false,\"feature_id\" : 50,\"name\" : \"scheduled_reports\"},{\"enabled\" : false,\"feature_id\" : 51,\"name\" : \"time_audits\"},{\"enabled\" : false,\"feature_id\" : 52,\"name\" : \"locking_time_entries\"},{\"enabled\" : false,\"feature_id\" : 53,\"name\" : \"edit_team_member_time_entries\"},{\"enabled\" : false,\"feature_id\" : 54,\"name\" : \"edit_team_member_profile\"},{\"enabled\" : false,\"feature_id\" : 55,\"name\" : \"tracking_reminders\"},{\"enabled\" : false,\"feature_id\" : 56,\"name\" : \"time_entry_constraints\"},{\"enabled\" : false,\"feature_id\" : 57,\"name\" : \"priority_support\"},{\"enabled\" : false,\"feature_id\" : 58,\"name\" : \"labour_cost\"},{\"enabled\" : false,\"feature_id\" : 59,\"name\" : \"report_employee_profitability\"},{\"enabled\" : false,\"feature_id\" : 60,\"name\" : \"report_project_profitability\"},{\"enabled\" : false,\"feature_id\" : 61,\"name\" : \"report_comparative\"},{\"enabled\" : false,\"feature_id\" : 62,\"name\" : \"report_data_trends\"},{\"enabled\" : false,\"feature_id\" : 63,\"name\" : \"report_export_xlsx\"},{\"enabled\" : false,\"feature_id\" : 64,\"name\" : \"tasks\"},{\"enabled\" : false,\"feature_id\" : 65,\"name\" : \"project_dashboard\"}],\"workspace_id\" : 2817276}],\"workspaces\" : [{\"admin\" : true,\"api_token\" : \"token\",\"at\" : \"2018-09-01T08:27:56+00:00\",\"business_ws\" : false,\"csv_upload\" : null,\"default_currency\" : \"USD\",\"default_hourly_rate\" : 0,\"ical_enabled\" : true,\"ical_url\" : \"/ical/workspace_user/cf8775d2110d5d874ffa633434c901bd\",\"id\" : 2817276,\"logo_url\" : \"https://assets.toggl.com/images/workspace.jpg\",\"name\" : \"workspace\",\"only_admins_may_create_projects\" : false,\"only_admins_see_billable_rates\" : false,\"only_admins_see_team_dashboard\" : false,\"premium\" : true,\"profile\" : 0,\"projects_billable_by_default\" : true,\"rounding\" : 1,\"rounding_minutes\" : 0,\"server_deleted_at\" : null,\"subscription\" : null,\"suspended_at\" : null}]}" };
     User user;
-    error err = user.LoadUserAndRelatedDataFromJSONString(json, false);
+    error err = user.LoadUserAndRelatedDataFromJSONString(json, false, true);
     ASSERT_EQ(err, noError);
 
     ASSERT_EQ(user.Email(), "m@rtinbriza.cz");

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -280,8 +280,8 @@ TEST(Database, SaveAndLoadCurrentAPIToken) {
     ASSERT_EQ(Poco::UInt64(0), uid_from_db);
 }
 
-Json::Value jsonStringToValue(const std::string json_string) {
-    Json::Value root;
+Json::Value &jsonStringToValue(const std::string json_string) {
+    static thread_local Json::Value root;
     Json::Reader reader;
     reader.parse(json_string, root);
     return root;
@@ -1740,30 +1740,6 @@ TEST(User, DurationFormat) {
     u.SetDurationFormat("decimal");
     ASSERT_EQ("decimal", u.DurationFormat());
     ASSERT_EQ("decimal", Formatter::DurationFormat);
-}
-
-TEST(BaseModel, LoadFromDataStringWithInvalidJSON) {
-    User u;
-    error err = u.LoadFromDataString("foobar");
-    ASSERT_NE(noError, err);
-}
-
-TEST(BaseModel, LoadFromDataString) {
-    User u;
-    error err = u.LoadFromDataString(loadTestData());
-    ASSERT_EQ(noError, err);
-}
-
-TEST(BaseModel, LoadFromJSONStringWithEmptyString) {
-    User u;
-    u.LoadFromJSON(jsonStringToValue(""));
-    ASSERT_TRUE(true);
-}
-
-TEST(BaseModel, LoadFromJSONStringWithInvalidString) {
-    User u;
-    u.LoadFromJSON(jsonStringToValue("foobar"));
-    ASSERT_TRUE(true);
 }
 
 TEST(BaseModel, BatchUpdateJSONWithoutGUID) {

--- a/src/util/json.cc
+++ b/src/util/json.cc
@@ -15,4 +15,24 @@ std::vector<std::string> JsonHelper::convert(const Json::Value &json) {
     return ret;
 }
 
+template<>
+Poco::UInt64 JsonHelper::convert(const Json::Value& json) {
+    return json.asUInt64();
+}
+
+template<>
+Poco::Int64 JsonHelper::convert(const Json::Value& json) {
+    return json.asInt64();
+}
+
+template<>
+std::string JsonHelper::convert(const Json::Value& json) {
+    return json.asString();
+}
+
+template<>
+bool JsonHelper::convert(const Json::Value& json) {
+    return json.asBool();
+}
+
 } // namespace toggl

--- a/src/util/json.cc
+++ b/src/util/json.cc
@@ -10,7 +10,8 @@ template<>
 std::vector<std::string> JsonHelper::convert(const Json::Value &json) {
     std::vector<std::string> ret;
     for (auto i : json) {
-        ret.push_back(i.asString());
+        if (!i.asString().empty())
+            ret.push_back(i.asString());
     }
     return ret;
 }

--- a/src/util/json.cc
+++ b/src/util/json.cc
@@ -1,0 +1,18 @@
+// Copyright 2020 Toggl Desktop developers.
+
+#include "json.h"
+
+#include "model/time_entry.h"
+
+namespace toggl {
+
+template<>
+std::vector<std::string> JsonHelper::convert(const Json::Value &json) {
+    std::vector<std::string> ret;
+    for (auto i : json) {
+        ret.push_back(i.asString());
+    }
+    return ret;
+}
+
+} // namespace toggl

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -6,17 +6,20 @@
 #define JSON_H
 
 #include <json/json.h>
+#include <Poco/Types.h>
 
 namespace toggl {
 
 class JsonHelper {
 public:
     template <class T>
-    static T convert(const ::Json::Value &json) {
-        return json.as<T>();
-    }
+    static T convert(const ::Json::Value &json);
 };
 
+template <> Poco::Int64 JsonHelper::convert(const ::Json::Value& json);
+template <> Poco::UInt64 JsonHelper::convert(const ::Json::Value& json);
+template <> std::string JsonHelper::convert(const ::Json::Value& json);
+template <> bool JsonHelper::convert(const ::Json::Value& json);
 template <> std::vector<std::string> JsonHelper::convert(const ::Json::Value &json);
 
 } // namespace toggl

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -1,0 +1,24 @@
+// Copyright 2020 Toggl Desktop developers.
+
+// helper methods for Json usage
+
+#ifndef JSON_H
+#define JSON_H
+
+#include <json/json.h>
+
+namespace toggl {
+
+class JsonHelper {
+public:
+    template <class T>
+    static T convert(const ::Json::Value &json) {
+        return json.as<T>();
+    }
+};
+
+template <> std::vector<std::string> JsonHelper::convert(const ::Json::Value &json);
+
+} // namespace toggl
+
+#endif // JSON_H

--- a/src/util/property.h
+++ b/src/util/property.h
@@ -66,6 +66,29 @@ public:
         }
         return true;
     }
+    /* Setters for current values only (previous value stays) */
+    void SetCurrent(const T& current) {
+        current_ = current;
+    }
+    void SetCurrent(const T&& current) {
+        current_ = std::move(current);
+    }
+    /* Setters for previous values (to enable loading from db) */
+    void SetPrevious(const T& previous) {
+        previous_ = previous;
+    }
+    void SetPrevious(const T&& previous) {
+        previous_ = std::move(previous);
+    }
+    /* Insert will modify current and previous value at once */
+    void Insert(const T& previous, const T& current) {
+        current_ = current;
+        previous_ = previous;
+    }
+    void Insert(const T&& previous, const T&& current) {
+        current_ = std::move(current);
+        previous_ = std::move(previous);
+    }
     /* Data access operators */
     // Notice that references are returned only as const
     // Only the -> operator is allowed to modify data inside (but should probably be const as well in the future)

--- a/src/util/property.h
+++ b/src/util/property.h
@@ -110,6 +110,9 @@ public:
     const T& Get() const {
         return current_;
     }
+    const T& GetPrevious() const {
+        return previous_;
+    }
     /* Equality */
     bool operator ==(const Property<T> &o) const {
         return current_ == o.current_;


### PR DESCRIPTION
### 📒 Description
This change introduces the ability to merge changed Time Entry properties between the server and desktop client.
Most notable changes are:
 * `BaseModel::LoadFromJSON` is no longer virtual because it was never used as such.
 * Some `BatchUpdateResult` methods (and friends) were removed because these were the only places where `LoadFromJSON` was properly used as virtual
 * The `isSyncServer` `Context` property is now passed down to JSON parsing methods in `User`.

The actual heavy lifting is then done in the short lambda function in `TimeEntry::LoadFromJSON`. It basically consists of comparing the "previous" stored value of the property in question with what we got from the server.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
- With this PR, the Sync server implementation is feature complete and ready for testing and bugfixing

Closes #4186

### 🔎 Review hints
This PR potentially modifies the behavior with regular legacy sync implementation (although it shouldn't). This needs thorough testing.
Otherwise, nothing should really change from the user perspective. Only thing this should improve is when you have a time entry and modify one property from a different client and another property in the desktop client. There should be no conflicts.