### PR TITLE
Add drag-to-create TE action on Timeline (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Models/TimelineData.swift
@@ -45,7 +45,7 @@ final class TimelineData {
     ///   - cmd: TimelineDisplayCommand from Objc
     ///   - zoomLevel: Zoom Level
     ///   - runningTimeEntry: Running Time Entry
-    init(cmd: TimelineDisplayCommand, zoomLevel: TimelineDatasource.ZoomLevel, runningTimeEntry: TimeEntryViewItem?) {
+    init(cmd: TimelineDisplayCommand, zoomLevel: TimelineDatasource.ZoomLevel, runningTimeEntry: TimeEntryViewItem?, dragCreatedTimeEntry: TimelineTimeEntryPlaceholder? = nil) {
         self.zoomLevel = zoomLevel
         self.start = cmd.start
         self.end = cmd.end
@@ -57,8 +57,13 @@ final class TimelineData {
             timeEntries.append(runningTimeEntry)
         }
 
+        self.timeEntries = timeEntries.map { TimelineTimeEntry($0) }
+        if let entry = dragCreatedTimeEntry {
+            self.timeEntries.append(entry)
+        }
+
         // Sort
-        self.timeEntries = timeEntries.map { TimelineTimeEntry($0) }.sorted(by: { (lhs, rhs) -> Bool in
+        self.timeEntries = self.timeEntries.sorted(by: { (lhs, rhs) -> Bool in
             return lhs.start < rhs.start
         })
         numberOfSections = Section.allCases.count

--- a/src/ui/osx/TogglDesktop/Features/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Models/TimelineTimeEntry.swift
@@ -97,7 +97,7 @@ final class TimelineTimeEntry: TimelineBaseTimeEntry {
     /// Small Time Entry has some different configs
     var isSmall: Bool {
         // It's small bar if duration less than 1 min
-        return abs(timeEntry.duration_in_seconds) <= 60
+        return abs(start - end) <= 60
     }
 
     // MARK: Init
@@ -119,11 +119,16 @@ final class TimelineTimeEntry: TimelineBaseTimeEntry {
     // MARK: Public
 
     func isToday() -> Bool {
-        guard let date = timeEntry.ended else { return false }
+        let date = Date(timeIntervalSince1970: end)
         return Calendar.current.isDateInToday(date)
     }
 
     func updateEndTimeForRunning() {
         end = Date().timeIntervalSince1970
     }
+}
+
+/// Simple item to represent simple placeholder view in place where the time entry will be placed later.
+/// For example, used to show a view when user is creating entry with dragging action.
+final class TimelineTimeEntryPlaceholder: TimelineBaseTimeEntry {
 }

--- a/src/ui/osx/TogglDesktop/Features/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/TimelineFlowLayout.swift
@@ -224,6 +224,7 @@ extension TimelineFlowLayout {
         return (Constants.TimeLabel.Size.height + verticalPaddingTimeLabel) / CGFloat(zoomLevel.span)
     }
 
+    /// Returns timestamp from a click point, depending on a zoom level and position
     public func convertTimestamp(from location: CGPoint) -> TimeInterval {
         let beginDay = Date.startOfDay(from: currentDate.timeIntervalSince1970)
         let start = TimeInterval((location.y / ratio)) + beginDay

--- a/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineBaseCell.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineBaseCell.swift
@@ -18,8 +18,6 @@ protocol TimelineBaseCellDelegate: class {
     func timelineCellOpenEditor(_ sender: TimelineBaseCell)
 }
 
-/// Parent cellof the Timeline Time Entry Cell
-/// TODO: Remove this class, since there is only one subclass
 class TimelineBaseCell: NSCollectionViewItem {
 
     private struct Constants {
@@ -51,6 +49,12 @@ class TimelineBaseCell: NSCollectionViewItem {
     private(set) var backgroundColor: NSColor?
     var isResizable: Bool { return false }
     var isHoverable: Bool { return false }
+
+    /// Determine if the size of the Time Entry is small
+    /// It's essential to reduce the radius corner
+    var isSmallSize: Bool {
+        return view.frame.height <= 10
+    }
 
     // Resizable tracker
     private var mousePosition = MousePosition.none { didSet { updateCursor() }}
@@ -97,7 +101,7 @@ class TimelineBaseCell: NSCollectionViewItem {
     /// - Parameters:
     ///   - foregroundColor: Foreground Color
     ///   - isSmallEntry: isSmallEntry
-    func renderColor(with foregroundColor: NSColor, isSmallEntry: Bool) {
+    func renderColor(with foregroundColor: NSColor) {
         let adaptiveColor = foregroundColor.getAdaptiveColorForShape()
         backgroundColor = adaptiveColor.lighten(by: 0.2)
 
@@ -106,7 +110,7 @@ class TimelineBaseCell: NSCollectionViewItem {
         backgroundBox?.borderColor = backgroundColor ?? adaptiveColor
 
         // Find the suitable corner radius
-        let cornerRadius = TimelineBaseCell.suitableCornerRadius(isSmallEntry, height: view.frame.height)
+        let cornerRadius = TimelineBaseCell.suitableCornerRadius(isSmallSize, height: view.frame.height)
         foregroundBox.cornerRadius = cornerRadius
         backgroundBox?.cornerRadius = cornerRadius
     }

--- a/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryCell.swift
@@ -30,12 +30,6 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     private(set) var timeEntry: TimelineTimeEntry!
     private lazy var timeEntryMenu = TimelineTimeEntryMenu()
 
-    /// Determine if the size of the Time Entry is small
-    /// It's essential to reduce the radius corner
-    private var isSmallSize: Bool {
-        return view.frame.height <= 10
-    }
-
     /// The view that the NSPopover should be presents
     var popoverView: NSView {
         if isSmallSize {
@@ -89,7 +83,7 @@ final class TimelineTimeEntryCell: TimelineBaseCell {
     /// - Parameter timeEntry: Current Time Entry
     func config(for timeEntry: TimelineTimeEntry) {
         self.timeEntry = timeEntry
-        renderColor(with: timeEntry.color, isSmallEntry: timeEntry.isSmall)
+        renderColor(with: timeEntry.color)
         populateInfo()
         handleRunningTimeEntry()
     }

--- a/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryPlaceholderCell.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryPlaceholderCell.swift
@@ -1,0 +1,25 @@
+//
+//  TimelineTimeEntryPlaceholderCell.swift
+//  TogglDesktop
+//
+//  Created by Andrew Nester on 23.06.2020.
+//  Copyright © 2020 Alari. All rights reserved.
+//
+
+import Cocoa
+
+class TimelineTimeEntryPlaceholderCell: TimelineBaseCell {
+    @IBOutlet weak var placeholderLabel: NSTextField!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        placeholderLabel.stringValue = NSLocalizedString("New entry",
+                                                         comment: "Placeholder text to show when dragg-creating new Time Entry")
+    }
+
+    override func viewWillAppear() {
+        super.viewDidAppear()
+        renderColor(with: TimeEntryViewItem.defaultProjectColor())
+    }
+}

--- a/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryPlaceholderCell.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryPlaceholderCell.xib
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="TimelineTimeEntryPlaceholderCell" customModule="TogglDesktop" customModuleProvider="target"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="200" height="120"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="wlA-Jb-0cb" customClass="CornerBoxView" customModule="TogglDesktop" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="200" height="120"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="0.0"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                            <color key="value" name="timeline-background-color"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </customView>
+                <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="U1Q-Ej-cVI" customClass="CornerBoxView" customModule="TogglDesktop" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="200" height="120"/>
+                    <subviews>
+                        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sgG-mk-OCF">
+                            <rect key="frame" x="30" y="101" width="170" height="15"/>
+                            <subviews>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="k5r-l6-xWv" userLabel="Placeholder text">
+                                    <rect key="frame" x="-2" y="0.0" width="89" height="15"/>
+                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" title="No Description" id="UTS-5M-sr1">
+                                        <font key="font" metaFont="label" size="12"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                            </subviews>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="sgG-mk-OCF" secondAttribute="trailing" id="1eU-b1-bRH"/>
+                        <constraint firstItem="sgG-mk-OCF" firstAttribute="top" secondItem="U1Q-Ej-cVI" secondAttribute="top" constant="4" id="Loe-wm-cVI"/>
+                        <constraint firstItem="sgG-mk-OCF" firstAttribute="leading" secondItem="U1Q-Ej-cVI" secondAttribute="leading" constant="30" id="w9I-VI-Rps"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                            <color key="value" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                            <color key="value" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </customView>
+                <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1HQ-4a-ckZ" customClass="CornerBoxView" customModule="TogglDesktop" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="20" height="120"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="20" id="8xQ-vF-Qed"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="0.0"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                            <color key="value" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </customView>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="1HQ-4a-ckZ" secondAttribute="bottom" id="0oN-BX-BCm"/>
+                <constraint firstItem="wlA-Jb-0cb" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="FXn-gE-lMk"/>
+                <constraint firstAttribute="bottom" secondItem="U1Q-Ej-cVI" secondAttribute="bottom" id="LdD-9O-tli"/>
+                <constraint firstItem="1HQ-4a-ckZ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="MyJ-vR-M6e"/>
+                <constraint firstItem="1HQ-4a-ckZ" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="NRW-Z6-rTW"/>
+                <constraint firstItem="U1Q-Ej-cVI" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="OAg-RN-Tbq"/>
+                <constraint firstItem="wlA-Jb-0cb" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="gQp-vS-zsS"/>
+                <constraint firstItem="U1Q-Ej-cVI" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="iZK-bh-Lov"/>
+                <constraint firstAttribute="trailing" secondItem="wlA-Jb-0cb" secondAttribute="trailing" id="mnb-tn-mkU"/>
+                <constraint firstAttribute="bottom" secondItem="wlA-Jb-0cb" secondAttribute="bottom" id="nne-hb-e8h"/>
+                <constraint firstAttribute="trailing" secondItem="U1Q-Ej-cVI" secondAttribute="trailing" id="ysB-cU-u2l"/>
+            </constraints>
+            <point key="canvasLocation" x="139" y="154"/>
+        </customView>
+        <collectionViewItem identifier="TimelineTimeEntryPlaceholderCell" id="IF3-sB-61S" customClass="TimelineTimeEntryPlaceholderCell" customModule="TogglDesktop" customModuleProvider="target">
+            <connections>
+                <outlet property="backgroundBox" destination="U1Q-Ej-cVI" id="6VX-cE-YtX"/>
+                <outlet property="foregroundBox" destination="1HQ-4a-ckZ" id="bkD-9W-fpL"/>
+                <outlet property="placeholderLabel" destination="k5r-l6-xWv" id="VdS-co-kBA"/>
+                <outlet property="view" destination="Hz6-mo-xeY" id="jva-7u-gci"/>
+            </connections>
+        </collectionViewItem>
+    </objects>
+    <resources>
+        <namedColor name="timeline-background-color">
+            <color red="0.98039215686274506" green="0.98431372549019602" blue="0.9882352941176471" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -28,6 +28,10 @@
 		4917325824C06BA3003EE7CC /* cacert.pem in Resources */ = {isa = PBXBuildFile; fileRef = 4917325624C06BA3003EE7CC /* cacert.pem */; };
 		4917325E24C06F6F003EE7CC /* TogglDesktopLibrary.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4917325D24C06F6F003EE7CC /* TogglDesktopLibrary.dylib */; };
 		4917325F24C06F6F003EE7CC /* TogglDesktopLibrary.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4917325D24C06F6F003EE7CC /* TogglDesktopLibrary.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4921BE2024C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4921BE1E24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift */; };
+		4921BE2124C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4921BE1F24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib */; };
+		4921BE2224C87136006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4921BE1F24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib */; };
+		4921BE2324C87136006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4921BE1E24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift */; };
 		492F5F02248550F800FFEC70 /* TimelineInitialDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492F5F01248550F800FFEC70 /* TimelineInitialDateProvider.swift */; };
 		49418B4B249CEBA300265665 /* TogglDesktopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D3603A24878FA000527DE8 /* TogglDesktopTests.swift */; };
 		4943FB6124C070010000DE3C /* TogglDesktopLibrary.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4943FB5C24C06F8B0000DE3C /* TogglDesktopLibrary.dylib */; };
@@ -715,6 +719,8 @@
 		4917325524C069DD003EE7CC /* const.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = const.h; path = ../../../../const.h; sourceTree = "<group>"; };
 		4917325624C06BA3003EE7CC /* cacert.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = cacert.pem; path = ../../../../ssl/cacert.pem; sourceTree = "<group>"; };
 		4917325D24C06F6F003EE7CC /* TogglDesktopLibrary.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = TogglDesktopLibrary.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		4921BE1E24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineTimeEntryPlaceholderCell.swift; sourceTree = "<group>"; };
+		4921BE1F24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TimelineTimeEntryPlaceholderCell.xib; sourceTree = "<group>"; };
 		492F5F01248550F800FFEC70 /* TimelineInitialDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineInitialDateProvider.swift; sourceTree = "<group>"; };
 		49418B40249CE77D00265665 /* TogglDesktopTests-AppStore.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TogglDesktopTests-AppStore.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49418B44249CE77D00265665 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1877,6 +1883,8 @@
 				BA75FF2222BCC1EA00D3F08C /* TimelineTimeLabelCell.xib */,
 				BA75FF2522BCC1FC00D3F08C /* TimelineTimeEntryCell.swift */,
 				BA75FF2622BCC1FC00D3F08C /* TimelineTimeEntryCell.xib */,
+				4921BE1E24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift */,
+				4921BE1F24C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib */,
 				BAA0104D22CB66D0007C1541 /* TimelineEmptyTimeEntryCell.swift */,
 				BAA0104E22CB66D0007C1541 /* TimelineEmptyTimeEntryCell.xib */,
 				BA75FF2922BCC20D00D3F08C /* TimelineActivityCell.swift */,
@@ -2299,6 +2307,7 @@
 				BAE007DE21FAF00D00404379 /* Media.xcassets in Resources */,
 				C5DA1FC517F1B38B001C4565 /* LoginViewController.xib in Resources */,
 				69FC180517E6534400B96425 /* Credits.rtf in Resources */,
+				4921BE2124C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib in Resources */,
 				BAB5FFD723F15A65003781D3 /* TimelineBackgroundCell.xib in Resources */,
 				BAAF56A42223E19C003D0D73 /* TimeDecoratorView.xib in Resources */,
 				BA5E988F23BF4A6E0089A2C7 /* TimelineActivityRecorderViewController.xib in Resources */,
@@ -2366,6 +2375,7 @@
 				BA37ACE123D8900C0013EE26 /* TimelineActivityHoverController.xib in Resources */,
 				BAE64E172368334000244D2B /* TimeDecoratorView.xib in Resources */,
 				BAE64E182368334000244D2B /* FeedbackWindowController.xib in Resources */,
+				4921BE2224C87136006E8BB5 /* TimelineTimeEntryPlaceholderCell.xib in Resources */,
 				BAE64E192368334000244D2B /* IdleNotificationWindowController.xib in Resources */,
 				BAE64E1A2368334000244D2B /* WorkspaceCellView.xib in Resources */,
 				BAE64E1B2368334000244D2B /* MainMenu.xib in Resources */,
@@ -2896,6 +2906,7 @@
 				BA712EC221BF907200A2D8DD /* UndoManager.swift in Sources */,
 				BAA11AC12251F49E007F31D2 /* WorkspaceStorage.swift in Sources */,
 				3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */,
+				4921BE2024C8705C006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift in Sources */,
 				BA45AAF623FBEED4000C94C0 /* CornerBoxView.swift in Sources */,
 				BA13E576243476FA005244AD /* OnboardingViewController.swift in Sources */,
 				BA13D2062269B7C400EB3833 /* CalendarViewController.swift in Sources */,
@@ -3113,6 +3124,7 @@
 				BAE64DC22368334000244D2B /* WorkspaceStorage.swift in Sources */,
 				BAE64DC32368334000244D2B /* CountryViewItem.m in Sources */,
 				BAE64DC42368334000244D2B /* CalendarViewController.swift in Sources */,
+				4921BE2324C87136006E8BB5 /* TimelineTimeEntryPlaceholderCell.swift in Sources */,
 				BA37ACBE23D890050013EE26 /* LayerBackedViewController.swift in Sources */,
 				BAF9364D23E8114800EE1076 /* TimelineResizeHoverController.swift in Sources */,
 				BAE64DC62368334000244D2B /* SystemService.m in Sources */,


### PR DESCRIPTION
### 📒 Description
This PR adds a new way of creating time entries - users can click and drag to create an entry. It allows creating TEs with the correct size without needing to change the duration in edit popup.
![drag-to-create-short](https://user-images.githubusercontent.com/3470113/88182068-669cac00-cc38-11ea-87d8-7686db2fd12e.gif)

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
100% Swift changes

### 👫 Relationships
Closes #3832 

### 🔎 Review hints
Just play with the feature. Test if other Timeline features are still working.