### PR TITLE
Sync: Fix loading of user preferences

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -6396,7 +6396,7 @@ error Context::pullUserPreferences() {
             return error("Failed to load user preferences");
         }
 
-        if (user_->LoadUserPreferencesFromJSON(root)) {
+        if (user_->LoadUserPreferencesFromJSON(root, false)) {
             // Reload list if user preferences
             // have changed (collapse time entries)
             UIElements render;

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -1191,7 +1191,6 @@ error Database::LoadUserByID(
         std::string fullname("");
         std::string email("");
         bool record_timeline(false);
-        bool store_start_and_stop_time(false);
         std::string timeofday_format("");
         std::string duration_format("");
         std::string offline_data("");
@@ -1201,7 +1200,7 @@ error Database::LoadUserByID(
         *session_ <<
                   "select local_id, id, default_wid, since, "
                   "fullname, "
-                  "email, record_timeline, store_start_and_stop_time, "
+                  "email, record_timeline, "
                   "timeofday_format, duration_format, offline_data, "
                   "default_pid, default_tid, collapse_entries "
                   "from users where id = :id limit 1",
@@ -1212,7 +1211,6 @@ error Database::LoadUserByID(
                   into(fullname),
                   into(email),
                   into(record_timeline),
-                  into(store_start_and_stop_time),
                   into(timeofday_format),
                   into(duration_format),
                   into(offline_data),
@@ -1240,7 +1238,6 @@ error Database::LoadUserByID(
         user->SetFullname(fullname);
         user->SetEmail(email);
         user->SetRecordTimeline(record_timeline);
-        user->SetStoreStartAndStopTime(store_start_and_stop_time);
         user->SetTimeOfDayFormat(timeofday_format);
         user->SetDurationFormat(duration_format);
         user->SetOfflineData(offline_data);
@@ -3391,8 +3388,6 @@ error Database::SaveUser(
                           "default_wid = :default_wid, "
                           "since = :since, id = :id, fullname = :fullname, "
                           "email = :email, record_timeline = :record_timeline, "
-                          "store_start_and_stop_time = "
-                          " :store_start_and_stop_time, "
                           "timeofday_format = :timeofday_format, "
                           "duration_format = :duration_format, "
                           "offline_data = :offline_data, "
@@ -3406,7 +3401,6 @@ error Database::SaveUser(
                           useRef(user->Fullname()),
                           useRef(user->Email()),
                           useRef(user->RecordTimeline()),
-                          useRef(user->StoreStartAndStopTime()),
                           useRef(user->TimeOfDayFormat()),
                           useRef(user->DurationFormat()),
                           useRef(user->OfflineData()),
@@ -3427,13 +3421,13 @@ error Database::SaveUser(
                 *session_ <<
                           "insert into users("
                           "id, default_wid, since, fullname, email, "
-                          "record_timeline, store_start_and_stop_time, "
+                          "record_timeline, "
                           "timeofday_format, duration_format, offline_data, "
                           "default_pid, default_tid"
                           ") values("
                           ":id, :default_wid, :since, :fullname, "
                           ":email, "
-                          ":record_timeline, :store_start_and_stop_time, "
+                          ":record_timeline, "
                           ":timeofday_format, :duration_format, :offline_data, "
                           ":default_pid, :default_tid"
                           ")",
@@ -3443,7 +3437,6 @@ error Database::SaveUser(
                           useRef(user->Fullname()),
                           useRef(user->Email()),
                           useRef(user->RecordTimeline()),
-                          useRef(user->StoreStartAndStopTime()),
                           useRef(user->TimeOfDayFormat()),
                           useRef(user->DurationFormat()),
                           useRef(user->OfflineData()),

--- a/src/database/migrations.cc
+++ b/src/database/migrations.cc
@@ -665,6 +665,9 @@ error Migrations::migrateUsers() {
         return err;
     }
 
+    // TODO when modifying the structure of this table, drop the store_start_and_stop_time,
+    // it's been removed from the class altogether -- martin
+
     return err;
 }
 

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -405,11 +405,6 @@ void User::SetOfflineData(const std::string &value) {
         SetDirty();
 }
 
-void User::SetStoreStartAndStopTime(bool value) {
-    if (StoreStartAndStopTime.Set(value))
-        SetDirty();
-}
-
 void User::ConfirmLoadedMore() {
     HasLoadedMore.Set(true);
 }
@@ -877,7 +872,6 @@ error User::loadUserFromJSON(const Json::Value &data) {
     SetEmail(data["email"].asString());
     SetFullname(data["fullname"].asString());
     SetRecordTimeline(data["record_timeline"].asBool());
-    SetStoreStartAndStopTime(data["store_start_and_stop_time"].asBool());
     SetTimeOfDayFormat(data["timeofday_format"].asString());
     SetDurationFormat(data["duration_format"].asString());
 

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -850,6 +850,7 @@ void User::LoadUserAndRelatedDataFromJSON(
 
     // user is contained in Sync API but it is in root of data in v8
     error err = loadUserFromJSON(syncApi ? data["user"] : data);
+    LoadUserPreferencesFromJSON(syncApi ? data["preferences"] : data, true);
     // other entities are contained about the same
     if (err == noError) {
         loadRelatedDataFromJSON(data, including_related_data, syncServer);
@@ -871,9 +872,6 @@ error User::loadUserFromJSON(const Json::Value &data) {
     SetAPIToken(data["api_token"].asString());
     SetEmail(data["email"].asString());
     SetFullname(data["fullname"].asString());
-    SetRecordTimeline(data["record_timeline"].asBool());
-    SetTimeOfDayFormat(data["timeofday_format"].asString());
-    SetDurationFormat(data["duration_format"].asString());
 
     return noError;
 }
@@ -1194,13 +1192,24 @@ void User::loadUserTimeEntryFromJSON(
     model->EnsureGUID();
 }
 
+// returns true if the CollapseTimeEntries property has changed (to reload UI)
 bool User::LoadUserPreferencesFromJSON(
-    Json::Value data) {
-    if (data.isMember("CollapseTimeEntries")
+    const Json::Value &data,
+    bool excludeCollapseTimeEntries) {
+    if (data.isMember("record_timeline"))
+        SetRecordTimeline(data["record_timeline"].asBool());
+    if (data.isMember("timeofday_format"))
+        SetTimeOfDayFormat(data["timeofday_format"].asString());
+    if (data.isMember("duration_format"))
+        SetDurationFormat(data["duration_format"].asString());
+
+    if (!excludeCollapseTimeEntries
+            && data.isMember("CollapseTimeEntries")
             && data["CollapseTimeEntries"].asBool() != CollapseEntries()) {
         SetCollapseEntries(data["CollapseTimeEntries"].asBool());
         return true;
     }
+
     return false;
 }
 

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -37,7 +37,6 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     // Unix timestamp of the user data; returned from API
     Property<Poco::Int64> Since { 0 };
     Property<bool> RecordTimeline { false };
-    Property<bool> StoreStartAndStopTime { false };
 
     Property<bool> HasLoadedMore { false };
     Property<bool> CollapseEntries { false };
@@ -56,7 +55,6 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     // Unix timestamp of the user data; returned from API
     void SetSince(Poco::Int64 value);
     void SetRecordTimeline(bool value);
-    void SetStoreStartAndStopTime(bool value);
     void ConfirmLoadedMore();
     void SetCollapseEntries(bool value);
 

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -162,8 +162,10 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     void LoadObmExperiments(Json::Value const &obm);
 
+    // excludeCollapseTimeEntries should be removed when getting rid of Context::pullUserPreferences
     bool LoadUserPreferencesFromJSON(
-        Json::Value data);
+        const Json::Value &data,
+        bool excludeCollapseTimeEntries);
 
     template <class T>
     bool SetModelID(

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -450,26 +450,12 @@ TEST(Database, SavesAndLoadsUserFields) {
     ASSERT_EQ(noError,
               user.LoadUserAndRelatedDataFromJSONString(loadTestData(), true, false));
 
-    ASSERT_TRUE(user.StoreStartAndStopTime());
-    // Change fields
-    user.SetStoreStartAndStopTime(false);
-
     std::vector<ModelChange> changes;
     ASSERT_EQ(noError, db.instance()->SaveUser(&user, true, &changes));
 
     // Load user into another instance
     User user2;
     ASSERT_EQ(noError, db.instance()->LoadUserByID(user.ID(), &user2));
-    ASSERT_FALSE(user2.StoreStartAndStopTime());
-
-    // Change fields, again
-    user.SetStoreStartAndStopTime(true);
-    ASSERT_EQ(noError, db.instance()->SaveUser(&user, true, &changes));
-
-    // Load user into another instance
-    User user3;
-    ASSERT_EQ(noError, db.instance()->LoadUserByID(user.ID(), &user3));
-    ASSERT_TRUE(user3.StoreStartAndStopTime());
 }
 
 TEST(Database, SavesAndLoadsObmExperiments) {


### PR DESCRIPTION
### 📒 Description
In Sync, the user preference JSON is split from the user and put in the "preferences" part of the server response. This PR fixes handling this by moving preference parsing to `User::LoadUserPreferencesFromJSON`. 
The same method is used in `Context::pullUserPreferences` which is then in turn used when logging in and when syncing.
It's probably not necessary to have it there in the future but for the sake of keeping the same behavior before we get rid of legacy sync and that a UI reload depends on it, I'm keeping it in place for now.

Also, as a part of fixing this, I noticed the `User::StoreStartAndStopTime` property is not used anywhere, so I got rid of it. It's still present in the `users` database table but SQLite doesn't support column drops so I just left it there, it doesn't feel like a big burden. I left a small note there for anybody who's modifying the table in the future that they can drop it.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Fixes #4254 

### 🔎 Review hints
When using both sync and legacy protocols, the following properties should be handled right:
 * `RecordTimeline`
 * `TimeOfDayFormat`
 * `DurationFormat`
 * `CollapseTimeEntries`

