### PR TITLE
Sync: enable changing TE workspaces

### DIFF
--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -2179,15 +2179,11 @@ error Database::saveModel(
                           useRef(model->LocalID()),
                           now;
             } else {
-                // For cases where we need to remove the ID from the TE (like when changing the workspace)
                 *session_ <<
                           "update time_entries set "
-                          "id = null "
-                          "where local_id = :local_id",
-                          useRef(model->LocalID()),
-                          now;
-                *session_ <<
-                          "update time_entries set "
+                          /* For cases where we need to remove the ID from the TE (like when changing the workspace) */
+                          "id = null, "
+                          /* Regular column updates */
                           "uid = :uid, description = :description, wid = :wid, "
                           "guid = :guid, pid = :pid, tid = :tid, "
                           "billable = :billable, "

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -2179,6 +2179,13 @@ error Database::saveModel(
                           useRef(model->LocalID()),
                           now;
             } else {
+                // For cases where we need to remove the ID from the TE (like when changing the workspace)
+                *session_ <<
+                          "update time_entries set "
+                          "id = null "
+                          "where local_id = :local_id",
+                          useRef(model->LocalID()),
+                          now;
                 *session_ <<
                           "update time_entries set "
                           "uid = :uid, description = :description, wid = :wid, "

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -131,6 +131,19 @@ Logger BaseModel::logger() const {
     return { ModelName() };
 }
 
+BaseModel::BaseModel(const BaseModel &o)
+    // ID, GUID, LocalID are intentionally omitted
+    : UIModifiedAt { o.UIModifiedAt }
+    , UID { o.UID }
+    , Dirty { true }
+    , DeletedAt { o.DeletedAt }
+    , IsMarkedAsDeletedOnServer { o.IsMarkedAsDeletedOnServer }
+    , UpdatedAt { o.UpdatedAt }
+    , ValidationError { o.ValidationError }
+    , Unsynced { o.Unsynced }
+{
+}
+
 void BaseModel::SetID(Poco::UInt64 value) {
     if (ID.Set(value))
         SetDirty();

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -23,6 +23,7 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT BaseModel {
  public:
     BaseModel() {}
+    BaseModel(const BaseModel &o);
     virtual ~BaseModel() {}
 
     Property<Poco::Int64> LocalID { 0 };

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -153,6 +153,7 @@ std::string TimeEntry::String() const {
         << " ID=" << ID()
         << " local_id=" << LocalID()
         << " description=" << Description()
+        << " uid=" << UID()
         << " wid=" << WID()
         << " guid=" << GUID()
         << " pid=" << PID()
@@ -190,6 +191,26 @@ void TimeEntry::SetStartTime(Poco::Int64 value, bool userModified) {
 void TimeEntry::SetStopTime(Poco::Int64 value, bool userModified) {
     if (StopTime.Set(value, userModified))
         SetDirty();
+}
+
+TimeEntry::TimeEntry(const TimeEntry &o)
+    : BaseModel(o)
+    , Description { o.Description }
+    , CreatedWith { o.CreatedWith }
+    , ProjectGUID { o.ProjectGUID }
+    , TagNames { o.TagNames }
+    , WID { o.WID }
+    , PID { o.PID }
+    , TID { o.TID }
+    , StartTime { o.StartTime }
+    , StopTime { o.StopTime }
+    , DurationInSeconds { o.DurationInSeconds }
+    , LastStartAt { o.LastStartAt }
+    , Billable { o.Billable }
+    , DurOnly { o.DurOnly }
+    , SkipPomodoro { o.SkipPomodoro }
+{
+
 }
 
 void TimeEntry::SetDescription(const std::string &value, bool userModified) {

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -17,6 +17,7 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
  public:
     TimeEntry() : BaseModel() {}
+    TimeEntry(const TimeEntry &o);
     virtual ~TimeEntry() {}
 
     Property<std::string> Description { "" };


### PR DESCRIPTION
### 📒 Description
This PR enables changing workspaces for time entries again.

This is achieved by:
 * Splitting the time entry into two, essentially creating a new one, server-side (that means clearing the ID in the one we're keeping locally)
 * Allowing cloning the `TimeEntry` and `BaseModel` class (without copying the `ID`, `GUID` and `LocalID` fields).
 * Clearing the `id` field in the database when updating time entries (now it was just left alone when the TE was updated) 
 * And finally, sending the new mock time entry (containing an old `ID) to the server for deletion, along with a "new" time entry in another workspace for creation.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4221 

### 🔎 Review hints
Try changing TE workspaces, while online and while offline. Everything should work the same with both sync and legacy synchronization protocols.
