### PR TITLE
Sync: Handle when only ID/GUID changed when removing a project 

### DIFF
--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -621,6 +621,9 @@ Json::Value TimeEntry::SyncPayload() const {
         if (PID() > 0) {
             insertIfValue("project_id", PID, Json::Int64(PID()));
         }
+        else if (PID.IsDirty()) {
+            result["project_id"] = Json::nullValue;
+        }
         else {
             insertIf("project_id", ProjectGUID);
         }


### PR DESCRIPTION
### 📒 Description
About what subject says. In some cases, when removing a project from a time entry, nothing happens. This fixes it.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
I think there's no bug reported for this

### 🔎 Review hints
Try adding and removing projects in various situations.

