### PR TITLE
Fix BaseModel database performance by not making it dirty everytime

### DIFF
--- a/src/model/autotracker.cc
+++ b/src/model/autotracker.cc
@@ -22,24 +22,18 @@ bool AutotrackerRule::Matches(const TimelineEvent &event) const {
 }
 
 void AutotrackerRule::SetTerm(const std::string &value) {
-    if (Term() != value) {
-        Term.Set(value);
+    if (Term.Set(value))
         SetDirty();
-    }
 }
 
 void AutotrackerRule::SetPID(Poco::UInt64 value) {
-    if (PID()  != value) {
-        PID.Set(value);
+    if (PID.Set(value))
         SetDirty();
-    }
 }
 
 void AutotrackerRule::SetTID(Poco::UInt64 value) {
-    if (TID() != value) {
-        TID.Set(value);
+    if (TID.Set(value))
         SetDirty();
-    }
 }
 
 std::string AutotrackerRule::String() const {

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -55,8 +55,8 @@ void BaseModel::ClearValidationError() {
 }
 
 void BaseModel::SetValidationError(const std::string &value) {
-    ValidationError.Set(value);
-    SetDirty();
+    if (ValidationError.Set(value))
+        SetDirty();
 }
 
 std::string BaseModel::SyncType() const {
@@ -74,8 +74,8 @@ void BaseModel::SetUpdatedAtString(const std::string &value) {
 }
 
 void BaseModel::MarkAsDeletedOnServer() {
-    IsMarkedAsDeletedOnServer.Set(true);
-    SetDirty();
+    if (IsMarkedAsDeletedOnServer.Set(true))
+        SetDirty();
 }
 
 error BaseModel::LoadFromDataString(const std::string &data_string) {
@@ -142,23 +142,23 @@ Logger BaseModel::logger() const {
 }
 
 void BaseModel::SetID(Poco::UInt64 value) {
-    ID.Set(value);
-    SetDirty();
+    if (ID.Set(value))
+        SetDirty();
 }
 
 void BaseModel::SetUIModifiedAt(Poco::Int64 value) {
-    UIModifiedAt.Set(value);
-    SetDirty();
+    if (UIModifiedAt.Set(value))
+        SetDirty();
 }
 
 void BaseModel::SetGUID(const std::string &value) {
-    GUID.Set(value);
-    SetDirty();
+    if (GUID.Set(value))
+        SetDirty();
 }
 
 void BaseModel::SetUID(Poco::UInt64 value) {
-    UID.Set(value);
-    SetDirty();
+    if (UID.Set(value))
+        SetDirty();
 }
 
 void BaseModel::SetDirty() {
@@ -178,13 +178,13 @@ void BaseModel::ClearUnsynced() {
 }
 
 void BaseModel::SetDeletedAt(Poco::Int64 value) {
-    DeletedAt.Set(value);
-    SetDirty();
+    if (DeletedAt.Set(value))
+        SetDirty();
 }
 
 void BaseModel::SetUpdatedAt(Poco::Int64 value) {
-    UpdatedAt.Set(value);
-    SetDirty();
+    if (UpdatedAt.Set(value))
+        SetDirty();
 }
 
 }   // namespace toggl

--- a/src/model/client.cc
+++ b/src/model/client.cc
@@ -32,17 +32,13 @@ std::string Client::String() const {
 }
 
 void Client::SetName(const std::string &value) {
-    if (Name() != value) {
-        Name.Set(value);
+    if (Name.Set(value))
         SetDirty();
-    }
 }
 
 void Client::SetWID(Poco::UInt64 value) {
-    if (WID() != value) {
-        WID.Set(value);
+    if (WID.Set(value))
         SetDirty();
-    }
 }
 
 void Client::LoadFromJSON(Json::Value data) {

--- a/src/model/obm_action.cc
+++ b/src/model/obm_action.cc
@@ -19,24 +19,18 @@ std::string ObmAction::String() const {
 }
 
 void ObmAction::SetExperimentID(Poco::UInt64 value) {
-    if (ExperimentID() != value) {
-        ExperimentID.Set(value);
+    if (ExperimentID.Set(value))
         SetDirty();
-    }
 }
 
 void ObmAction::SetKey(const std::string &value) {
-    if (Key() != value) {
-        Key.Set(value);
+    if (Key.Set(value))
         SetDirty();
-    }
 }
 
 void ObmAction::SetValue(const std::string &value) {
-    if (Value() != value) {
-        Value.Set(value);
+    if (Value.Set(value))
         SetDirty();
-    }
 }
 
 std::string ObmAction::ModelName() const {
@@ -67,31 +61,23 @@ std::string ObmExperiment::String() const {
 }
 
 void ObmExperiment::SetNr(Poco::UInt64 value) {
-    if (Nr() != value) {
-        Nr.Set(value);
+    if (Nr.Set(value))
         SetDirty();
-    }
 }
 
 void ObmExperiment::SetHasSeen(bool value) {
-    if (HasSeen() != value) {
-        HasSeen.Set(value);
+    if (HasSeen.Set(value))
         SetDirty();
-    }
 }
 
 void ObmExperiment::SetIncluded(bool value) {
-    if (Included() != value) {
-        Included.Set(value);
+    if (Included.Set(value))
         SetDirty();
-    }
 }
 
 void ObmExperiment::SetActions(const std::string &value) {
-    if (Actions() != value) {
-        Actions.Set(value);
+    if (Actions.Set(value))
         SetDirty();
-    }
 }
 
 std::string ObmExperiment::ModelName() const {

--- a/src/model/project.cc
+++ b/src/model/project.cc
@@ -49,45 +49,33 @@ std::string Project::FullName() const {
 }
 
 void Project::SetClientGUID(const std::string &value) {
-    if (ClientGUID() != value) {
-        ClientGUID.Set(value);
+    if (ClientGUID.Set(value))
         SetDirty();
-    }
 }
 
 void Project::SetActive(bool value) {
-    if (Active() != value) {
-        Active.Set(value);
+    if (Active.Set(value))
         SetDirty();
-    }
 }
 
 void Project::SetPrivate(bool value) {
-    if (Private() != value) {
-        Private.Set(value);
+    if (Private.Set(value))
         SetDirty();
-    }
 }
 
 void Project::SetName(const std::string &value) {
-    if (Name() != value) {
-        Name.Set(value);
+    if (Name.Set(value))
         SetDirty();
-    }
 }
 
 void Project::SetBillable(bool value) {
-    if (Billable() != value) {
-        Billable.Set(value);
+    if (Billable.Set(value))
         SetDirty();
-    }
 }
 
 void Project::SetColor(const std::string &value) {
-    if (Color() != value) {
-        Color.Set(Poco::UTF8::toLower(value));
+    if (Color.Set(Poco::UTF8::toLower(value)))
         SetDirty();
-    }
 }
 
 std::string Project::ColorCode() const {
@@ -104,24 +92,18 @@ error Project::SetColorCode(const std::string &color_code) {
 }
 
 void Project::SetWID(Poco::UInt64 value) {
-    if (WID() != value) {
-        WID.Set(value);
+    if (WID.Set(value))
         SetDirty();
-    }
 }
 
 void Project::SetCID(Poco::UInt64 value) {
-    if (CID() != value) {
-        CID.Set(value);
+    if (CID.Set(value))
         SetDirty();
-    }
 }
 
 void Project::SetClientName(const std::string &value) {
-    if (ClientName() != value) {
-        ClientName.Set(value);
+    if (ClientName.Set(value))
         SetDirty();
-    }
 }
 
 void Project::LoadFromJSON(Json::Value data) {

--- a/src/model/tag.cc
+++ b/src/model/tag.cc
@@ -19,17 +19,13 @@ std::string Tag::String() const {
 }
 
 void Tag::SetWID(Poco::UInt64 value) {
-    if (WID() != value) {
-        WID.Set(value);
+    if (WID.Set(value))
         SetDirty();
-    }
 }
 
 void Tag::SetName(const std::string &value) {
-    if (Name() != value) {
-        Name.Set(value);
+    if (Name.Set(value))
         SetDirty();
-    }
 }
 
 void Tag::LoadFromJSON(Json::Value data) {

--- a/src/model/task.cc
+++ b/src/model/task.cc
@@ -17,31 +17,23 @@ std::string Task::String() const {
 }
 
 void Task::SetPID(Poco::UInt64 value) {
-    if (PID() != value) {
-        PID.Set(value);
+    if (PID.Set(value))
         SetDirty();
-    }
 }
 
 void Task::SetWID(Poco::UInt64 value) {
-    if (WID() != value) {
-        WID.Set(value);
+    if (WID.Set(value))
         SetDirty();
-    }
 }
 
 void Task::SetName(const std::string &value) {
-    if (Name() != value) {
-        Name.Set(value);
+    if (Name.Set(value))
         SetDirty();
-    }
 }
 
 void Task::SetActive(bool value) {
-    if (Active() != value) {
-        Active.Set(value);
+    if (Active.Set(value))
         SetDirty();
-    }
 }
 
 void Task::LoadFromJSON(Json::Value data) {

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -178,32 +178,24 @@ void TimeEntry::SetLastStartAt(Poco::Int64 value) {
 }
 
 void TimeEntry::SetDurOnly(bool value) {
-    if (DurOnly() != value) {
-        DurOnly.Set(value);
+    if (DurOnly.Set(value))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetStartTime(Poco::Int64 value, bool userModified) {
-    if (StartTime() != value) {
-        StartTime.Set(value, userModified);
+    if (StartTime.Set(value, userModified))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetStopTime(Poco::Int64 value, bool userModified) {
-    if (StopTime() != value) {
-        StopTime.Set(value, userModified);
+    if (StopTime.Set(value, userModified))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetDescription(const std::string &value, bool userModified) {
     const std::string &trimValue = trim_whitespace(value);
-    if (Description() != trimValue) {
-        Description.Set(trimValue, userModified);
+    if (Description.Set(trimValue, userModified))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetStopString(const std::string &value, bool userModified) {
@@ -211,24 +203,18 @@ void TimeEntry::SetStopString(const std::string &value, bool userModified) {
 }
 
 void TimeEntry::SetCreatedWith(const std::string &value) {
-    if (CreatedWith() != value) {
-        CreatedWith.Set(value, false);
+    if (CreatedWith.Set(value, false))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetBillable(bool value, bool userModified) {
-    if (Billable() != value) {
-        Billable.Set(value, userModified);
+    if (Billable.Set(value, userModified))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetWID(Poco::UInt64 value) {
-    if (WID() != value) {
-        WID.Set(value);
+    if (WID.Set(value))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetStopUserInput(const std::string &value) {
@@ -258,42 +244,34 @@ void TimeEntry::SetStopUserInput(const std::string &value) {
 }
 
 void TimeEntry::SetTID(Poco::UInt64 value, bool userModified) {
-    if (TID() != value) {
-        TID.Set(value, userModified);
+    if (TID.Set(value, userModified))
         SetDirty();
-    }
 }
 
 static const char kTagSeparator = '\t';
 
 void TimeEntry::SetTags(const std::string &tags, bool userModified) {
-    if (Tags() != tags) {
-        decltype(TagNames)::value_type tmp;
-        if (!tags.empty()) {
-            std::stringstream ss(tags);
-            while (ss.good()) {
-                std::string tag;
-                getline(ss, tag, kTagSeparator);
-                tmp.push_back(tag);
-            }
+    decltype(TagNames)::value_type tmp;
+    if (!tags.empty()) {
+        std::stringstream ss(tags);
+        while (ss.good()) {
+            std::string tag;
+            getline(ss, tag, kTagSeparator);
+            tmp.push_back(tag);
         }
-        TagNames.Set(std::move(tmp), userModified);
-        SetDirty();
     }
+    if (TagNames.Set(std::move(tmp), userModified))
+        SetDirty();
 }
 
 void TimeEntry::SetPID(Poco::UInt64 value, bool userModified) {
-    if (PID() != value) {
-        PID.Set(value, userModified);
+    if (PID.Set(value, userModified))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetDurationInSeconds(Poco::Int64 value, bool userModified) {
-    if (DurationInSeconds() != value) {
-        DurationInSeconds.Set(value, userModified);
+    if (DurationInSeconds.Set(value, userModified))
         SetDirty();
-    }
 }
 
 void TimeEntry::SetStartUserInput(const std::string &value,
@@ -340,10 +318,8 @@ void TimeEntry::SetDurationUserInput(const std::string &value) {
 }
 
 void TimeEntry::SetProjectGUID(const std::string &value, bool userModified) {
-    if (ProjectGUID() != value) {
-        ProjectGUID.Set(value, userModified);
+    if (ProjectGUID.Set(value, userModified))
         SetDirty();
-    }
 }
 
 const std::string TimeEntry::Tags() const {

--- a/src/model/timeline_event.cc
+++ b/src/model/timeline_event.cc
@@ -29,54 +29,42 @@ std::string TimelineEvent::ModelURL() const {
 }
 
 void TimelineEvent::SetTitle(const std::string &value) {
-    if (Title() != value) {
-        Title.Set(value);
+    if (Title.Set(value))
         SetDirty();
-    }
 }
 
 void TimelineEvent::SetStartTime(Poco::Int64 value) {
-    if (StartTime() != value) {
-        StartTime.Set(value);
+    if (StartTime.Set(value)) {
         updateDuration();
         SetDirty();
     }
 }
 
 void TimelineEvent::SetEndTime(Poco::Int64 value) {
-    if (EndTime() != value) {
-        EndTime.Set(value);
+    if (EndTime.Set(value))  {
         updateDuration();
         SetDirty();
     }
 }
 
 void TimelineEvent::SetIdle(bool value) {
-    if (Idle() != value) {
-        Idle.Set(value);
+    if (Idle.Set(value))
         SetDirty();
-    }
 }
 
 void TimelineEvent::SetFilename(const std::string &value) {
-    if (Filename() != value) {
-        Filename.Set(value);
+    if (Filename.Set(value))
         SetDirty();
-    }
 }
 
 void TimelineEvent::SetChunked(bool value) {
-    if (Chunked() != value) {
-        Chunked.Set(value);
+    if (Chunked.Set(value))
         SetDirty();
-    }
 }
 
 void TimelineEvent::SetUploaded(bool value) {
-    if (Uploaded() != value) {
-        Uploaded.Set(value);
+    if (Uploaded.Set(value))
         SetDirty();
-    }
 }
 
 Json::Value TimelineEvent::SaveToJSON(int) const {

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -384,40 +384,30 @@ bool User::CanAddProjects() const {
 }
 
 void User::SetFullname(const std::string &value) {
-    if (Fullname() != value) {
-        Fullname.Set(value);
+    if (Fullname.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetTimeOfDayFormat(const std::string &value) {
     Formatter::TimeOfDayFormat = value;
-    if (TimeOfDayFormat() != value) {
-        TimeOfDayFormat.Set(value);
+    if (TimeOfDayFormat.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetDurationFormat(const std::string &value) {
     Formatter::DurationFormat = value;
-    if (DurationFormat() != value) {
-        DurationFormat.Set(value);
+    if (DurationFormat.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetOfflineData(const std::string &value) {
-    if (OfflineData() != value) {
-        OfflineData.Set(value);
+    if (OfflineData.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetStoreStartAndStopTime(bool value) {
-    if (StoreStartAndStopTime() != value) {
-        StoreStartAndStopTime.Set(value);
+    if (StoreStartAndStopTime.Set(value))
         SetDirty();
-    }
 }
 
 void User::ConfirmLoadedMore() {
@@ -425,17 +415,13 @@ void User::ConfirmLoadedMore() {
 }
 
 void User::SetRecordTimeline(bool value) {
-    if (RecordTimeline() != value) {
-        RecordTimeline.Set(value);
+    if (RecordTimeline.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetEmail(const std::string &value) {
-    if (Email() != value) {
-        Email.Set(value);
+    if (Email.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetAPIToken(const std::string &value) {
@@ -445,38 +431,28 @@ void User::SetAPIToken(const std::string &value) {
 }
 
 void User::SetSince(Poco::Int64 value) {
-    if (Since() != value) {
-        Since.Set(value);
+    if (Since.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetDefaultWID(Poco::UInt64 value) {
-    if (DefaultWID() != value) {
-        DefaultWID.Set(value);
+    if (DefaultWID.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetDefaultPID(Poco::UInt64 value) {
-    if (DefaultPID() != value) {
-        DefaultPID.Set(value);
+    if (DefaultPID.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetDefaultTID(Poco::UInt64 value) {
-    if (DefaultTID() != value) {
-        DefaultTID.Set(value);
+    if (DefaultTID.Set(value))
         SetDirty();
-    }
 }
 
 void User::SetCollapseEntries(bool value) {
-    if (CollapseEntries() != value) {
-        CollapseEntries.Set(value);
+    if (CollapseEntries.Set(value))
         SetDirty();
-    }
 }
 
 // Stop a time entry, mark it as dirty.

--- a/src/model/workspace.cc
+++ b/src/model/workspace.cc
@@ -16,52 +16,38 @@ std::string Workspace::String() const {
 }
 
 void Workspace::SetName(const std::string &value) {
-    if (Name() != value) {
-        Name.Set(value);
+    if (Name.Set(value))
         SetDirty();
-    }
 }
 
 void Workspace::SetPremium(bool value) {
-    if (Premium() != value) {
-        Premium.Set(value);
+    if (Premium.Set(value))
         SetDirty();
-    }
 }
 
 void Workspace::SetOnlyAdminsMayCreateProjects(bool value) {
-    if (OnlyAdminsMayCreateProjects() != value) {
-        OnlyAdminsMayCreateProjects.Set(value);
+    if (OnlyAdminsMayCreateProjects.Set(value))
         SetDirty();
-    }
 }
 
 void Workspace::SetAdmin(bool value) {
-    if (Admin() != value) {
-        Admin.Set(value);
+    if (Admin.Set(value))
         SetDirty();
-    }
 }
 
 void Workspace::SetProjectsBillableByDefault(bool value) {
-    if (ProjectsBillableByDefault() != value) {
-        ProjectsBillableByDefault.Set(value);
+    if (ProjectsBillableByDefault.Set(value))
         SetDirty();
-    }
 }
 
 void Workspace::SetBusiness(bool value) {
-    if (Business() != value) {
-        Business.Set(value);
+    if (Business.Set(value))
         SetDirty();
-    }
 }
 
 void Workspace::SetLockedTime(time_t value) {
-    if (LockedTime() != value) {
-        LockedTime.Set(value);
+    if (LockedTime.Set(value))
         SetDirty();
-    }
 }
 
 void Workspace::LoadFromJSON(Json::Value n) {

--- a/src/util/property.h
+++ b/src/util/property.h
@@ -39,19 +39,32 @@ public:
         previous_ = current_;
     }
     /* Setters */
-    void Set(const T& value, bool makeDirty = true) {
+    bool Set(const T& value, bool makeDirty = true) {
+        if (value == current_) {
+            previous_ = value;
+            return false;
+        }
         if (makeDirty)
             previous_ = std::move(current_);
         else
             previous_ = value;
         current_ = value;
+        return true;
     }
-    void Set(const T&& value, bool makeDirty = true) {
-        if (makeDirty)
-            previous_ = std::move(current_);
-        else
+    bool Set(const T&& value, bool makeDirty = true) {
+        if (value == current_) {
             previous_ = std::move(value);
-        current_ = value;
+            return false;
+        }
+        if (makeDirty) {
+            previous_ = std::move(current_);
+            current_ = std::move(value);
+        }
+        else {
+            previous_ = std::move(value);
+            current_ = previous_;
+        }
+        return true;
     }
     /* Data access operators */
     // Notice that references are returned only as const


### PR DESCRIPTION
### 📒 Description
This PR addresses the performance hit some Windows users were experiencing - performance went straight downhill after applying my performance patch.
As Anna correctly noted, the `Dirty` property was set on each call to `Set<Something>` even when there was no change. This happened mostly for the `ID` and `GUID` properties because I made this error only in `BaseModel` (I wonder why, because in other models it's fine).
This PR changes all models to check the `Property<T>::Set` return value to determine if there was any change so we're consistent and it also reduces the lines of code slightly.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Windows app performance is fixed

### 👫 Relationships
Closes #4223

### 🔎 Review hints
No changes to the functionality should be present. You can check the duration of the database storage times in the logs.

