### PR TITLE
Do not set focus to project text box after new client is created

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -675,6 +675,11 @@ namespace TogglDesktop
             var item = asClientItem.Model;
 
             this.selectClient(item);
+
+            if (this.newProjectTextBox.Text.IsNullOrEmpty())
+            {
+                this.newProjectTextBox.Focus();
+            }
         }
 
         private void selectClient(Toggl.TogglGenericView item)
@@ -763,7 +768,10 @@ namespace TogglDesktop
 
             this.resetToSavedClient();
 
-            this.newProjectTextBox.Focus();
+            if (this.newProjectTextBox.Text.IsNullOrEmpty())
+            {
+                this.newProjectTextBox.Focus();
+            }
 
             return true;
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -675,8 +675,6 @@ namespace TogglDesktop
             var item = asClientItem.Model;
 
             this.selectClient(item);
-
-            this.newProjectTextBox.Focus();
         }
 
         private void selectClient(Toggl.TogglGenericView item)


### PR DESCRIPTION
### 📒 Description
Do not set focus to project text box after a new client is created.
This logic has been there since the old design where it could've been relevant.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Do not set focus to project text box after a new client is created.

### 👫 Relationships
Closes #4184 

### 🔎 Review hints
see #4184 