### PR TITLE
Fix bug with description cleared while user typing

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/EditorViewController.swift
@@ -272,8 +272,8 @@ extension EditorViewController {
         projectTextField.setTimeEntry(timeEntry)
         calendarViewControler.prepareLayout(with: timeEntry.started)
 
-        // Update description with condition to prevent lossing text
-        if !(oldValue?.guid == timeEntry.guid && descriptionTextField.currentEditor() != nil) || !timeEntry.isRunning() {
+        // do not update description if user is editing but update if it's first `fillData()` call
+        if descriptionTextField.currentEditor() == nil || oldValue == nil {
             descriptionTextField.stringValue = timeEntry.descriptionName
         }
 


### PR DESCRIPTION
### 📒 Description
On Edit popup when a user was editing not running TE, the app was force-updating description field once a response from BE is received.

Removed `!timeEntry.isRunning()` condition to fix this. It was added to fix a bug with autocomplete but I cannot reproduce it, so I suppose this condition is not needed now.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4217

### 🔎 Review hints
Before the fix this issue was easily reproduced:
1. Open edit popup for non-running TE
1. Focus on desc field -> type new name
1. Focus next field but quickly go back to desc and edit it
1. App will receive the response from BE about the first edit and update desc text to the previous one

Test:
- Test flow above 
- Test if there're no regression issues with autocomplete for the description field
- Test any other flow to break the description field
