### PR TITLE
Perform only one v9/me/preferences call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,9 @@ build/test/gtest-all.o: $(GTEST_ROOT)/src/gtest-all.cc
 
 build/onboarding_service.o: src/onboarding_service.cpp
 	$(cxx) $(cflags) -c src/onboarding_service.cpp -o build/onboarding_service.o
+	
+build/alpha_features.o: src/alpha_features.cpp
+	$(cxx) $(cflags) -c src/alpha_features.cpp -o build/alpha_features.o
 
 objects: build/jsoncpp.o \
 	build/related_data.o \
@@ -378,7 +381,8 @@ objects: build/jsoncpp.o \
 	build/timeline_uploader.o \
 	build/color_convert.o \
 	build/window_change_recorder.o \
-	build/onboarding_service.o
+	build/onboarding_service.o \
+	build/alpha_features.o
 
 test_objects: build/test/gtest-all.o \
 	build/test/test_data.o \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(LIBRARY_SOURCE_FILES
     database/database.cc
     database/migrations.cc
 
+    model/alpha_features.cpp
     model/autotracker.cc
     model/base_model.cc
     model_change.cc

--- a/src/const.h
+++ b/src/const.h
@@ -134,6 +134,7 @@
 // there was a typo in the initial set of flags, use both variants
 #define kSyncStrategyLegacy1 "dekstop_sync_client"
 #define kSyncStrategyLegacy2 "desktop_sync_client"
+#define kTimelineUi "desktop_timeline_ui"
 
 #define kDesktopClient "desktop"
 

--- a/src/context.h
+++ b/src/context.h
@@ -22,6 +22,7 @@
 #include "timeline_notifications.h"
 #include "types.h"
 #include "websocket_client.h"
+#include "model/alpha_features.h"
 
 #include <Poco/Activity.h>
 #include <Poco/LocalDateTime.h>
@@ -576,6 +577,10 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     void TrackTimelineMenuContext(const TimelineMenuContextType type);
 
+    AlphaFeatures* GetAlphaFeatures() {
+        return alpha_features_;
+    }
+
  protected:
     void uiUpdaterActivity();
     void checkReminders();
@@ -838,8 +843,6 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     TimeEntry *pomodoro_break_entry_;
 
-    bool is_using_sync_server_;
-
     // To cache grouped entries open/close status
     std::map<std::string, bool_t> entry_groups;
 
@@ -867,6 +870,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     bool need_enable_SSO;
     std::string sso_confirmation_code;
+
+    AlphaFeatures *alpha_features_;
 };
 void on_websocket_message(
     void *context,

--- a/src/context.h
+++ b/src/context.h
@@ -578,7 +578,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void TrackTimelineMenuContext(const TimelineMenuContextType type);
 
     AlphaFeatures* GetAlphaFeatures() {
-        return alpha_features_;
+        return user_ ? user_->AlphaFeatureSettings : nullptr;
     }
 
  protected:
@@ -871,7 +871,11 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     bool need_enable_SSO;
     std::string sso_confirmation_code;
 
-    AlphaFeatures *alpha_features_;
+    enum SyncState {
+        STARTUP,
+        LEGACY,
+        BATCHED
+    } sync_state_;
 };
 void on_websocket_message(
     void *context,

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		4943FBA624C085160000DE3C /* libPocoUtil.60.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 4943FBA424C085160000DE3C /* libPocoUtil.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		4943FBA824C085190000DE3C /* libPocoXML.60.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4943FBA724C085190000DE3C /* libPocoXML.60.dylib */; };
 		4943FBA924C085190000DE3C /* libPocoXML.60.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 4943FBA724C085190000DE3C /* libPocoXML.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		495F133E24EEACAE00B7C3E9 /* alpha_features.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 495F133C24EEACAE00B7C3E9 /* alpha_features.cpp */; };
+		495F133F24EEACAE00B7C3E9 /* alpha_features.h in Headers */ = {isa = PBXBuildFile; fileRef = 495F133D24EEACAE00B7C3E9 /* alpha_features.h */; };
 		74AA947A18091AE10000539F /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74AA947918091AE10000539F /* WebKit.framework */; };
 		74CAAD0318185A9B001B77BB /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74CAAD0218185A9B001B77BB /* Carbon.framework */; };
 		B890837624AE388100E40C38 /* json.cc in Sources */ = {isa = PBXBuildFile; fileRef = B890837324AE388100E40C38 /* json.cc */; };
@@ -157,6 +159,8 @@
 		4943FBA124C085140000DE3C /* libPocoNetSSL.60.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoNetSSL.60.dylib; path = ../../ui/osx/TogglDesktop/TogglDesktopLibrary/Dependencies/poco/libPocoNetSSL.60.dylib; sourceTree = "<group>"; };
 		4943FBA424C085160000DE3C /* libPocoUtil.60.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoUtil.60.dylib; path = ../../ui/osx/TogglDesktop/TogglDesktopLibrary/Dependencies/poco/libPocoUtil.60.dylib; sourceTree = "<group>"; };
 		4943FBA724C085190000DE3C /* libPocoXML.60.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoXML.60.dylib; path = ../../ui/osx/TogglDesktop/TogglDesktopLibrary/Dependencies/poco/libPocoXML.60.dylib; sourceTree = "<group>"; };
+		495F133C24EEACAE00B7C3E9 /* alpha_features.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = alpha_features.cpp; sourceTree = "<group>"; };
+		495F133D24EEACAE00B7C3E9 /* alpha_features.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alpha_features.h; sourceTree = "<group>"; };
 		74AA947918091AE10000539F /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		74CAAD0218185A9B001B77BB /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		B890837324AE388100E40C38 /* json.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = json.cc; sourceTree = "<group>"; };
@@ -345,6 +349,8 @@
 				B8B6ECA0244616FF0008FA32 /* user.h */,
 				B8B6ECA3244617000008FA32 /* workspace.cc */,
 				B8B6ECAB244617000008FA32 /* workspace.h */,
+				495F133C24EEACAE00B7C3E9 /* alpha_features.cpp */,
+				495F133D24EEACAE00B7C3E9 /* alpha_features.h */,
 			);
 			path = model;
 			sourceTree = "<group>";
@@ -531,6 +537,7 @@
 				B8B6ECC3244617000008FA32 /* workspace.h in Headers */,
 				B8B6EC70244616B10008FA32 /* types.h in Headers */,
 				B8B6EC65244616B10008FA32 /* netconf.h in Headers */,
+				495F133F24EEACAE00B7C3E9 /* alpha_features.h in Headers */,
 				B8B6EC7C244616B10008FA32 /* get_focused_window.h in Headers */,
 				B8B6EC67244616B10008FA32 /* timeline_uploader.h in Headers */,
 				B8B6EC76244616B10008FA32 /* context.h in Headers */,
@@ -658,6 +665,7 @@
 				B8B6EC89244616B10008FA32 /* help_article.cc in Sources */,
 				B8B6ECBB244617000008FA32 /* workspace.cc in Sources */,
 				B8B6EC84244616B10008FA32 /* timeline_uploader.cc in Sources */,
+				495F133E24EEACAE00B7C3E9 /* alpha_features.cpp in Sources */,
 				B8B6EC75244616B10008FA32 /* websocket_client.cc in Sources */,
 				B890837624AE388100E40C38 /* json.cc in Sources */,
 				B8B6ECDF2446173A0008FA32 /* database.cc in Sources */,

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -486,6 +486,7 @@
     <ClInclude Include="..\..\..\model\workspace.h" />
     <ClCompile Include="..\..\..\onboarding_service.h" />
     <ClCompile Include="..\..\..\cpptime.h" />
+    <ClInclude Include="..\..\..\model\alpha_features.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
@@ -529,6 +530,7 @@
     <ClCompile Include="..\..\..\color_convert.cc" />
     <ClCompile Include="..\..\..\model\workspace.cc" />
     <ClCompile Include="..\..\..\onboarding_service.cpp" />
+    <ClCompile Include="..\..\..\model\alpha_features.cpp" />
     <ClCompile Include="dllmain.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug.Broken|Win32'">false</CompileAsManaged>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug.Broken|Win32'">

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
@@ -168,6 +168,9 @@
     <ClInclude Include="..\..\..\util\json.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\model\alpha_features.h">
+      <Filter>Header Files\model</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -298,6 +301,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\util\json.cc">
       <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\model\alpha_features.cpp">
+      <Filter>Source Files\model</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/model/alpha_features.cpp
+++ b/src/model/alpha_features.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <https_client.h>
+#include <json/json.h>
+
+#include "alpha_features.h"
+#include "urls.h"
+#include "const.h"
+#include "types.h"
+
+
+namespace toggl {
+
+	AlphaFeatures::AlphaFeatures() {
+        isSyncEnabled_ = false;
+        isTimelineUiEnabled_ = false;
+	}
+
+    void AlphaFeatures::ReadAlphaFeatures(Json::Value root) {
+        if (root.isMember("alpha_features")) {
+            for (auto i : root["alpha_features"]) {
+                if (i.isMember("code")) {
+                    // there was a typo in the initial set of flags, use both variants to be sure
+                    if ((i["code"] == kSyncStrategyLegacy1 || i["code"] == kSyncStrategyLegacy2) && i["enabled"].asBool()) {
+                        isSyncEnabled_ = true;
+                    }
+                    else if (i["code"] == kTimelineUi && i["enabled"].asBool()) {
+                        isTimelineUiEnabled_ = true;
+                    }
+                }
+            }
+        }
+        else {
+            logger.log("Syncer - /me/preferences response didn't contain alpha_features");
+        }
+    }
+
+    bool AlphaFeatures::IsSyncEnabled() {
+        return isSyncEnabled_;
+    }
+
+    bool AlphaFeatures::IsTimelineUiEnabled() {
+        return isTimelineUiEnabled_;
+    }
+}
+

--- a/src/model/alpha_features.cpp
+++ b/src/model/alpha_features.cpp
@@ -10,10 +10,10 @@
 
 namespace toggl {
 
-	AlphaFeatures::AlphaFeatures() {
+    AlphaFeatures::AlphaFeatures() {
         isSyncEnabled_ = false;
         isTimelineUiEnabled_ = false;
-	}
+    }
 
     void AlphaFeatures::ReadAlphaFeatures(Json::Value root) {
         if (root.isMember("alpha_features")) {

--- a/src/model/alpha_features.h
+++ b/src/model/alpha_features.h
@@ -1,0 +1,16 @@
+#pragma once
+namespace toggl {
+	class AlphaFeatures
+	{
+		public:
+			AlphaFeatures();
+			void ReadAlphaFeatures(Json::Value root);
+			bool IsSyncEnabled();
+			bool IsTimelineUiEnabled();
+		private:
+			bool isSyncEnabled_;
+			bool isTimelineUiEnabled_;
+			Logger logger { "alpha_features" };
+	};
+}
+

--- a/src/model/alpha_features.h
+++ b/src/model/alpha_features.h
@@ -1,16 +1,16 @@
 #pragma once
 namespace toggl {
-	class AlphaFeatures
-	{
-		public:
-			AlphaFeatures();
-			void ReadAlphaFeatures(Json::Value root);
-			bool IsSyncEnabled();
-			bool IsTimelineUiEnabled();
-		private:
-			bool isSyncEnabled_;
-			bool isTimelineUiEnabled_;
-			Logger logger { "alpha_features" };
-	};
+    class AlphaFeatures
+    {
+         public:
+            AlphaFeatures();
+            void ReadAlphaFeatures(Json::Value root);
+            bool IsSyncEnabled();
+            bool IsTimelineUiEnabled();
+         private:
+            bool isSyncEnabled_;
+            bool isTimelineUiEnabled_;
+            Logger logger { "alpha_features" };
+    };
 }
 

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -17,6 +17,7 @@
 #include "model/timeline_event.h"
 #include "urls.h"
 #include "onboarding_service.h"
+#include "model/alpha_features.h";
 
 #include <Poco/Base64Decoder.h>
 #include <Poco/Base64Encoder.h>
@@ -89,6 +90,10 @@ void removeProjectFromRelatedModels(Poco::UInt64 pid,
 
 
 User::~User() {
+    if (AlphaFeatureSettings) {
+        delete AlphaFeatureSettings;
+        AlphaFeatureSettings = nullptr;
+    }
     related.Clear();
 }
 
@@ -1172,6 +1177,12 @@ bool User::LoadUserPreferencesFromJSON(
     return false;
 }
 
+void User::LoadAlphaFeaturesFromJSON(const Json::Value& data) {
+    if (AlphaFeatureSettings == nullptr) {
+        AlphaFeatureSettings = new AlphaFeatures();
+    }
+    AlphaFeatureSettings->ReadAlphaFeatures(data);
+}
 
 error User::UserID(
     const std::string &json_data_string,

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -211,7 +211,7 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         std::string *result);
 
     AlphaFeatures* AlphaFeatureSettings;
-    void User::LoadAlphaFeaturesFromJSON(const Json::Value& data);
+    void LoadAlphaFeaturesFromJSON(const Json::Value& data);
 
  private:
     void loadUserTagFromJSON(

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -14,6 +14,7 @@
 #include "related_data.h"
 #include "types.h"
 #include "model/workspace.h"
+#include "model/alpha_features.h"
 
 #include <Poco/LocalDateTime.h>
 #include <Poco/Types.h>
@@ -22,7 +23,8 @@ namespace toggl {
 
 class TOGGL_INTERNAL_EXPORT User : public BaseModel {
  public:
-    User() : BaseModel() {}
+    User() : BaseModel(),
+        AlphaFeatureSettings(nullptr) {}
     // Before undeleting, see how the copy constructor in BaseModel works
     User(const User &o) = delete;
     User &operator=(const User &o) = delete;
@@ -207,6 +209,9 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
         const std::string &email,
         const std::string &password,
         std::string *result);
+
+    AlphaFeatures* AlphaFeatureSettings;
+    void User::LoadAlphaFeaturesFromJSON(const Json::Value& data);
 
  private:
     void loadUserTagFromJSON(

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1705,9 +1705,14 @@ TogglRgbColor toggl_get_adaptive_rgb_color_from_hex(
     return toggl::ColorConverter::GetRgbAdaptiveColor(to_string(hexColor), type);
 }
 
+<<<<<<< HEAD
 TogglServerType toggl_get_server_type() {
     if (toggl::urls::IsUsingStagingAsBackend())
         return TogglServerStaging;
     else
         return TogglServerProduction;
+=======
+bool IsTimelineUiEnabled(void *context) {
+    return app(context)->GetAlphaFeatures()->IsTimelineUiEnabled();
+>>>>>>> 841ff34c1... Perform only one v9/me/preferences call
 }

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1705,14 +1705,14 @@ TogglRgbColor toggl_get_adaptive_rgb_color_from_hex(
     return toggl::ColorConverter::GetRgbAdaptiveColor(to_string(hexColor), type);
 }
 
-<<<<<<< HEAD
 TogglServerType toggl_get_server_type() {
     if (toggl::urls::IsUsingStagingAsBackend())
         return TogglServerStaging;
     else
         return TogglServerProduction;
-=======
+}
+
 bool IsTimelineUiEnabled(void *context) {
-    return app(context)->GetAlphaFeatures()->IsTimelineUiEnabled();
->>>>>>> 841ff34c1... Perform only one v9/me/preferences call
+    auto alphaFeatures = app(context)->GetAlphaFeatures();
+    return alphaFeatures && alphaFeatures->IsTimelineUiEnabled();
 }


### PR DESCRIPTION
### 📒 Description
v9/me/preferences and v9/me/preferences/desktop responses are exactly the same, so there should be no reason to perform both calls. We should perform only one of these calls.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes

- [ ] context.cc

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4324 

### 🔎 Review hints
Test if user settings are updated on user login, on app startup and on full sync.

