### PR TITLE
Install pending updates as close to app startup as possible

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/BugsnagService.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/BugsnagService.cs
@@ -35,7 +35,7 @@ public static class BugsnagService
             report.Event.Metadata.Add("Details", new Dictionary<string, string>
             {
                 {
-                    "Channel", Toggl.UpdateChannel()
+                    "Channel", Toggl.UpdateService.UpdateChannel.Value
                 },
                 {
                     "Bitness", Utils.Bitness()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Reflection;
-using System.Security;
 using System.Windows.Interop;
 using System.Windows.Media;
-using Microsoft.Win32;
 using TogglDesktop.Services;
 using Application = System.Windows.Forms.Application;
 
@@ -37,6 +35,9 @@ static class Program
             UserId = user_id;
         };
         BugsnagService.Init();
+#if TOGGL_ALLOW_UPDATE_CHECK
+        Toggl.UpdateService.InstallPendingUpdatesOnStartup();
+#endif
         DeepLinkProtocolInstaller.InstallProtocol();
         singleInstanceManager.BeforeStartup -= OnBeforeStartup;
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Linq;
+using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using TogglDesktop.Services;
@@ -15,6 +16,9 @@ namespace TogglDesktop.ViewModels
         {
             VersionText = versionText;
             _updateService = updateService;
+            SelectedChannel = _updateService.UpdateChannel.Value;
+            this.WhenValueChanged(x => x.SelectedChannel)
+                .Subscribe(_updateService.UpdateChannel.OnNext);
             var updateStatus = updateService.UpdateStatus;
             IsUpdateCheckEnabled = updateService.IsUpdateCheckEnabled;
             if (IsUpdateCheckEnabled)
@@ -39,27 +43,12 @@ namespace TogglDesktop.ViewModels
 
         public IReactiveCommand UpdateAndRestartCommand { get; }
 
-        public bool InstallPendingUpdate()
-        {
-            return _updateService.InstallPendingUpdate();
-        }
-
         private void UpdateAndRestart()
         {
             Toggl.PrepareShutdown();
             _updateService.InstallPendingUpdate();
             Program.Shutdown(0);
         }
-
-        public void InitUpdateChannel(string channel)
-        {
-            SelectedChannel = channel;
-            this.ObservableForProperty(x => x.SelectedChannel)
-                .Select(x => x.Value)
-                .Subscribe(SetUpdateChannel);
-        }
-
-        private static void SetUpdateChannel(string channel) => Toggl.SetUpdateChannel(channel);
 
         private static string GetUpdateStatusText(UpdateStatus status) =>
             status.HasUpdate

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/AboutWindowViewModel.cs
@@ -16,7 +16,7 @@ namespace TogglDesktop.ViewModels
         {
             VersionText = versionText;
             _updateService = updateService;
-            SelectedChannel = _updateService.UpdateChannel.Value;
+            _updateService.UpdateChannel.DistinctUntilChanged().Subscribe(channel => SelectedChannel = channel);
             this.WhenValueChanged(x => x.SelectedChannel)
                 .Subscribe(_updateService.UpdateChannel.OnNext);
             var updateStatus = updateService.UpdateStatus;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -174,7 +174,7 @@ namespace TogglDesktop
         private void initializeWindows()
         {
             var aboutWindowViewModel = new AboutWindowViewModel(
-                updateService: new UpdateService(Toggl.IsUpdateCheckDisabled(), Toggl.UpdatesPath),
+                updateService: Toggl.UpdateService,
                 versionText: $"Version {Program.Version()} {Utils.Bitness()}");
 
             this.childWindows = new Window[]{
@@ -258,7 +258,8 @@ namespace TogglDesktop
 
             this.loadPositions();
 
-            this.GetWindow<AboutWindow>().ViewModel.InitUpdateChannel(Toggl.UpdateChannel());
+            var updateChannelFromLocalDb = Toggl.UpdateChannel();
+            Toggl.UpdateService.UpdateChannel.OnNext(updateChannelFromLocalDb);
 
             this.errorBar.Hide();
             this.statusBar.Hide();


### PR DESCRIPTION
### 📒 Description
Install pending updates as close to the app startup as possible. This can help alleviate some bugs related to auto-update.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Rework UpdateService creation to avoid calling Toggl.UpdateChannel() before DB is initialized (win)
- [x] Install pending updates right after BugsnagService is initialized

### 👫 Relationships
Closes #4330.

### 🔎 Review hints
⚠️ Do not merge before #4331 is tested and merged ⚠️ 

Test the auto-update on Windows 7 and Windows 10.
Test that the update channel switching works.

Please also test both the update *to* this version and *from* this version (to save time and to make the conditions as close to production as possible, can be done using the dev channel after the merge to master).