### PR TITLE
Sync: Check if WS is premium for each individual item

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -6537,8 +6537,12 @@ error Context::syncHandleResponse(Json::Value &array, const std::vector<T*> &sou
                     }
 
                     model->LoadFromJSON(i["payload"]["result"], isUsingSyncServer());
-                    model->ClearDirty();
                     model->ClearUnsynced();
+                    error err = save(false);
+                    if (err != noError) {
+                        displayError(err);
+                        return err;
+                    }
                 }
             }
             else if (i["payload"]["result"].isMember("error_message") && i["payload"]["result"]["error_message"].isMember("default_message")) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -6441,7 +6441,10 @@ void Context::syncCollectJSON(Json::Value &array, const std::vector<T*> &source)
         // When removing this, see the SyncPayload method, it relies on returning GUIDs
         syncTranslateGUIDToLocalID(payload);
 
-        if (!payload.isNull()) {
+        // If updating, there always has to be a payload
+        // When creating, it hypothetically doesn't need to be there
+        // Deleting doesn't have any payload at all
+        if (!payload.isNull() || i->SyncType() != "update") {
             item["payload"] = payload;
             item["type"] = i->SyncType();
             item["meta"] = i->SyncMetadata();

--- a/src/context.h
+++ b/src/context.h
@@ -683,7 +683,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pullUserPreferences();
 
     template <typename T>
-    void syncCollectJSON(Json::Value &array, const std::vector<T*> &source, bool isPremium);
+    void syncCollectJSON(Json::Value &array, const std::vector<T*> &source);
     void syncStripPremiumDataFromModelJSON(Json::Value &item);
     void syncTranslateGUIDToLocalID(Json::Value &item);
     template <typename T>

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -15,7 +15,7 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
  public:
-    Project() : BaseModel() {}
+    Project() : BaseModel() { EnsureGUID(); }
 
     Property<std::string> Name { "" };
     Property<std::string> Color { "" };


### PR DESCRIPTION
### 📒 Description
Just determining if we can work with billable flags by looking into the user's workspaces wasn't enough. This will check if the workspace is premium for each individual TE/Project and fix erroneous behavior.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
This was reported on Slack, probably not on GH yet.

### 🔎 Review hints
~~Andrii, just run the app and it should get resolved automatically.~~ Try creating multiple new projects in two different workspaces and assign them to time entries consecutively. For example:
 * Create TE A, B
 * In workspaces X and Y, create projects:
   * X1 for A, 
   * Y1 for A
   * X2 for B
   * Y2 for A (intentional).
 * Assign X1 to B
 * Assign X2 to A
 * Assign Y1 to B
 * Assign Y2 to B

In the end, B should belong to workspace Y and project Y2. A should belong to workspace X and project X2. No errors should occur in the process. 

