### PR TITLE
In-app notification about the upcoming rebranding

### DIFF
--- a/releases/message.json
+++ b/releases/message.json
@@ -1,13 +1,11 @@
 {
-	"id": 2,
-	"from": 1576573200,
-	"to": 1591747200,
-	"type": 0,
-  "appversion": "7.5.46",
-	"title": "Update your app to continue using Toggl",
-	"text": "To ensure that your Toggl app continues to sync entries, please update the app by clicking on the cogwheel menu icon -> About -> Restart now. Alternatively, download and install the latest version manually.",
-	"button": "Download here",
-	"url-mac": "https://toggl.com/toggl-desktop/",
-	"url-win": "https://toggl.com/toggl-desktop/",
-	"url-linux": "https://toggl.com/toggl-desktop/"
+	"id": 3,
+	"from": 1598857200,
+	"to": 1599462000,
+	"title": "We're Getting a New Name!",
+	"text": "Toggl is becoming Toggl Track! We'll still be the Toggl you know and love on mobile, desktop, and web - but we've welcomed Toggl Plan and Toggl Hire into the family.",
+	"button": "Learn More",
+	"url-mac": "https://support.toggl.com/en/articles/4338240-frequently-asked-questions-toggl-track-toggl-plan-and-toggl-hire",
+	"url-win": "https://support.toggl.com/en/articles/4338240-frequently-asked-questions-toggl-track-toggl-plan-and-toggl-hire",
+	"url-linux": "https://support.toggl.com/en/articles/4338240-frequently-asked-questions-toggl-track-toggl-plan-and-toggl-hire"
 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -307,8 +307,8 @@ error Context::StartEvents() {
 
             analytics_.TrackOs(db_->AnalyticsClientID(), os_info.str());
             analytics_.TrackOSDetails(db_->AnalyticsClientID());
-            fetchMessage(0);
         }
+        fetchMessage(0);
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1589,8 +1589,8 @@ error Context::fetchMessage(const bool periodic) {
             HTTPRequest req;
             if ("production" != environment_) {
                 // testing location
-                req.host = "https://indrekv.github.io";
-                req.relative_url = "/message.json";
+                req.host = "https://raw.githubusercontent.com";
+                req.relative_url = "/toggl-open-source/toggldesktop/rebranding/upcoming-rebranding-notification/releases/message.json";
             } else {
                 req.host = "https://raw.githubusercontent.com";
                 req.relative_url = "/toggl-open-source/toggldesktop/master/releases/message.json";


### PR DESCRIPTION
### 📒 Description
In-app notification about the upcoming rebranding

### 🕶️ Types of changes
 - **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] New in-app message about the upcoming rebranding
- [x] Minor improvements to make it easier to test in the staging env
### 👫 Relationships
Closes #4299

### 🔎 Review hints

Check if the message is according to the specs:
https://www.notion.so/toggl/customer-email-sends-in-app-announcements-rebrand-coming-soon-3cdbbcde0f1c4a1ab89d4a568d6d0643#7f1d1c7a5d5b4bce94198d8b9b235206

Testing in Staging:
1. Comment out these lines: https://github.com/toggl-open-source/toggldesktop/blob/master/src/context.cc#L1566-L1569
2. EITHER change the date on your computer to 1st September 2020 because the message should be shown since 31st August, or change OR comment out the code that checks the 'from' date.
3. Rebuild the solution.
4. Run the app, observe the notification.

Testing in Production (after this is merged to master, can be tested on any version supporting in-app notifications):
1. Change the date on your computer to 1st September 2020.
2. Make sure that the value of the `settings.message_seen` in the local DB is <= 2 or just delete the local DB.
3. Run the app, observe the notification.