### PR TITLE
Only set TEs to billable when the WS they're in is premium (lib)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4096,7 +4096,7 @@ Project *Context::CreateProject(
 
         ws = user_->related.WorkspaceByID(workspace_id);
         if (ws) {
-            billable = ws->ProjectsBillableByDefault();
+            billable = ws->ProjectsBillableByDefault() && ws->Premium();
         }
 
         std::string client_name("");


### PR DESCRIPTION
### 📒 Description
We have a `ProjectsBillableByDefault` workspace setting that's for some reason true even for nonpremium workspaces (that don't support billable TEs). This PR will just ignore the setting if the WS is not premium. 

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Fixes #3792

### 🔎 Review hints
No more flickering Billable flag on TEs when a project is created.

