### PR TITLE
Record activity switch

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1479,6 +1479,11 @@ public static partial class Toggl
         return toggl_is_timeline_ui_enabled(ctx);
     }
 
+    public static bool SetTimelineRecordingEnabled(bool recordTimeline)
+    {
+        return toggl_timeline_toggle_recording(ctx, recordTimeline);
+    }
+
     #endregion
 
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -316,6 +316,7 @@
     <Compile Include="ui\ViewModels\TimeEntryCellViewModel.cs" />
     <Compile Include="ui\ViewModels\TimeEntryLabelViewModel.cs" />
     <Compile Include="ui\ViewModels\TimeEntryListViewModel.cs" />
+    <Compile Include="ui\ViewModels\TimelineViewModel.cs" />
     <Compile Include="ui\ViewModels\TimerEntryListViewViewModel.cs" />
     <Compile Include="ui\ViewModels\TimerViewModel.cs" />
     <Compile Include="ui\ViewModels\ViewModelExtensions.cs" />
@@ -325,6 +326,9 @@
     </Compile>
     <Compile Include="ui\views\SSOLoginView.xaml.cs">
       <DependentUpon>SSOLoginView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ui\views\Timeline.xaml.cs">
+      <DependentUpon>Timeline.xaml</DependentUpon>
     </Compile>
     <Compile Include="ui\views\ValidationErrorControl.xaml.cs">
       <DependentUpon>ValidationErrorControl.xaml</DependentUpon>
@@ -609,6 +613,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="ui\views\SSOLoginView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ui\views\Timeline.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Reactive;
+using System.Threading.Tasks;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace TogglDesktop.ViewModels
+{
+    public class TimelineViewModel : ReactiveObject
+    {
+        public TimelineViewModel()
+        {
+            this.WhenAnyValue(x => x.RecordActivity).Subscribe(x => SaveRecordActivity());
+            OpenTogglHelpUri = ReactiveCommand.Create(() =>
+                Toggl.OpenInBrowser("https://support.toggl.com/en/articles/3836325-toggl-desktop-for-windows"));
+        }
+
+        [Reactive] 
+        public bool RecordActivity { get; set; } = Toggl.IsTimelineRecordingEnabled();
+
+        private void SaveRecordActivity()
+        {
+            Task.Run(() => Toggl.SetTimelineRecordingEnabled(RecordActivity));
+        }
+
+        public ReactiveCommand<Unit, Unit> OpenTogglHelpUri { get; set; }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -10,7 +11,8 @@ namespace TogglDesktop.ViewModels
     {
         public TimelineViewModel()
         {
-            this.WhenAnyValue(x => x.RecordActivity).Subscribe(x => SaveRecordActivity());
+            this.WhenAnyValue(x => x.RecordActivity).ObserveOn(RxApp.TaskpoolScheduler)
+                .Subscribe(value => Toggl.SetTimelineRecordingEnabled(value));
             OpenTogglHelpUri = ReactiveCommand.Create(() =>
                 Toggl.OpenInBrowser("https://support.toggl.com/en/articles/3836325-toggl-desktop-for-windows"));
         }
@@ -18,11 +20,6 @@ namespace TogglDesktop.ViewModels
         [Reactive] 
         public bool RecordActivity { get; set; } = Toggl.IsTimelineRecordingEnabled();
 
-        private void SaveRecordActivity()
-        {
-            Task.Run(() => Toggl.SetTimelineRecordingEnabled(RecordActivity));
-        }
-
-        public ReactiveCommand<Unit, Unit> OpenTogglHelpUri { get; set; }
+        public ReactiveCommand<Unit, Unit> OpenTogglHelpUri { get; }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerEntryListViewViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerEntryListViewViewModel.cs
@@ -17,5 +17,7 @@ namespace TogglDesktop.ViewModels
         public byte SelectedTab { get; set; } = Toggl.GetActiveTab();
 
         public bool IsTimelineViewEnabled => Toggl.IsTimelineUiEnabled();
+
+        public TimelineViewModel TimelineViewModel { get; } = new TimelineViewModel();
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -1,0 +1,76 @@
+﻿<UserControl x:Class="TogglDesktop.Timeline"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
+             xmlns:togglDesktop="clr-namespace:TogglDesktop"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800"
+             d:DataContext="{d:DesignInstance viewModels:TimelineViewModel, IsDesignTimeCreatable=False}">
+    <Grid Background="{DynamicResource Toggl.Background}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="*"></RowDefinition>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"></ColumnDefinition>
+            <ColumnDefinition Width="*"></ColumnDefinition>
+        </Grid.ColumnDefinitions>
+        <mah:ToggleSwitch Margin="10 14 0 0"
+                          OnLabel=""
+                          OffLabel=""
+                          IsChecked="{Binding RecordActivity}"
+                          Grid.Row="0" Grid.Column="0">
+            Record activity
+        </mah:ToggleSwitch>
+        <Viewbox Width="15" Height="15" Grid.Row="0" Grid.Column="1"
+                 HorizontalAlignment="Left"
+                 VerticalAlignment="Bottom"
+                 Margin="12 0 0 0"
+                 Name="RecordActivityInfoBox"
+                 MouseEnter="RecordActivityInfoBoxOnMouseEnter">
+            <Grid>
+                <Ellipse Fill="{DynamicResource Toggl.DisabledTextBrush}"
+                         Width="15" Height="15"
+                         VerticalAlignment="Center"
+                         HorizontalAlignment="Center">
+                </Ellipse>
+                <TextBlock HorizontalAlignment="Center" 
+                           TextAlignment="Center"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource Toggl.CardBackground}"
+                           FontWeight="UltraBold"
+                           FontFamily="Verdana">i</TextBlock>
+                <Popup IsOpen="False" Name="RecordActivityInfoPopup" StaysOpen="False" UseLayoutRounding="True" >
+                    <Border BorderThickness="1" Background="{DynamicResource Toggl.CardBackground}"
+                            BorderBrush="{DynamicResource Toggl.Background}">
+                        <StackPanel MaxWidth="250" Margin="10 10 10 10">
+                            <TextBlock Style="{StaticResource Toggl.CaptionSemiBoldText}">
+                                Having trouble recalling what you were working on?
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource Toggl.CaptionBlackText}"
+                                       Margin="0 12 0 0">
+                                Record your computer activity and revisit it later in the day to fill in gaps in your Timeline.
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource Toggl.CaptionBlackText}"
+                                       Margin="0 12 0 0">
+                                All data is private. Only you can see it.
+                            </TextBlock>
+                            <Label HorizontalAlignment="Center"
+                                   Margin="0 12 0 0">
+                                <Hyperlink NavigateUri="https://support.toggl.com/en/articles/3836325-toggl-desktop-for-windows"
+                                           Style="{StaticResource Toggl.NormalHyperlink}"
+                                           Command="{Binding OpenTogglHelpUri}">
+                                    Learn more
+                                </Hyperlink>
+                            </Label>
+                        </StackPanel>
+                    </Border>
+                </Popup>
+            </Grid>
+        </Viewbox>
+    </Grid>
+</UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -33,17 +33,7 @@
                  Name="RecordActivityInfoBox"
                  MouseEnter="RecordActivityInfoBoxOnMouseEnter">
             <Grid>
-                <Ellipse Fill="{DynamicResource Toggl.DisabledTextBrush}"
-                         Width="15" Height="15"
-                         VerticalAlignment="Center"
-                         HorizontalAlignment="Center">
-                </Ellipse>
-                <TextBlock HorizontalAlignment="Center" 
-                           TextAlignment="Center"
-                           VerticalAlignment="Center"
-                           Foreground="{DynamicResource Toggl.CardBackground}"
-                           FontWeight="UltraBold"
-                           FontFamily="Verdana">i</TextBlock>
+                <Path Fill="#B1B1B5" Data="{StaticResource Toggl.InfoIconGeometry}"/>
                 <Popup IsOpen="False" Name="RecordActivityInfoPopup" StaysOpen="False" UseLayoutRounding="True" >
                     <Border BorderThickness="1" Background="{DynamicResource Toggl.CardBackground}"
                             BorderBrush="{DynamicResource Toggl.Background}">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -17,7 +17,7 @@
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"></ColumnDefinition>
-            <ColumnDefinition Width="*"></ColumnDefinition>
+            <ColumnDefinition Width="Auto"></ColumnDefinition>
         </Grid.ColumnDefinitions>
         <mah:ToggleSwitch Margin="10 14 0 0"
                           OnLabel=""
@@ -26,41 +26,40 @@
                           Grid.Row="0" Grid.Column="0">
             Record activity
         </mah:ToggleSwitch>
-        <Viewbox Width="15" Height="15" Grid.Row="0" Grid.Column="1"
-                 HorizontalAlignment="Left"
-                 VerticalAlignment="Bottom"
-                 Margin="12 0 0 0"
-                 Name="RecordActivityInfoBox"
-                 MouseEnter="RecordActivityInfoBoxOnMouseEnter">
-            <Grid>
+        <Grid Grid.Column="1" Grid.Row="0"
+              Width="16" Height="16"
+              VerticalAlignment="Center"
+              Margin="0 12 0 0">
+            <Canvas MouseEnter="RecordActivityInfoBoxOnMouseEnter" x:Name="InfoIcon">
                 <Path Fill="#B1B1B5" Data="{StaticResource Toggl.InfoIconGeometry}"/>
-                <Popup IsOpen="False" Name="RecordActivityInfoPopup" StaysOpen="False" UseLayoutRounding="True" >
-                    <Border BorderThickness="1" Background="{DynamicResource Toggl.CardBackground}"
+            </Canvas>
+            <Popup IsOpen="False" Name="RecordActivityInfoPopup" StaysOpen="False" UseLayoutRounding="True"
+                   PlacementTarget="{Binding ElementName=InfoIcon}" AllowsTransparency="True">
+                <Border BorderThickness="1" Background="{DynamicResource Toggl.CardBackground}"
                             BorderBrush="{DynamicResource Toggl.Background}">
-                        <StackPanel MaxWidth="250" Margin="10 10 10 10">
-                            <TextBlock Style="{StaticResource Toggl.CaptionSemiBoldText}">
+                    <StackPanel MaxWidth="250" Margin="10 10 10 10">
+                        <TextBlock Style="{StaticResource Toggl.CaptionSemiBoldText}">
                                 Having trouble recalling what you were working on?
-                            </TextBlock>
-                            <TextBlock Style="{StaticResource Toggl.CaptionBlackText}"
+                        </TextBlock>
+                        <TextBlock Style="{StaticResource Toggl.CaptionBlackText}"
                                        Margin="0 12 0 0">
                                 Record your computer activity and revisit it later in the day to fill in gaps in your Timeline.
-                            </TextBlock>
-                            <TextBlock Style="{StaticResource Toggl.CaptionBlackText}"
+                        </TextBlock>
+                        <TextBlock Style="{StaticResource Toggl.CaptionBlackText}"
                                        Margin="0 12 0 0">
                                 All data is private. Only you can see it.
-                            </TextBlock>
-                            <Label HorizontalAlignment="Center"
+                        </TextBlock>
+                        <Label HorizontalAlignment="Center"
                                    Margin="0 12 0 0">
-                                <Hyperlink NavigateUri="https://support.toggl.com/en/articles/3836325-toggl-desktop-for-windows"
+                            <Hyperlink NavigateUri="https://support.toggl.com/en/articles/3836325-toggl-desktop-for-windows"
                                            Style="{StaticResource Toggl.NormalHyperlink}"
                                            Command="{Binding OpenTogglHelpUri}">
-                                    Learn more
-                                </Hyperlink>
-                            </Label>
-                        </StackPanel>
-                    </Border>
-                </Popup>
-            </Grid>
-        </Viewbox>
+                                Learn more
+                            </Hyperlink>
+                        </Label>
+                    </StackPanel>
+                </Border>
+            </Popup>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -21,7 +21,7 @@ namespace TogglDesktop
         public Timeline()
         {
             InitializeComponent();
-            Loaded += (s, e) => ViewModel = new TimelineViewModel();
+            Toggl.OnLogin += (open, userId) => ViewModel = new TimelineViewModel();
         }
 
         private void RecordActivityInfoBoxOnMouseEnter(object sender, MouseEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -21,7 +21,6 @@ namespace TogglDesktop
         public Timeline()
         {
             InitializeComponent();
-            Toggl.OnLogin += (open, userId) => ViewModel = new TimelineViewModel();
         }
 
         private void RecordActivityInfoBoxOnMouseEnter(object sender, MouseEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using TogglDesktop.ViewModels;
+
+namespace TogglDesktop
+{
+    /// <summary>
+    /// Interaction logic for Timeline.xaml
+    /// </summary>
+    public partial class Timeline : UserControl
+    {
+        public TimelineViewModel ViewModel
+        {
+            get => DataContext as TimelineViewModel;
+            set => DataContext = value;
+        }
+
+        public Timeline()
+        {
+            InitializeComponent();
+            this.Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, EventArgs args)
+        {
+            ViewModel = new TimelineViewModel();
+        }
+
+        private void RecordActivityInfoBoxOnMouseEnter(object sender, MouseEventArgs e)
+        {
+            RecordActivityInfoPopup.IsOpen = true;
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Navigation;
 using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
@@ -20,12 +21,7 @@ namespace TogglDesktop
         public Timeline()
         {
             InitializeComponent();
-            this.Loaded += OnLoaded;
-        }
-
-        private void OnLoaded(object sender, EventArgs args)
-        {
-            ViewModel = new TimelineViewModel();
+            Loaded += (s, e) => ViewModel = new TimelineViewModel();
         }
 
         private void RecordActivityInfoBoxOnMouseEnter(object sender, MouseEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
@@ -89,9 +89,8 @@
                 <toggl:TimeEntryList x:Name="Entries"
                                      FocusTimer="onFocusTimer"/>
             </TabItem>
-            <TabItem Header="Timeline"
-                     Visibility="{Binding Path=IsTimelineViewEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <StackPanel></StackPanel>
+	        <TabItem Header="Timeline" Visibility="{Binding Path=IsTimelineViewEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <toggl:Timeline/>
             </TabItem>
         </TabControl>
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
@@ -90,7 +90,7 @@
                                      FocusTimer="onFocusTimer"/>
             </TabItem>
 	        <TabItem Header="Timeline" Visibility="{Binding Path=IsTimelineViewEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <toggl:Timeline/>
+                <toggl:Timeline x:Name="Timeline"/>
             </TabItem>
         </TabControl>
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
@@ -90,7 +90,7 @@
                                      FocusTimer="onFocusTimer"/>
             </TabItem>
 	        <TabItem Header="Timeline" Visibility="{Binding Path=IsTimelineViewEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <toggl:Timeline x:Name="Timeline"/>
+                <toggl:Timeline DataContext="{Binding TimelineViewModel}"/>
             </TabItem>
         </TabControl>
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
@@ -55,6 +55,7 @@ namespace TogglDesktop
             if (userID != 0)
             {
                 ViewModel = new TimerEntryListViewViewModel();
+                Timeline.ViewModel = ViewModel.TimelineViewModel;
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
@@ -55,7 +55,6 @@ namespace TogglDesktop
             if (userID != 0)
             {
                 ViewModel = new TimerEntryListViewViewModel();
-                Timeline.ViewModel = ViewModel.TimelineViewModel;
             }
         }
 


### PR DESCRIPTION
### 📒 Description
Record activity switch and Info icon near Record activity with tooltip on hover (tooltip content same as in macOS app).

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality) 
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
Added Timeline.xaml and TimelineViewModel

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4290 
Relates to #4269 

### 🔎 Review hints
I implemented the Info tooltip as popup, to have the behavior like in MacOS (it closes only on click, not when user drags the mouse to another place). Though I'm not sure it's the best way. Another issue with tooltip was that it's not possible to click the "Learn more" link.

