### PR TITLE
Disable copy constructors for all models except Settings and TimeEntry

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -538,7 +538,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error CreateCompressedTimelineBatchForUpload(TimelineBatch *batch) override;
     error StartTimelineEvent(TimelineEvent *event) override;
     error MarkTimelineBatchAsUploaded(
-        const std::vector<TimelineEvent> &events) override;
+        const std::vector<const TimelineEvent*> &events) override;
 
     error SetPromotionResponse(
         const int64_t promotion_type,

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -449,9 +449,8 @@ void GUI::DisplayTimeEntryList(const bool open,
     logger.debug("DisplayTimeEntryList done in ", stopwatch.elapsed() / 1000, " ms");
 }
 
-void GUI::DisplayTimeline(
-    const bool open,
-    const std::vector<TimelineEvent> list,
+void GUI::DisplayTimeline(const bool open,
+    const std::vector<const TimelineEvent *> list,
     const std::vector<view::TimeEntry> &entries_list) {
 
     if (!on_display_timeline_) {
@@ -497,14 +496,14 @@ void GUI::DisplayTimeline(
         // Attach matching events to chunk
         TogglTimelineEventView *first_event = nullptr;
         TogglTimelineEventView *ev = nullptr;
-        for (std::vector<TimelineEvent>::const_iterator it = list.begin();
+        for (std::vector<const TimelineEvent*>::const_iterator it = list.begin();
                 it != list.end(); it++) {
-            const TimelineEvent event = *it;
+            const TimelineEvent *event = *it;
 
             // Calculate the start time of the chunk
             // that fits this timeline event
             time_t chunk_start_time =
-                (event.Start() / kTimelineChunkSeconds)
+                (event->Start() / kTimelineChunkSeconds)
                 * kTimelineChunkSeconds;
 
             if (epoch_time != chunk_start_time) {
@@ -518,14 +517,14 @@ void GUI::DisplayTimeline(
             bool item_present = false;
             TogglTimelineEventView *event_app = first_event;
             while (event_app) {
-                if (compare_string(event_app->Filename, to_char_t(event.Filename())) == 0) {
-                    timeline_event_view_update_duration(event_app, event_app->Duration + event.Duration());
+                if (compare_string(event_app->Filename, to_char_t(event->Filename())) == 0) {
+                    timeline_event_view_update_duration(event_app, event_app->Duration + event->Duration());
                     app_present = true;
                     item_present = false;
                     ev = reinterpret_cast<TogglTimelineEventView *>(event_app->Event);
                     while (ev) {
-                        if (compare_string(ev->Title, to_char_t(event.Title())) == 0) {
-                            timeline_event_view_update_duration(ev, ev->Duration + event.Duration());
+                        if (compare_string(ev->Title, to_char_t(event->Title())) == 0) {
+                            timeline_event_view_update_duration(ev, ev->Duration + event->Duration());
                             item_present = true;
                         }
                         ev = reinterpret_cast<TogglTimelineEventView *>(ev->Next);
@@ -542,7 +541,7 @@ void GUI::DisplayTimeline(
 
             if (!app_present) {
                 TogglTimelineEventView *app_event_view = timeline_event_view_init(event);
-                if (event.Duration() > 0) {
+                if (event->Duration() > 0) {
                     app_event_view->Header = true;
                     if (app_event_view->Title) {
                         free(app_event_view->Title);

--- a/src/gui.h
+++ b/src/gui.h
@@ -444,7 +444,7 @@ class TOGGL_INTERNAL_EXPORT GUI : public SyncStateMonitor {
 
     void DisplayTimeline(
         const bool open,
-        const std::vector<TimelineEvent> list,
+        const std::vector<const TimelineEvent*> list,
         const std::vector<view::TimeEntry> &entries_list);
 
     TogglTimelineEventView* SortList(TogglTimelineEventView *head);

--- a/src/model/autotracker.h
+++ b/src/model/autotracker.h
@@ -17,6 +17,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT AutotrackerRule : public BaseModel {
  public:
     AutotrackerRule() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    AutotrackerRule(const AutotrackerRule &o) = delete;
+    AutotrackerRule &operator=(const AutotrackerRule &o) = delete;
     virtual ~AutotrackerRule() {}
 
     Property<std::string> Term { "" };

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -23,6 +23,7 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT BaseModel {
  public:
     BaseModel() {}
+    // The copy constructor expect the copy to be stored in the database - no ID is copied and the copy is marked as dirty
     BaseModel(const BaseModel &o);
     virtual ~BaseModel() {}
 

--- a/src/model/client.h
+++ b/src/model/client.h
@@ -18,6 +18,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT Client : public BaseModel {
  public:
     Client() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    Client(const Client &o) = delete;
+    Client &operator=(const Client &o) = delete;
 
     Property<Poco::UInt64> WID { 0 };
     Property<std::string> Name { "" };

--- a/src/model/obm_action.h
+++ b/src/model/obm_action.h
@@ -16,6 +16,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
  public:
     ObmAction() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    ObmAction(const ObmAction &o) = delete;
+    ObmAction &operator=(const ObmAction &o) = delete;
 
     Property<Poco::UInt64> ExperimentID { 0 };
     Property<std::string> Key { "" };
@@ -35,6 +38,9 @@ class TOGGL_INTERNAL_EXPORT ObmAction : public BaseModel {
 class TOGGL_INTERNAL_EXPORT ObmExperiment : public BaseModel {
  public:
     ObmExperiment() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    ObmExperiment(const ObmExperiment &o) = delete;
+    ObmExperiment &operator=(const ObmExperiment &o) = delete;
 
     Property<std::string> Actions { "" };
     Property<Poco::UInt64> Nr { 0 };

--- a/src/model/project.h
+++ b/src/model/project.h
@@ -16,6 +16,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT Project : public BaseModel {
  public:
     Project() : BaseModel() { EnsureGUID(); }
+    // Before undeleting, see how the copy constructor in BaseModel works
+    Project(const Project &o) = delete;
+    Project &operator=(const Project &o) = delete;
 
     Property<std::string> Name { "" };
     Property<std::string> Color { "" };

--- a/src/model/tag.h
+++ b/src/model/tag.h
@@ -14,6 +14,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT Tag : public BaseModel {
  public:
     Tag() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    Tag(const Tag &o) = delete;
+    Tag &operator=(const Tag &o) = delete;
 
     Property<std::string> Name { "" };
     Property<Poco::UInt64> WID { 0 };

--- a/src/model/task.h
+++ b/src/model/task.h
@@ -16,6 +16,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT Task : public BaseModel {
  public:
     Task() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    Task(const Task &o) = delete;
+    Task &operator=(const Task &o) = delete;
 
     Property<std::string> Name { "" };
     Property<Poco::UInt64> WID { 0 };

--- a/src/model/timeline_event.h
+++ b/src/model/timeline_event.h
@@ -16,6 +16,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT TimelineEvent : public BaseModel, public TimedEvent {
  public:
     TimelineEvent() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    TimelineEvent(const TimelineEvent &o) = delete;
+    TimelineEvent &operator=(const TimelineEvent &o) = delete;
     virtual ~TimelineEvent() {}
 
     Property<std::string> Title { "" };

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -1398,15 +1398,14 @@ bool User::CanSeeBillable(
 }
 
 void User::MarkTimelineBatchAsUploaded(
-    const std::vector<TimelineEvent> &events) {
+    const std::vector<const TimelineEvent*> &events) {
 
-    for (std::vector<TimelineEvent>::const_iterator i = events.begin();
+    for (std::vector<const TimelineEvent*>::const_iterator i = events.begin();
             i != events.end();
             ++i) {
-        TimelineEvent event = *i;
-        TimelineEvent *uploaded = related.TimelineEventByGUID(event.GUID());
+        TimelineEvent *uploaded = related.TimelineEventByGUID((*i)->GUID());
         if (!uploaded) {
-            logger().error("Could not find timeline event to mark it as uploaded: ", event.String());
+            logger().error("Could not find timeline event to mark it as uploaded: ", (*i)->String());
             continue;
         }
         uploaded->SetUploaded(true);
@@ -1509,21 +1508,21 @@ void User::CompressTimeline() {
                    related.TimelineEvents.size(), " compressed into ", compressed.size(), " chunks");
 }
 
-std::vector<TimelineEvent> User::CompressedTimelineForUI(const Poco::LocalDateTime *date) const {
+std::vector<const TimelineEvent*> User::CompressedTimelineForUI(const Poco::LocalDateTime *date) const {
     return CompressedTimeline(date, false);
 }
 
-std::vector<TimelineEvent> User::CompressedTimelineForUpload(const Poco::LocalDateTime *date) const {
+std::vector<const TimelineEvent*> User::CompressedTimelineForUpload(const Poco::LocalDateTime *date) const {
     return CompressedTimeline(date, true);
 }
 
-std::vector<TimelineEvent> User::CompressedTimeline(const Poco::LocalDateTime *date, bool is_for_upload) const {
-    std::vector<TimelineEvent> list;
+std::vector<const TimelineEvent*> User::CompressedTimeline(const Poco::LocalDateTime *date, bool is_for_upload) const {
+    std::vector<const TimelineEvent*> list;
     for (std::vector<TimelineEvent *>::const_iterator i =
         related.TimelineEvents.begin();
             i != related.TimelineEvents.end();
             ++i) {
-        TimelineEvent *event = *i;
+        const TimelineEvent *event = *i;
         poco_check_ptr(event);
 
         // Skip if this event is deleted or uploaded
@@ -1547,7 +1546,7 @@ std::vector<TimelineEvent> User::CompressedTimeline(const Poco::LocalDateTime *d
             }
         }
         // Make a copy of the timeline event
-        list.push_back(*event);
+        list.push_back(event);
     }
     return list;
 }

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -23,6 +23,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT User : public BaseModel {
  public:
     User() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    User(const User &o) = delete;
+    User &operator=(const User &o) = delete;
     ~User();
 
     Property<std::string> APIToken { "" };
@@ -150,11 +153,11 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     error SetAPITokenFromOfflineData(const std::string &password);
 
     void MarkTimelineBatchAsUploaded(
-        const std::vector<TimelineEvent> &events);
+        const std::vector<const TimelineEvent*> &events);
     void CompressTimeline();
 
-    std::vector<TimelineEvent> CompressedTimelineForUI(const Poco::LocalDateTime *date) const;
-    std::vector<TimelineEvent> CompressedTimelineForUpload(const Poco::LocalDateTime *date = nullptr) const;
+    std::vector<const TimelineEvent *> CompressedTimelineForUI(const Poco::LocalDateTime *date) const;
+    std::vector<const TimelineEvent *> CompressedTimelineForUpload(const Poco::LocalDateTime *date = nullptr) const;
 
     error UpdateJSON(
         std::vector<TimeEntry *> * const,
@@ -261,7 +264,7 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
 
     void loadObmExperimentFromJson(Json::Value const &obm);
 
-    std::vector<TimelineEvent> CompressedTimeline(
+    std::vector<const TimelineEvent *> CompressedTimeline(
         const Poco::LocalDateTime *date = nullptr, bool is_for_upload = true) const;
 
     Poco::Mutex loadTimeEntries_m_;

--- a/src/model/workspace.h
+++ b/src/model/workspace.h
@@ -14,6 +14,9 @@ namespace toggl {
 class TOGGL_INTERNAL_EXPORT Workspace : public BaseModel {
  public:
     Workspace() : BaseModel() {}
+    // Before undeleting, see how the copy constructor in BaseModel works
+    Workspace(const Workspace &o) = delete;
+    Workspace &operator=(const Workspace &o) = delete;
 
     Property<std::string> Name { "" };
     Property<time_t> LockedTime { 0 };

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -201,7 +201,7 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
     db.instance()->SaveUser(&user, true, &changes);
 
     user.CompressTimeline();
-    std::vector<TimelineEvent> timeline_events = user.CompressedTimelineForUpload();
+    std::vector<const TimelineEvent*> timeline_events = user.CompressedTimelineForUpload();
 
     if (timeline_events.size() != 1) {
         std::cerr << "user.related.TimelineEvents:" << std::endl;
@@ -213,11 +213,11 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
         }
 
         std::cerr << "user.CompressedTimelineForUpload:" << std::endl;
-        for (std::vector<TimelineEvent>::const_iterator it =
+        for (std::vector<const TimelineEvent*>::const_iterator it =
             timeline_events.begin();
                 it != timeline_events.end(); it++) {
-            TimelineEvent ev = *it;
-            std::cerr << ev.String() << std::endl;
+            const TimelineEvent *ev = *it;
+            std::cerr << ev->String() << std::endl;
         }
     }
 
@@ -231,29 +231,29 @@ TEST(User, CreateCompressedTimelineBatchForUpload) {
 
     ASSERT_EQ(size_t(1), timeline_events.size());
 
-    TimelineEvent ready_for_upload = timeline_events[0];
-    ASSERT_TRUE(ready_for_upload.Chunked());
-    ASSERT_EQ(good->UID(), ready_for_upload.UID());
+    const TimelineEvent *ready_for_upload = timeline_events[0];
+    ASSERT_TRUE(ready_for_upload->Chunked());
+    ASSERT_EQ(good->UID(), ready_for_upload->UID());
 
-    ASSERT_NE(good2->Start(), ready_for_upload.Start());
-    ASSERT_NE(uploaded->Start(), ready_for_upload.Start());
-    ASSERT_NE(too_old->Start(), ready_for_upload.Start());
-    ASSERT_NE(too_fresh->Start(), ready_for_upload.Start());
-    ASSERT_EQ(good->Start(), ready_for_upload.Start());
+    ASSERT_NE(good2->Start(), ready_for_upload->Start());
+    ASSERT_NE(uploaded->Start(), ready_for_upload->Start());
+    ASSERT_NE(too_old->Start(), ready_for_upload->Start());
+    ASSERT_NE(too_fresh->Start(), ready_for_upload->Start());
+    ASSERT_EQ(good->Start(), ready_for_upload->Start());
 
     ASSERT_EQ(static_cast<Poco::Int64>(
         good_duration_seconds + good2_duration_seconds),
-              ready_for_upload.Duration());
-    ASSERT_EQ(good->Filename(), ready_for_upload.Filename());
-    ASSERT_EQ(good->Title(), ready_for_upload.Title());
-    ASSERT_EQ(good->Idle(), ready_for_upload.Idle());
-    ASSERT_FALSE(ready_for_upload.Uploaded());
+              ready_for_upload->Duration());
+    ASSERT_EQ(good->Filename(), ready_for_upload->Filename());
+    ASSERT_EQ(good->Title(), ready_for_upload->Title());
+    ASSERT_EQ(good->Idle(), ready_for_upload->Idle());
+    ASSERT_FALSE(ready_for_upload->Uploaded());
 
     // Fake that we have uploaded the chunked timeline event now
     user.MarkTimelineBatchAsUploaded(timeline_events);
 
     // Now, no more events should exist for upload
-    std::vector<TimelineEvent> left_for_upload = user.CompressedTimelineForUpload();
+    std::vector<const TimelineEvent*> left_for_upload = user.CompressedTimelineForUpload();
     ASSERT_EQ(std::size_t(0), left_for_upload.size());
 }
 
@@ -1576,8 +1576,8 @@ TEST(JSON, ConvertTimelineToJSON) {
     event.SetTitle("Is this just fantasy?");
     event.SetIdle(true);
     {
-        std::vector<TimelineEvent> list;
-        list.push_back(event);
+        std::vector<const TimelineEvent*> list;
+        list.push_back(&event);
 
         std::string json = convertTimelineToJSON(list, desktop_id);
         Json::Value root = jsonStringToValue(json);
@@ -1592,8 +1592,8 @@ TEST(JSON, ConvertTimelineToJSON) {
 
     event.SetIdle(false);
     {
-        std::vector<TimelineEvent> list;
-        list.push_back(event);
+        std::vector<const TimelineEvent*> list;
+        list.push_back(&event);
 
         std::string json = convertTimelineToJSON(list, desktop_id);
         Json::Value root = jsonStringToValue(json);
@@ -1610,8 +1610,8 @@ TEST(JSON, ConvertTimelineToJSON) {
 
     event.SetTitle("Õhtu jõuab, päev veereb {\"\b\t");
     {
-        std::vector<TimelineEvent> list;
-        list.push_back(event);
+        std::vector<const TimelineEvent*> list;
+        list.push_back(&event);
 
         std::string json = convertTimelineToJSON(list, desktop_id);
         Json::Value root = jsonStringToValue(json);

--- a/src/test/toggl_api_test.cc
+++ b/src/test/toggl_api_test.cc
@@ -74,7 +74,7 @@ std::vector<TimeEntry> time_entries;
 std::vector<std::string> project_colors;
 
 // on_obm_experiment
-std::vector<ObmExperiment> obm_experiments;
+std::vector<ObmExperiment*> obm_experiments;
 
 TimeEntry time_entry_by_id(uint64_t id) {
     TimeEntry te;
@@ -275,10 +275,10 @@ void on_obm_experiment(
     const uint64_t nr,
     const bool_t included,
     const bool_t seen) {
-    ObmExperiment experiment;
-    experiment.SetNr(nr);
-    experiment.SetIncluded(included);
-    experiment.SetHasSeen(seen);
+    ObmExperiment *experiment = new ObmExperiment;
+    experiment->SetNr(nr);
+    experiment->SetIncluded(included);
+    experiment->SetHasSeen(seen);
     testresult::obm_experiments.push_back(experiment);
 }
 

--- a/src/timeline_notifications.h
+++ b/src/timeline_notifications.h
@@ -37,10 +37,10 @@ class TOGGL_INTERNAL_EXPORT TimelineBatch {
         api_token_ = value;
     }
 
-    std::vector<TimelineEvent> &Events() {
+    std::vector<const TimelineEvent*> &Events() {
         return events_;
     }
-    void SetEvents(const std::vector<TimelineEvent> &value) {
+    void SetEvents(std::vector<const TimelineEvent*> &&value) {
         events_ = value;
     }
 
@@ -54,7 +54,7 @@ class TOGGL_INTERNAL_EXPORT TimelineBatch {
  private:
     Poco::UInt64 user_id_;
     std::string api_token_;
-    std::vector<TimelineEvent> events_;
+    std::vector<const TimelineEvent*> events_;
     std::string desktop_id_;
 };
 
@@ -75,7 +75,7 @@ class TOGGL_INTERNAL_EXPORT TimelineDatasource {
 
     // A batch of timeline events has been upladed and is marked assuch.
     virtual error MarkTimelineBatchAsUploaded(
-        const std::vector<TimelineEvent> &events) = 0;
+        const std::vector<const TimelineEvent*> &events) = 0;
 };
 
 };  // namespace toggl

--- a/src/timeline_uploader.cc
+++ b/src/timeline_uploader.cc
@@ -96,16 +96,16 @@ error TimelineUploader::upload(TimelineBatch *batch) {
 }
 
 std::string convertTimelineToJSON(
-    const std::vector<TimelineEvent> &timeline_events,
+    const std::vector<const TimelineEvent*> &timeline_events,
     const std::string &desktop_id) {
 
     Json::Value root;
 
-    for (std::vector<TimelineEvent>::const_iterator i = timeline_events.begin();
+    for (std::vector<const TimelineEvent*>::const_iterator i = timeline_events.begin();
             i != timeline_events.end();
             ++i) {
-        TimelineEvent event = *i;
-        Json::Value n = event.SaveToJSON();
+        const TimelineEvent *event = *i;
+        Json::Value n = event->SaveToJSON();
         n["desktop_id"] = desktop_id;
         root.append(n);
     }

--- a/src/timeline_uploader.h
+++ b/src/timeline_uploader.h
@@ -16,7 +16,7 @@
 namespace toggl {
 
 std::string convertTimelineToJSON(
-    const std::vector<TimelineEvent> &timeline_events,
+    const std::vector<const TimelineEvent*> &timeline_events,
     const std::string &desktop_id);
 
 class TOGGL_INTERNAL_EXPORT TimelineUploader {

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -602,11 +602,11 @@ void timeline_chunk_view_clear(
 }
 
 TogglTimelineEventView *timeline_event_view_init(
-    const toggl::TimelineEvent &event) {
+    const toggl::TimelineEvent *event) {
     TogglTimelineEventView *event_view = new TogglTimelineEventView();
-    event_view->Title = copy_string(event.Title());
-    event_view->Filename = copy_string(event.Filename());
-    event_view->Duration = event.EndTime() - event.Start();
+    event_view->Title = copy_string(event->Title());
+    event_view->Filename = copy_string(event->Filename());
+    event_view->Duration = event->EndTime() - event->Start();
     event_view->DurationString = copy_string(toggl::Formatter::FormatDuration(event_view->Duration, toggl::Format::ImprovedOnlyMinAndSec));
     event_view->Header = false;
     event_view->Next = nullptr;

--- a/src/toggl_api_private.h
+++ b/src/toggl_api_private.h
@@ -110,7 +110,7 @@ void timeline_chunk_view_clear(
     TogglTimelineChunkView *first);
 
 TogglTimelineEventView *timeline_event_view_init(
-    const toggl::TimelineEvent &event);
+    const toggl::TimelineEvent *event);
 
 void timeline_chunk_view_list_clear(TogglTimelineChunkView *first);
 


### PR DESCRIPTION
### 📒 Description
Most models don't need to be copied anywhere around the library. The `TimelineEvent` class has been copied in multiple places though, seemingly unnecessarily because (as seen in this PR) the pointers to them can be passed around as const and the behavior doesn't change.

This PR disables copying for everything except `Settings` (which is not really a `BaseModel` at all) and `TimeEntry` where we actually create a copy when moving a TE between workspaces.

Some changes to the internal API has been made as well. Instead of passing `std::vector<TimelineEvent>` (or a reference to it), it's now `std::vector <const TimelineEvent*> &` and in the case of `TimelineBatch`, the setter is now utilizing move semantics for improved performance (no copying will occur).

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Timeline batches are smaller

### 👫 Relationships
Fixes #4273

### 🔎 Review hints
See #4273 for details.

