### PR TITLE
Move to desktop.track.toggl.com for production endpoints

### DIFF
--- a/src/urls.cc
+++ b/src/urls.cc
@@ -39,7 +39,7 @@ std::string API() {
     if (use_staging_as_backend) {
         return "https://desktop.track.toggl.space";
     }
-    return "https://desktop.toggl.com";
+    return "https://desktop.track.toggl.com";
 }
 
 std::string SyncAPI() {
@@ -53,14 +53,14 @@ std::string TimelineUpload() {
     if (use_staging_as_backend) {
         return "https://desktop.track.toggl.space";
     }
-    return "https://timeline.toggl.com";
+    return "https://desktop.track.toggl.com";
 }
 
 std::string WebSocket() {
     if (use_staging_as_backend) {
         return "https://desktop.track.toggl.space";
     }
-    return "https://stream.toggl.com";
+    return "https://desktop.track.toggl.com";
 }
 
 bool ImATeapot() {


### PR DESCRIPTION
### 📒 Description
Move to desktop.track.toggl.com for production endpoints

### 🕶️ Types of changes
- **Internal improvement** (non-breaking change)

### 🤯 List of changes
- [x] Move to desktop.track.toggl.com for production: v8/v9 API, Timeline, WebSocket

### 👫 Relationships
Closes #4294 

### 🔎 Review hints
⚠️ Note: Test on Production configuration! ⚠️ 

A rough list of things to test:
- To verify v8/v9 APIs work:
  - TE start/stop/continue, changing description/project/tags/start time/end time, creating project/client/tags.
  - Login, Signup, Google Login
- To verify WebSocket endpoint works make sure the changes made in other clients (starting/stopping TE, changing TE details) get reflected in the desktop app in a matter of seconds
- To verify Timeline API works
  - turn Record activity on and wait until the end of 15-min chunk, open web app and see that activities are successfully uploaded to the server.
  - check that the Record activity setting is saved on the server. (e.g. clear cache, open the app and log in, change the Record activity setting, clear cache again, open the app and log in again, verify the Record activity setting change was persisted)

- Check that the Reports link is still working (desktop_login_tokens endpoint domain was changed, while desktop_login wasn't).