### PR TITLE
Fix "Show dock icon" settings behaviour (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/App/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/App/AppDelegate.m
@@ -244,8 +244,6 @@ void *ctx;
 		 if ([[NSApplication sharedApplication] isActive] && [strongSelf.mainWindowController.window isVisible])
 		 {
 			 [self.mainWindowController.window close];
-             [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
-             [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 		 }
 		 else
 		 {


### PR DESCRIPTION
### 📒 Description
Fixed bug when in preferences, the "Show dock icon" option is turned off but the Toggl still appears in the Dock.
Also if a user has a global shortcut to show/hide the app and quickly press it many times, the app icon could be duplicated.
See Issue #4117 for more details about the bug.

To fix the bug, removed two lines that were called on the show/hide global shortcut. The documentation doesn't explain why they are there, but they're definitely causing the issues.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4117 

### 🔎 Review hints
- Test the "Show dock icon" option
- Check if no side effects are present when using show/hide global shortcut (or menu item)

Please also:
[] Test on old macOS version (I could not do it because haven't set it up yet)
