### PR TITLE
Sync: Don't try to push broken data to backend

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -53,6 +53,7 @@
 #define kInvalidDateError "Date year must be between 2006 and 2030"
 #define kStartNotBeforeStopError "Stop time must be after start time"
 #define kMaximumDescriptionLengthError "Maximum length for description (3000 chars) exceeded"
+#define kForeignEntityLost "Assigned foreign entity could not be found"
 
 #define kCheckYourSignupError "Signup failed - please check your details. The e-mail might be already taken."  // NOLINT
 #define kEndpointGoneError "The API endpoint used by this app is gone. Please contact Toggl support!"  // NOLINT

--- a/src/const.h
+++ b/src/const.h
@@ -53,7 +53,7 @@
 #define kInvalidDateError "Date year must be between 2006 and 2030"
 #define kStartNotBeforeStopError "Stop time must be after start time"
 #define kMaximumDescriptionLengthError "Maximum length for description (3000 chars) exceeded"
-#define kForeignEntityLost "Assigned foreign entity could not be found"
+#define kForeignEntityLostError "Assigned foreign entity could not be found"
 
 #define kCheckYourSignupError "Signup failed - please check your details. The e-mail might be already taken."  // NOLINT
 #define kEndpointGoneError "The API endpoint used by this app is gone. Please contact Toggl support!"  // NOLINT

--- a/src/context.h
+++ b/src/context.h
@@ -685,7 +685,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     template <typename T>
     void syncCollectJSON(Json::Value &array, const std::vector<T*> &source);
     void syncStripPremiumDataFromModelJSON(Json::Value &item);
-    void syncTranslateGUIDToLocalID(Json::Value &item);
+    bool syncTranslateGUIDToLocalID(Json::Value &item);
     template <typename T>
     error syncHandleResponse(Json::Value &array, const std::vector<T*> &source);
 


### PR DESCRIPTION
### 📒 Description
This PR adds a very simple check to the generation of the Sync JSON. If a foreign entity (client, project) GUID cannot be found, set a validation error to the entity and mark it as unsynced. For TEs, it will get displayed, for Projects and Clients, this will result in marking the TEs that use them as unsynced.

In an ideal case, this should never be triggered, it's a safeguard for potential issues in Sync implementation on our or server side.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
The easiest way to reproduce this is adding a broken item to your database directly. Be sure to disable foreign keys by running `PRAGMA foreign_keys = 0` if you're using SQLiteBrowser3 because it enables them by default and TogglDesktop has them disabled. (Also, the foreign key wouldn't really help us in this case because it's only created for the `cid` column that actually CAN point nowhere.)

