### PR TITLE
Upload macOS app installers as artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,9 +92,14 @@ jobs:
         export "APPLE_APPID_PASSWORD=${{ secrets.MACOS_APPID_PASSWORD }}"
         bash ./dist/osx/build.sh notarize
     - name: Compose dmg
-      if: github.event_name == 'release'
       run: |
         bash ./dist/osx/build.sh dmg
+    - name: Upload artifacts to GitHub
+      if: github.event_name != 'release'
+      uses: actions/upload-artifact@v2
+      with:
+        name: TogglDesktop.dmg
+        path: "${{ env.installer }}"
     - name: Update Appcast
       if: github.event_name == 'release'
       run: |


### PR DESCRIPTION
### 📒 Description
Upload macOS app installers as artifacts

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
 - [x] Compose dmg without notarization and upload it as an artifact on every non-release build

### 👫 Relationships
Closes #4219 

### 🔎 Review hints
Look into the artifacts from this PR's build. Take the .dmg, install the app, verify that it can be installed and it works.
