### PR TITLE
Improve CocoaPods speed for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,14 @@ jobs:
         security unlock-keychain -p password ~/Library/Keychains/build.keychain
         security set-keychain-settings -lu
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k password ~/Library/Keychains/build.keychain
+    
+    - name: Cache cocoapods
+      uses: actions/cache@v2
+      with:
+        path: src/ui/osx/Pods
+        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pods-
     - name: Get cocoapods
       run: |
         bash ./dist/osx/build.sh cocoapods

--- a/src/ui/osx/Podfile
+++ b/src/ui/osx/Podfile
@@ -1,5 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
-
 platform :osx, '10.11'
 use_frameworks!
 inhibit_all_warnings!

--- a/src/ui/osx/Podfile.lock
+++ b/src/ui/osx/Podfile.lock
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - Sparkle
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - AppAuth
     - Bugsnag
     - GTMAppAuth
@@ -40,6 +40,6 @@ SPEC CHECKSUMS:
   MASShortcut: d9e4909e878661cc42877cc9d6efbe638273ab57
   Sparkle: 593ac2e677c07bcb6c3b22d621240e7cbedaab57
 
-PODFILE CHECKSUM: 47f76cb65908a796afa9bee0b52af94cd2c5633f
+PODFILE CHECKSUM: 799c066621b5b0ae6e7d607d88405719913d7ee8
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
### 📒 Description
Removed `source` from Podfile. This enables CDN support for the CocoaPods `trunk specs repo` and consequently improves the speed of the first `pod install` run.
@skel35 added cache step for GH Actions workflow that caches Pods folder and improves `pod install` run if the cache is available.

For more information about CDN support on CocoaPods:
https://blog.cocoapods.org/CocoaPods-1.7.2/

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
-

### 👫 Relationships
Closes #4194 

### 🔎 Review hints
1. Run locally `bundle exec pod install`
1. Run GitHub Actions. Also, check if the `Cache cocoapods` step works.

