### PR TITLE
Post-rebranding in-app notification

### DIFF
--- a/releases/message.json
+++ b/releases/message.json
@@ -1,11 +1,13 @@
 {
-	"id": 3,
-	"from": 1598857200,
-	"to": 1599462000,
-	"title": "We're Getting a New Name!",
-	"text": "Toggl is becoming Toggl Track! We'll still be the Toggl you know and love on mobile, desktop, and web - but we've welcomed Toggl Plan and Toggl Hire into the family.",
-	"button": "Learn More",
-	"url-mac": "https://support.toggl.com/en/articles/4338240-frequently-asked-questions-toggl-track-toggl-plan-and-toggl-hire",
-	"url-win": "https://support.toggl.com/en/articles/4338240-frequently-asked-questions-toggl-track-toggl-plan-and-toggl-hire",
-	"url-linux": "https://support.toggl.com/en/articles/4338240-frequently-asked-questions-toggl-track-toggl-plan-and-toggl-hire"
+	"id": 4,
+	"from": 1599462000,
+	"to": 1600671600,
+	"type": 2,
+	"appversion": "TODO: replace this with the version immediately before the rebranded one",
+	"title": "Toggl is now Toggl Track!",
+	"text": "We're still the Toggl you know and love on mobile, desktop, and web - but we've welcomed Toggl Plan and Toggl Hire into the family.",
+	"button": "Check us out!",
+	"url-mac": "https://toggl.com/blog/toggl-rebrand-toggltrack",
+	"url-win": "https://toggl.com/blog/toggl-rebrand-toggltrack",
+	"url-linux": "https://toggl.com/blog/toggl-rebrand-toggltrack"
 }

--- a/releases/message.json
+++ b/releases/message.json
@@ -3,7 +3,7 @@
 	"from": 1599462000,
 	"to": 1600671600,
 	"type": 2,
-	"appversion": "TODO: replace this with the version immediately before the rebranded one",
+	"appversion": "7.5.259",
 	"title": "Toggl is now Toggl Track!",
 	"text": "We're still the Toggl you know and love on mobile, desktop, and web - but we've welcomed Toggl Plan and Toggl Hire into the family.",
 	"button": "Check us out!",

--- a/src/context.cc
+++ b/src/context.cc
@@ -1591,7 +1591,7 @@ error Context::fetchMessage(const bool periodic) {
             if ("production" != environment_) {
                 // testing location
                 req.host = "https://raw.githubusercontent.com";
-                req.relative_url = "/toggl-open-source/toggldesktop/rebranding/upcoming-rebranding-notification/releases/message.json";
+                req.relative_url = "/toggl-open-source/toggldesktop/rebranding/post-rebranding-notification/releases/message.json";
             } else {
                 req.host = "https://raw.githubusercontent.com";
                 req.relative_url = "/toggl-open-source/toggldesktop/master/releases/message.json";


### PR DESCRIPTION
### 📒 Description
Post-rebranding in-app notification

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] New in-app message to be shown after the rebranding

### 📔  TODO:
- [ ] Show the message only on the rebranded versions of the app

### 👫 Relationships
Closes #4303

Depends on #4316

### 🔎 Review hints

⚠️ Merge only on or right before September 7th ⚠️ 

Check if the message is according to the specs:
https://www.notion.so/toggl/customer-email-sends-in-app-announcements-rebrand-coming-soon-3cdbbcde0f1c4a1ab89d4a568d6d0643#7f1d1c7a5d5b4bce94198d8b9b235206

Testing in Staging:

Comment out these lines: https://github.com/toggl-open-source/toggldesktop/blob/master/src/context.cc#L1566-L1569
EITHER change the date on your computer to 8th September 2020 because the message should be shown since 7th September, or change OR comment out the code that checks the 'from' date.
Rebuild the solution.
Run the app, observe the notification.


Testing in Production (after this is merged to master, should work on the rebranded versions only):

Change the date on your computer to 8th September 2020.
Make sure that the value of the settings.message_seen in the local DB is <= 3 or just delete the local DB.
Run the app, observe the notification.
