### PR TITLE
Try to fix crash

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -32,7 +32,6 @@ static class Program
         Toggl.OnLogin += delegate (bool open, ulong user_id) {
             UserId = user_id;
         };
-        BugsnagService.Init();
         singleInstanceManager.BeforeStartup -= OnBeforeStartup;
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -255,6 +255,8 @@ namespace TogglDesktop
                 return;
             }
 
+            BugsnagService.Init();
+
             this.loadPositions();
 
             this.GetWindow<AboutWindow>().ViewModel.InitUpdateChannel(Toggl.UpdateChannel());


### PR DESCRIPTION
### 📒 Description
There is a bug reproducible on Windows7: after downloading update and restarting the app, it crashes on startup. I think it may happen because some error appears before `ctx` initialization and Bugsnag crashes as it needs `ctx` to report the error.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4247 

### 🔎 Review hints
I'm not sure that this actually fixes the issue, as I didn't manage to reproduce the bug again: it reproduced after installing Toggl on clean Windows and then it crashed every time, when I tried to start it. But then after installing the earlier version and updating it to the newest one again, it worked properly.

