### PR TITLE
Kill the app process when the updater is launched

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reactive.Subjects;
 using System.Runtime.InteropServices;
@@ -1192,7 +1193,7 @@ public static partial class Toggl
         if (aboutWindowViewModel.InstallPendingUpdate())
         {
             // quit, updater will restart the app
-            Environment.Exit(0);
+            Process.GetCurrentProcess().Kill();
         }
 
         DeleteOldUpdates();


### PR DESCRIPTION
### 📒 Description
Kill the app process when the updater is launched.
Apparently, `Environment.Exit(0)` makes the application hang on Windows 7 under certain conditions.

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Kill the app process instead of `Environment.Exit(0)` when the updater is launched

### 👫 Relationships
Closes #4247
Closes #4317

### 🔎 Review hints
Test the auto-update on Windows 7 and Windows 10.
It should be fine to use only the build from this branch because the bug occurs in the application *from* which the update is performed (as opposed to the app *to* which the update is performed).