### PR TITLE
Reduce workspace/preferences and preferences/desktop fetches (v2)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2645,12 +2645,7 @@ error Context::Login(
             ResetEnableSSO();
         }
 
-        err = pullWorkspacePreferences();
-        if (err != noError) {
-            return displayError(err);
-        }
-
-        err = pullUserPreferences();
+        err = pullAllPreferencesData();
         if (err != noError) {
             return displayError(err);
         }
@@ -5391,9 +5386,7 @@ error Context::pullAllUserData() {
             return err;
         }
 
-        pullWorkspacePreferences();
-
-        pullUserPreferences();
+        pullAllPreferencesData();
 
         stopwatch.stop();
         logger.debug("User with related data JSON fetched and parsed in ", stopwatch.elapsed() / 1000, " ms");
@@ -5481,9 +5474,7 @@ error Context::pullBatchedUserData() {
             return err;
         }
 
-        pullWorkspacePreferences();
-
-        pullUserPreferences();
+        pullAllPreferencesData();
 
         stopwatch.stop();
         logger.debug("User with related data JSON fetched and parsed in ", stopwatch.elapsed() / 1000, " ms");
@@ -6424,6 +6415,25 @@ error Context::pullUserPreferences() {
     }
     catch (const std::string & ex) {
         return ex;
+    }
+    return noError;
+}
+
+error Context::pullAllPreferencesData() {
+    {
+        Poco::Mutex::ScopedLock lock(user_m_);
+        if (!user_) {
+            logger().warning("cannot pull preferences data when logged out");
+            return noError;
+        }
+    }
+    error err = pullWorkspacePreferences();
+    if (err != noError) {
+        return err;
+    }
+    err = pullUserPreferences();
+    if (err != noError) {
+        return err;
     }
     return noError;
 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -80,6 +80,7 @@ Context::Context(const std::string &app_name, const std::string &app_version)
 , update_check_disabled_(UPDATE_CHECK_DISABLED)
 , trigger_sync_(false)
 , trigger_push_(false)
+, trigger_full_sync_(false)
 , quit_(false)
 , ui_updater_(this, &Context::uiUpdaterActivity)
 , reminder_(this, &Context::reminderActivity)
@@ -1080,6 +1081,7 @@ void Context::scheduleSync() {
 }
 
 void Context::FullSync() {
+    trigger_full_sync_ = true;
     user_->SetSince(0);
     Sync();
 }
@@ -5126,6 +5128,14 @@ void Context::legacySyncerActivity() {
                 displayError(err);
             }
 
+            if (trigger_full_sync_) {
+                err = pullAllPreferencesData();
+                if (err != noError) {
+                    displayError(err);
+                }
+                trigger_full_sync_ = false;
+            }
+
             setOnline("Data pulled");
 
             err = pushChanges(&trigger_sync_);
@@ -5185,6 +5195,14 @@ void Context::batchedSyncerActivity() {
             error err = pullBatchedUserData();
             if (err != noError) {
                 displayError(err);
+            }
+
+            if (trigger_full_sync_) {
+                err = pullAllPreferencesData();
+                if (err != noError) {
+                    displayError(err);
+                }
+                trigger_full_sync_ = false;
             }
 
             setOnline("Data pulled");
@@ -5386,8 +5404,6 @@ error Context::pullAllUserData() {
             return err;
         }
 
-        pullAllPreferencesData();
-
         stopwatch.stop();
         logger.debug("User with related data JSON fetched and parsed in ", stopwatch.elapsed() / 1000, " ms");
     } catch(const Poco::Exception& exc) {
@@ -5473,8 +5489,6 @@ error Context::pullBatchedUserData() {
         if (err != noError) {
             return err;
         }
-
-        pullAllPreferencesData();
 
         stopwatch.stop();
         logger.debug("User with related data JSON fetched and parsed in ", stopwatch.elapsed() / 1000, " ms");
@@ -5921,6 +5935,12 @@ error Context::pushEntries(
         if (resp.err != noError) {
             // if we're able to solve the error
             if ((*it)->ResolveError(resp.body)) {
+                displayError(save(false));
+            }
+
+            // if time entry is locked pull the updated info about locked reports in the workspaces
+            if ((*it)->isLocked(resp.body)) {
+                pullWorkspacePreferences();
                 displayError(save(false));
             }
 
@@ -6423,7 +6443,7 @@ error Context::pullAllPreferencesData() {
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
-            logger().warning("cannot pull preferences data when logged out");
+            logger.warning("cannot pull preferences data when logged out");
             return noError;
         }
     }

--- a/src/context.h
+++ b/src/context.h
@@ -681,6 +681,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error pullBatchedUserData();
     error pullChanges();
     error pullUserPreferences();
+    error pullAllPreferencesData();
 
     template <typename T>
     void syncCollectJSON(Json::Value &array, const std::vector<T*> &source);

--- a/src/context.h
+++ b/src/context.h
@@ -811,6 +811,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     bool trigger_sync_;
     bool trigger_push_;
+    bool trigger_full_sync_;
 
     Poco::LocalDateTime last_time_entry_list_render_at_;
 

--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -78,6 +78,10 @@ bool TimeEntry::isNotFound(const error &err) {
     return std::string::npos != std::string(err).find(
         "Time entry not found");
 }
+bool TimeEntry::isLocked(const error& err) {
+    return std::string::npos != std::string(err).find(
+        "Entries can't be added or edited in this period");
+}
 bool TimeEntry::isMissingCreatedWith(const error &err) const {
     return std::string::npos != std::string(err).find(
         "created_with needs to be provided an a valid string");

--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -78,6 +78,7 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     void StopTracking();
 
     static bool isNotFound(const error &err);
+    static bool isLocked(const error &err);
 
     const std::string GroupHash() const;
 


### PR DESCRIPTION
### 📒 Description
Perform workspace/preferences and preferences/desktop fetches only when doing full sync.
This is #3502, but reimplemented from scratch as there were too many changes since then.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- Perform workspace/preferences fetches only on locked time entry errors, login, and full sync.
- Perform preferences/desktop fetches only on login and full sync.

### 👫 Relationships
Closes #3417

### 🔎 Review hints
1. Test that preferences/desktop fetch is performed on full sync and on login:
- Open the desktop app
- Open the web app, go to Profile settings -> Group similar time entries -> Check or uncheck the checkbox
- Trigger sync manually in the desktop app / Log out and log back into the desktop app
- Make sure the time entry grouping setting was applied

2. Test that workspace/preferences fetch is performed on full sync and on login:
- Open the desktop app
- Open the web app, lock time entries (https://support.toggl.com/en/articles/2206898-locking-time-entries)
- Trigger sync manually in the desktop app / Log out and log back into the desktop app
- Make sure the entries are displayed as locked

3. Test that workspace/preferences fetch is performed when the locked time entry error is received.
- Open the desktop app
- Open the web app, lock time entries (https://support.toggl.com/en/articles/2206898-locking-time-entries)
- Try editing an entry that is supposed to be locked
- The entries are displayed as locked without the need to manually trigger the sync.
Unfortunately, this leads to a bad state, caused by #3513 and #3512. I suggest fixing these issues is out of scope of this PR as they can happen now as well.