### PR TITLE
Fix OAuth on Linux when not already logged in to Google

### DIFF
--- a/src/ui/linux/TogglDesktop/loginwidget.h
+++ b/src/ui/linux/TogglDesktop/loginwidget.h
@@ -61,6 +61,7 @@ class LoginWidget : public QWidget {
     Ui::LoginWidget *ui;
 
     QOAuth2AuthorizationCodeFlow oauth2;
+    QString temporaryOAuthCode;
 
     bool signupVisible;
 


### PR DESCRIPTION
### 📒 Description
After a long and painful debugging session I found out Qt sometimes doesn't escape the temporary authorization code that you get before actually requesting the access token from Google. This PR addresses that, removing HTTP escape sequences from the code and storing it temporarily.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Log out of your Google account, then try initiating Google login from Toggl Desktop.
