### PR TITLE
Sync: Only load last 10 days when starting (lib)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -5404,6 +5404,11 @@ error Context::pullBatchedUserData() {
         if (user_->HasValidSinceDate()) {
             since = user_->Since();
         }
+        else {
+            // just pull the last 10 days on full sync
+            since = time(nullptr) - 10 * 24 * 60 * 60;
+            user_->HasLoadedMore.Set(false);
+        }
     }
 
     if (api_token.empty()) {


### PR DESCRIPTION
### 📒 Description
$subj

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue) 

### 👫 Relationships
Fixes #4242

### 🔎 Review hints
Only the last 10 days should be loaded initially. Loading more should work right again.

