### PR TITLE
Start fetching in-app messages on user login instead of app startup

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -308,7 +308,6 @@ error Context::StartEvents() {
             analytics_.TrackOs(db_->AnalyticsClientID(), os_info.str());
             analytics_.TrackOSDetails(db_->AnalyticsClientID());
         }
-        fetchMessage(0);
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {
@@ -2819,6 +2818,8 @@ void Context::setUser(User *value, const bool logged_in) {
     }
 
     fetchUpdates();
+
+    fetchMessage(0);
 
     if (!ui_updater_.isRunning()) {
         ui_updater_.start();


### PR DESCRIPTION
### 📒 Description
Start fetching in-app messages on user login instead of app startup.

Notes:
`fetchMessage(0)` starts the periodic fetching task. It is fine to call it on user login because the periodic tasks are stopped on every user logout.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4342 

### 🔎 Review hints

Testing in Staging:

Comment out these lines: https://github.com/toggl-open-source/toggldesktop/blob/master/src/context.cc#L1567-L1570
EITHER change the date on your computer to 1st September 2020 because the message should be shown since 31st August, or change OR comment out the code that checks the 'from' date.
Rebuild the solution.
Run the app, observe the notification.

Test the scenario where the user is logged out before starting the app.
