### PR TITLE
Fix bug when TE name on Edit popup was not updated

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/EditorViewController.swift
@@ -272,8 +272,8 @@ extension EditorViewController {
         projectTextField.setTimeEntry(timeEntry)
         calendarViewControler.prepareLayout(with: timeEntry.started)
 
-        // do not update description if user is editing but update if it's first `fillData()` call
-        if descriptionTextField.currentEditor() == nil || oldValue == nil {
+        // do not update description if user is editing but update if it's first `fillData()` call or it's a new timeEntry
+        if descriptionTextField.currentEditor() == nil || oldValue == nil || timeEntry.guid != oldValue?.guid {
             descriptionTextField.stringValue = timeEntry.descriptionName
         }
 


### PR DESCRIPTION
### 📒 Description
This PR fixes side effect after closing Issue #4217 with PR #4272

Edit popup is in memory all the time and we need to make sure we replace the description field value
when the user wants to edit info for new time entry.
The previous fix did not take this into account and because of that when opening the Edit screen for the second time, the description field was not changed, and as a result, the time entry description was automatically updated with the new value - description of the previously open TE.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
### 👫 Relationships
Fixes side effect after closing Issue #4217 with PR #4272

### 🔎 Review hints
Make sure bug is not reproduced:
1. Open Edit popup for one TE
1. Open Edit popup for another TE
1. Check that info on the screen is valid
1. Repeat for other TEs

Test if issue #4217 is still fixed.

