### PR TITLE
Fix bug with SSO linking using Google account

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -294,12 +294,10 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error AsyncLogin(const std::string &email,
                      const std::string &password);
 
-    /// @param ssoConfirmationCode Set if this login call also needs to enable SSO for this user account. Empty by default.
     error Login(
         const std::string &email,
         const std::string &password,
-        const bool isSignup = false,
-        const std::string &ssoConfirmationCode = "");
+        const bool isSignup = false);
 
     error AsyncSignup(
         const std::string &email,
@@ -338,6 +336,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error GetSSOIdentityProvider(const std::string &email);
     error EnableSSO(const std::string &code, const std::string &api_token);
     void LoginSSO(const std::string api_token);
+    void SetNeedEnableSSO(const std::string code);
+    void ResetEnableSSO();
 
     error Logout();
 
@@ -865,6 +865,9 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     bool checkIfSkipPomodoro(TimeEntry *te);
 
     bool isUsingSyncServer() const;
+
+    bool need_enable_SSO;
+    std::string sso_confirmation_code;
 };
 void on_websocket_message(
     void *context,

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1649,23 +1649,24 @@ bool_t toggl_get_identity_provider_sso(void *context, const char_t *email) {
     return toggl::noError == app(context)->GetSSOIdentityProvider(to_string(email));
 }
 
+void toggl_set_need_enable_SSO(void *context, const char_t *code) {
+    std::string _code("");
+    if (code) {
+        _code = to_string(code);
+    }
+    app(context)->SetNeedEnableSSO(_code);
+}
+
+void toggl_reset_enable_SSO(void *context) {
+    app(context)->ResetEnableSSO();
+}
+
 void toggl_login_sso(void *context, const char_t *api_token) {
     std::string token("");
     if (api_token) {
         token = to_string(api_token);
     }
     app(context)->LoginSSO(token);
-}
-
-bool_t toggl_login_sso_link(
-    void *context,
-    const char_t *email,
-    const char_t *password,
-    const char_t *ssoConfirmationCode) {
-    return toggl::noError == app(context)->Login(to_string(email),
-                                                 to_string(password),
-                                                 false,
-                                                 to_string(ssoConfirmationCode));
 }
 
 void toggl_track_timeline_menu_context(void *context, TimelineMenuContextType menuType) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1281,16 +1281,16 @@ extern "C" {
         void *context,
         const char_t *email);
 
+    TOGGL_EXPORT void toggl_set_need_enable_SSO(
+        void *context,
+        const char_t *code);
+
+    TOGGL_EXPORT void toggl_reset_enable_SSO(
+        void *context);
+
     TOGGL_EXPORT void toggl_login_sso(
         void *context,
         const char_t *api_token);
-
-    /// Login user along with enabling/linking SSO account to Toggl account
-    TOGGL_EXPORT bool_t toggl_login_sso_link(
-        void *context,
-        const char_t *email,
-        const char_t *password,
-        const char_t *ssoConfirmationCode);
     
     TOGGL_EXPORT void toggl_track_timeline_menu_context(
         void *context,

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -128,14 +128,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Auth
 
 - (void)loginWithEmail:(NSString *)email password:(NSString *)password;
-
-/// Logs in an existing user with a given email and password.
-/// Additionaly links user's Toggl account with SSO provider using the @c confirmationCode.
-/// @param ssoConfirmation Needed to link existing Toggl account with the SSO provider.
-- (void)loginWithEmail:(NSString *)email password:(NSString *)password andSSOConfirmationCode:(NSString *)ssoConfirmation;
-
 - (void)getSSOIdentityProviderWithEmail:(NSString *) email;
 - (void)loginSSOWithAPIToken:(NSString *) apiToken;
+- (void)setNeedEnableSSOWithCode:(NSString *) code;
+- (void)resetEnableSSO;
 
 #pragma mark - Tracking
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -453,18 +453,24 @@ void *ctx;
     toggl_login_async(ctx, [email UTF8String], [password UTF8String]);
 }
 
-- (void)loginWithEmail:(NSString *)email password:(NSString *)password andSSOConfirmationCode:(NSString *)ssoConfirmation {
-    toggl_login_sso_link(ctx, [email UTF8String], [password UTF8String], [ssoConfirmation UTF8String]);
-}
-
-- (void)getSSOIdentityProviderWithEmail:(NSString *) email
+- (void)getSSOIdentityProviderWithEmail:(NSString *)email
 {
     toggl_get_identity_provider_sso(ctx, [email UTF8String]);
 }
 
-- (void)loginSSOWithAPIToken:(NSString *) apiToken
+- (void)loginSSOWithAPIToken:(NSString *)apiToken
 {
     toggl_login_sso(ctx, [apiToken UTF8String]);
+}
+
+- (void)setNeedEnableSSOWithCode:(NSString *)code
+{
+    toggl_set_need_enable_SSO(ctx, [code UTF8String]);
+}
+
+- (void)resetEnableSSO
+{
+    toggl_reset_enable_SSO(ctx);
 }
 
 @end


### PR DESCRIPTION
### 📒 Description
After login with SSO for the first time, the user needs to link it with the existing Toggl account.
Previously this linking worked only for simple email&pass login. This commit also allows to use Google/Apple login to perform this linking.

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)
May break existing SSO functionality.

### 🤯 List of changes
- Returned back `sso_confirmation_code` and `need_enable_SSO` flag in the `Context` class.
- `LoginViewController` resets those properties when needed

### 🔎 Review hints
SSO needs to be retested again.
Additionally, make sure to try linking SSO with Google/Apple sign in.
