### PR TITLE
Rename the desktop apps from "TogglDesktop" and "Toggl Desktop" to "Toggl Track"

### DIFF
--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -58,7 +58,7 @@
 ;--------------------------------
 ;General
 
-  Name "Toggl Desktop"
+  Name "Toggl Track"
 
   Icon "..\..\src\ui\windows\TogglDesktop\TogglDesktop\Resources\toggl.ico"
 
@@ -99,16 +99,16 @@
 ;Run App after install
 
   !define MUI_FINISHPAGE_RUN "$INSTDIR\TogglDesktop.exe"
-  !define MUI_FINISHPAGE_RUN_TEXT "Launch Toggl Desktop"
+  !define MUI_FINISHPAGE_RUN_TEXT "Launch Toggl Track"
 
 ;Install Location page
   !define MUI_PAGE_HEADER_TEXT "Install location"
   !define MUI_PAGE_HEADER_SUBTEXT ""
-  !define MUI_DIRECTORYPAGE_TEXT_TOP "Setup will install Toggl Desktop into $INSTDIR. Click Install to start the installation"
+  !define MUI_DIRECTORYPAGE_TEXT_TOP "Setup will install Toggl Track into $INSTDIR. Click Install to start the installation"
 
 ;Run App on Windows login
   !define MUI_FINISHPAGE_SHOWREADME
-  !define MUI_FINISHPAGE_SHOWREADME_TEXT "Run Toggl Desktop on Windows login"
+  !define MUI_FINISHPAGE_SHOWREADME_TEXT "Run Toggl Track on Windows login"
   !define MUI_FINISHPAGE_SHOWREADME_FUNCTION runOnStartup
 
 ;--------------------------------
@@ -185,19 +185,14 @@ Section
   ;Create Desktop shortcut at first install
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0
-    CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
-  ${Else}
-    ; Overwrite the possibly faulty shortcut (#4005)
-    IfFileExists $DESKTOP\TogglDesktop.lnk 0 +3
-      SetOutPath "$LOCALAPPDATA\TogglDesktop"
-      CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$LOCALAPPDATA\TogglDesktop\TogglDesktop.exe" ""
+    CreateShortCut "$DESKTOP\Toggl Track.lnk" "$INSTDIR\TogglDesktop.exe" ""
   ${EndIf}
 
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0
     ;Add/Remove programs entry
     !define REG_UNINSTALL "Software\Microsoft\Windows\CurrentVersion\Uninstall\TogglDesktop"
-    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "Toggl Desktop"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "Toggl Track"
     WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayIcon" "$\"$INSTDIR\TogglDesktop.exe$\""
     WriteRegStr HKCU "${REG_UNINSTALL}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
     WriteRegStr HKCU "${REG_UNINSTALL}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
@@ -207,12 +202,12 @@ Section
     WriteRegStr HKCU "${REG_UNINSTALL}" "InstallLocation" "$\"$INSTDIR$\""
     WriteRegStr HKCU "${REG_UNINSTALL}" "NoModify" 1
     WriteRegStr HKCU "${REG_UNINSTALL}" "NoRepair" 1
-    WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls Toggl Desktop"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls Toggl Track"
 
     ;Create start menu entry
     createDirectory "$SMPROGRAMS\Toggl"
-    createShortCut "$SMPROGRAMS\Toggl\Toggl Desktop.lnk" "$INSTDIR\TogglDesktop.exe" "" "$INSTDIR\toggl.ico"
-    createShortCut "$SMPROGRAMS\Toggl\Uninstall Toggl Desktop.lnk" "$INSTDIR\uninstall.exe" "" ""
+    createShortCut "$SMPROGRAMS\Toggl\Toggl Track.lnk" "$INSTDIR\TogglDesktop.exe" "" "$INSTDIR\toggl.ico"
+    createShortCut "$SMPROGRAMS\Toggl\Uninstall Toggl Track.lnk" "$INSTDIR\uninstall.exe" "" ""
   ${EndIf}
 SectionEnd
 
@@ -238,6 +233,7 @@ Section "Uninstall"
 
   ;Delete desktop shortcut
   Delete "$DESKTOP\TogglDesktop.lnk"
+  Delete "$DESKTOP\Toggl Track.lnk"
 
   RMDir "$INSTDIR"
 
@@ -251,7 +247,9 @@ Section "Uninstall"
 
   ;remove start menu links
   Delete "$SMPROGRAMS\Toggl\Toggl Desktop.lnk"
+  Delete "$SMPROGRAMS\Toggl\Toggl Track.lnk"
   Delete "$SMPROGRAMS\Toggl\Uninstall Toggl Desktop.lnk"
+  Delete "$SMPROGRAMS\Toggl\Uninstall Toggl Track.lnk"
   RMDir "$SMPROGRAMS\Toggl"
 
 SectionEnd

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -186,6 +186,9 @@ Section
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0
     CreateShortCut "$DESKTOP\Toggl Track.lnk" "$INSTDIR\TogglDesktop.exe" ""
+  ${Else}
+    IfFileExists "$DESKTOP\TogglDesktop.lnk" 0 +2
+    Rename /REBOOTOK "$DESKTOP\TogglDesktop.lnk" "$DESKTOP\Toggl Track.lnk"
   ${EndIf}
 
   ${If} $isOldUpdater == 0
@@ -232,7 +235,6 @@ Section "Uninstall"
   RMDir /r "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
 
   ;Delete desktop shortcut
-  Delete "$DESKTOP\TogglDesktop.lnk"
   Delete "$DESKTOP\Toggl Track.lnk"
 
   RMDir "$INSTDIR"

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -185,6 +185,9 @@ Section
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0
     CreateShortCut "$DESKTOP\Toggl Track.lnk" "$INSTDIR\TogglDesktop.exe" ""
+  ${Else}
+    IfFileExists "$DESKTOP\TogglDesktop.lnk" 0 +2
+    Rename /REBOOTOK "$DESKTOP\TogglDesktop.lnk" "$DESKTOP\Toggl Track.lnk"
   ${EndIf}
 
   ${If} $isOldUpdater == 0
@@ -231,7 +234,6 @@ Section "Uninstall"
   RMDir /r "$LOCALAPPDATA\Onova\TogglDesktop" ;Remove the prepared updates
 
   ;Delete desktop shortcut
-  Delete "$DESKTOP\TogglDesktop.lnk"
   Delete "$DESKTOP\Toggl Track.lnk"
 
   RMDir "$INSTDIR"

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -58,7 +58,7 @@
 ;--------------------------------
 ;General
 
-  Name "Toggl Desktop"
+  Name "Toggl Track"
   Icon "..\..\src\ui\windows\TogglDesktop\TogglDesktop\Resources\toggl.ico"
 
   ;Default installation folder. Local app data does not need
@@ -98,16 +98,16 @@
 ;Run App after install
 
   !define MUI_FINISHPAGE_RUN "$INSTDIR\TogglDesktop.exe"
-  !define MUI_FINISHPAGE_RUN_TEXT "Launch Toggl Desktop"
+  !define MUI_FINISHPAGE_RUN_TEXT "Launch Toggl Track"
 
 ;Install Location page
   !define MUI_PAGE_HEADER_TEXT "Install location"
   !define MUI_PAGE_HEADER_SUBTEXT ""
-  !define MUI_DIRECTORYPAGE_TEXT_TOP "Setup will install Toggl Desktop into $INSTDIR. Click Install to start the installation"
+  !define MUI_DIRECTORYPAGE_TEXT_TOP "Setup will install Toggl Track into $INSTDIR. Click Install to start the installation"
 
 ;Run App on Windows login
   !define MUI_FINISHPAGE_SHOWREADME
-  !define MUI_FINISHPAGE_SHOWREADME_TEXT "Run Toggl Desktop on Windows login"
+  !define MUI_FINISHPAGE_SHOWREADME_TEXT "Run Toggl Track on Windows login"
   !define MUI_FINISHPAGE_SHOWREADME_FUNCTION runOnStartup
 
 ;--------------------------------
@@ -184,19 +184,14 @@ Section
   ;Create Desktop shortcut at first install
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0
-    CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$INSTDIR\TogglDesktop.exe" ""
-  ${Else}
-    ; Overwrite the possibly faulty shortcut (#4005)
-    IfFileExists $DESKTOP\TogglDesktop.lnk 0 +3
-      SetOutPath "$LOCALAPPDATA\TogglDesktop"
-      CreateShortCut "$DESKTOP\TogglDesktop.lnk" "$LOCALAPPDATA\TogglDesktop\TogglDesktop.exe" ""
+    CreateShortCut "$DESKTOP\Toggl Track.lnk" "$INSTDIR\TogglDesktop.exe" ""
   ${EndIf}
 
   ${If} $isOldUpdater == 0
   ${AndIf} $isNewUpdater == 0
     ;Add/Remove programs entry
     !define REG_UNINSTALL "Software\Microsoft\Windows\CurrentVersion\Uninstall\TogglDesktop"
-    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "Toggl Desktop"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "Toggl Track"
     WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayIcon" "$\"$INSTDIR\TogglDesktop.exe$\""
     WriteRegStr HKCU "${REG_UNINSTALL}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
     WriteRegStr HKCU "${REG_UNINSTALL}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
@@ -206,12 +201,12 @@ Section
     WriteRegStr HKCU "${REG_UNINSTALL}" "InstallLocation" "$\"$INSTDIR$\""
     WriteRegStr HKCU "${REG_UNINSTALL}" "NoModify" 1
     WriteRegStr HKCU "${REG_UNINSTALL}" "NoRepair" 1
-    WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls Toggl Desktop"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls Toggl Track"
 
     ;Create start menu entry
     createDirectory "$SMPROGRAMS\Toggl"
-    createShortCut "$SMPROGRAMS\Toggl\Toggl Desktop.lnk" "$INSTDIR\TogglDesktop.exe" "" "$INSTDIR\toggl.ico"
-    createShortCut "$SMPROGRAMS\Toggl\Uninstall Toggl Desktop.lnk" "$INSTDIR\uninstall.exe" "" ""
+    createShortCut "$SMPROGRAMS\Toggl\Toggl Track.lnk" "$INSTDIR\TogglDesktop.exe" "" "$INSTDIR\toggl.ico"
+    createShortCut "$SMPROGRAMS\Toggl\Uninstall Toggl Track.lnk" "$INSTDIR\uninstall.exe" "" ""
   ${EndIf}
 SectionEnd
 
@@ -237,6 +232,7 @@ Section "Uninstall"
 
   ;Delete desktop shortcut
   Delete "$DESKTOP\TogglDesktop.lnk"
+  Delete "$DESKTOP\Toggl Track.lnk"
 
   RMDir "$INSTDIR"
 
@@ -250,7 +246,9 @@ Section "Uninstall"
 
   ;remove start menu links
   Delete "$SMPROGRAMS\Toggl\Toggl Desktop.lnk"
+  Delete "$SMPROGRAMS\Toggl\Toggl Track.lnk"
   Delete "$SMPROGRAMS\Toggl\Uninstall Toggl Desktop.lnk"
+  Delete "$SMPROGRAMS\Toggl\Uninstall Toggl Track.lnk"
   RMDir "$SMPROGRAMS\Toggl"
 
 SectionEnd

--- a/src/const.h
+++ b/src/const.h
@@ -95,7 +95,7 @@
 #define kClientNameAlreadyExists "Client name already exists"
 #define kDatabaseDiskMalformed "The database disk image is malformed"
 #define kMissingWS "You no longer have access to your last workspace"
-#define kOutOfDatePleaseUpgrade "Your version of Toggl Desktop is out of date, please upgrade!"
+#define kOutOfDatePleaseUpgrade "Your version of Toggl Track is out of date, please upgrade!"
 #define kThisEntryCantBeSavedPleaseAdd "This entry can't be saved - please add"
 #define kOneLoginAttemptLeft "Incorrect email or password. One more try before account gets locked for 5 minutes."
 #define kAccountIsLocked "Incorrect email or password. Account is locked for 5 minutes. Account owner has been notified."

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -263,7 +263,7 @@ error GUI::findMissingCallbacks() {
 void GUI::DisplayReminder() {
     logger.debug("DisplayReminder");
 
-    char_t *s1 = copy_string("Reminder from Toggl Desktop");
+    char_t *s1 = copy_string("Reminder from Toggl Track");
     char_t *s2 = copy_string("Don't forget to track your time!");
     on_display_reminder_(s1, s2);
     free(s1);
@@ -272,7 +272,7 @@ void GUI::DisplayReminder() {
 
 void GUI::DisplayPomodoro(const Poco::Int64 minutes) {
     logger.debug("DisplayPomodoro");
-    char_t *s1 = copy_string("Toggl Desktop Pomodoro Timer");
+    char_t *s1 = copy_string("Toggl Track Pomodoro Timer");
 
     std::stringstream ss;
     ss << "You've been working for " << minutes << " min, time to take a break!";
@@ -285,7 +285,7 @@ void GUI::DisplayPomodoro(const Poco::Int64 minutes) {
 
 void GUI::DisplayPomodoroBreak(const Poco::Int64 minutes) {
     logger.debug("DisplayPomodoroBreak");
-    char_t *s1 = copy_string("Toggl Desktop Pomodoro Break");
+    char_t *s1 = copy_string("Toggl Track Pomodoro Break");
 
     std::stringstream ss;
     ss << "Hope you enjoyed your " << minutes << " min break, time for work!";

--- a/src/ui/linux/TogglDesktop/aboutdialog.cpp
+++ b/src/ui/linux/TogglDesktop/aboutdialog.cpp
@@ -41,7 +41,7 @@ void AboutDialog::displayUpdate(const QString update_url) {
         ui->updateButton->setText(
             "Click here to download update!");
     } else {
-        ui->updateButton->setText("Toggl Desktop is up to date");
+        ui->updateButton->setText("Toggl Track is up to date");
     }
 }
 

--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) try {
     qRegisterMetaType<QVector<AutocompleteView*> >("QVector<AutocompleteView*>");
     qRegisterMetaType<QVector<GenericView*> >("QVector<GenericView*>");
 
-    QApplication::setApplicationName("Toggl Desktop");
+    QApplication::setApplicationName("Toggl Track");
     QApplication::setOrganizationName("Toggl");
 
     TogglApplication a(argc, argv);
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) try {
     Bugsnag::app.version = APP_VERSION;
 
     QCommandLineParser parser;
-    parser.setApplicationDescription("Toggl Desktop");
+    parser.setApplicationDescription("Toggl Track");
     parser.addHelpOption();
     parser.addVersionOption();
 

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -540,7 +540,7 @@ void MainWindowController::closeEvent(QCloseEvent *event) {
 
     QMessageBox::StandardButton dialog;
     dialog = QMessageBox::question(this,
-                                   "Quit Toggl Desktop",
+                                   "Quit Toggl Track",
                                    "Really quit the app?",
                                    QMessageBox::Ok | QMessageBox::Cancel);
     if (QMessageBox::Ok == dialog) {
@@ -562,7 +562,7 @@ void MainWindowController::displayUpdate(const QString url) {
     if (QMessageBox::Yes == QMessageBox(
         QMessageBox::Question,
         "Download new version?",
-        "A new version of Toggl Desktop is available. Continue with download?",
+        "A new version of Toggl Track is available. Continue with download?",
         QMessageBox::No|QMessageBox::Yes).exec()) {
         QDesktopServices::openUrl(QUrl(url));
         quitApp();

--- a/src/ui/osx/TogglDesktop/Features/About/AboutWindowController.xib
+++ b/src/ui/osx/TogglDesktop/Features/About/AboutWindowController.xib
@@ -42,7 +42,7 @@
                                 </imageView>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0nj-Ur-G2E">
                                     <rect key="frame" x="65" y="251" width="98" height="14"/>
-                                    <textFieldCell key="cell" lineBreakMode="clipping" title="TOGGL DESKTOP" id="5cr-k5-6Pf">
+                                    <textFieldCell key="cell" lineBreakMode="clipping" title="TOGGL TRACK" id="5cr-k5-6Pf">
                                         <font key="font" metaFont="systemMedium" size="11"/>
                                         <color key="textColor" name="login-text-color"/>
                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/src/ui/osx/TogglDesktop/Features/IdleNotification/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/Features/IdleNotification/IdleNotificationWindowController.xib
@@ -24,7 +24,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" id="OXh-s9-LHB">
+        <window title="Toggl Track" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" id="OXh-s9-LHB">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="517" y="489" width="300" height="410"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>

--- a/src/ui/osx/TogglDesktop/Features/MainMenu/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/Features/MainMenu/Base.lproj/MainMenu.xib
@@ -15,10 +15,10 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <menu title="AMainMenu" systemMenu="main" id="29">
             <items>
-                <menuItem title="Toggl Desktop" id="56">
-                    <menu key="submenu" title="Toggl Desktop" systemMenu="apple" id="57">
+                <menuItem title="Toggl Track" id="56">
+                    <menu key="submenu" title="Toggl Track" systemMenu="apple" id="57">
                         <items>
-                            <menuItem title="About Toggl Desktop" id="58">
+                            <menuItem title="About Toggl Track" id="58">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="onAboutMenuItem:" target="494" id="tGk-iF-fGC"/>
@@ -47,7 +47,7 @@
                             <menuItem isSeparatorItem="YES" id="143">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Hide Toggl Desktop" keyEquivalent="h" id="134">
+                            <menuItem title="Hide Toggl Track" keyEquivalent="h" id="134">
                                 <connections>
                                     <action selector="hide:" target="-1" id="eMV-wj-GQh"/>
                                 </connections>
@@ -71,7 +71,7 @@
                             <menuItem isSeparatorItem="YES" id="149">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Quit Toggl Desktop" keyEquivalent="q" id="136">
+                            <menuItem title="Quit Toggl Track" keyEquivalent="q" id="136">
                                 <connections>
                                     <action selector="terminate:" target="-3" id="449"/>
                                 </connections>
@@ -287,7 +287,7 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Help" systemMenu="help" id="491">
                         <items>
-                            <menuItem title="Toggl Desktop Help" keyEquivalent="?" id="492">
+                            <menuItem title="Toggl Track Help" keyEquivalent="?" id="492">
                                 <connections>
                                     <action selector="onHelpMenuItem:" target="494" id="Yuo-YB-F1l"/>
                                 </connections>

--- a/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
@@ -289,7 +289,7 @@ extern void *ctx;
             [[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, no network"];
             break;
         case 2 :
-            [[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, Toggl not responding"];
+            [[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, Toggl Track not responding"];
             break;
         default :
             [self closeError];

--- a/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.xib
+++ b/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.xib
@@ -15,7 +15,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="MainWindow" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="1">
+        <window title="Toggl Track" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="MainWindow" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="300" height="400"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>

--- a/src/ui/osx/TogglDesktop/Features/Other/UnsupportedNotice.m
+++ b/src/ui/osx/TogglDesktop/Features/Other/UnsupportedNotice.m
@@ -68,10 +68,10 @@
 
 	if (result == NSOrderedAscending)
 	{
-		text = @"Toggl Desktop will stop working with your current version of OS X from the 1st of January 2019.\n\n";
+		text = @"Toggl Track will stop working with your current version of OS X from the 1st of January 2019.\n\n";
 	}
 
-	text = [text stringByAppendingString:@"Please upgrade your system to macOS 10.11 or later to continue using Toggl Desktop."];
+	text = [text stringByAppendingString:@"Please upgrade your system to macOS 10.11 or later to continue using Toggl Track."];
 
 	[self setMessageText:title];
 	[self setInformativeText:text];

--- a/src/ui/osx/TogglDesktop/Features/Other/UserNotificationCenter.m
+++ b/src/ui/osx/TogglDesktop/Features/Other/UserNotificationCenter.m
@@ -126,7 +126,7 @@
 
 - (void)scheduleAutoTrackerWithProjectName:(NSString *)projectName projectID:(NSNumber *)projectID taskID:(NSNumber *)taskID
 {
-	NSUserNotification *notification = [self defaultUserNotificationWithTitle:@"Toggl Desktop Autotracker"
+	NSUserNotification *notification = [self defaultUserNotificationWithTitle:@"Toggl Track Autotracker"
 															  informativeText:[NSString stringWithFormat:@"Track %@?", projectName]];
 
 	notification.hasActionButton = YES;
@@ -145,7 +145,7 @@
 
 - (void)scheduleUpdateReady
 {
-    NSUserNotification *notification = [self defaultUserNotificationWithTitle:@"A new version of Toggl Desktop is ready!"
+    NSUserNotification *notification = [self defaultUserNotificationWithTitle:@"A new version of Toggl Track is ready!"
                                                               informativeText:@"Click here to restart and install"];
 
     notification.userInfo = @{ @"update-restart": @"YES" };

--- a/src/ui/osx/TogglDesktop/Features/Permission/SystemPermissionManager.swift
+++ b/src/ui/osx/TogglDesktop/Features/Permission/SystemPermissionManager.swift
@@ -71,9 +71,9 @@ extension SystemPermissionManager {
     private func presentScreenRecordingAlert(_ complete: () -> Void) {
         let alert = NSAlert()
         alert.messageText = "Screen Recording permission not granted!"
-        alert.informativeText = "To get the focused application window name properly for the Timeline, TogglDesktop needs" +
+        alert.informativeText = "To get the focused application window name properly for the Timeline, Toggl Track needs" +
             "to be granted the Screen Recording permission in Security & Privacy in System Preferences." +
-            "\n\nPlease open System Preferences -> Security & Privacy -> Privacy Tab -> Select Screen Recording and enable TogglDesktop app."
+            "\n\nPlease open System Preferences -> Security & Privacy -> Privacy Tab -> Select Screen Recording and enable Toggl Track app."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open")
         alert.addButton(withTitle: "Later")

--- a/src/ui/osx/TogglDesktop/Features/Preferences/PreferencesWindowController.xib
+++ b/src/ui/osx/TogglDesktop/Features/Preferences/PreferencesWindowController.xib
@@ -879,7 +879,7 @@
                                                         <rect key="frame" x="158" y="310" width="136" height="14"/>
                                                         <string key="toolTip">Screen Recording permission not granted!
 
-To get the focused application window name properly for the Timeline, TogglDesktop needs to be granted the Screen Recording permission in Security &amp; Privacy in System Preferences .</string>
+To get the focused application window name properly for the Timeline, Toggl Track needs to be granted the Screen Recording permission in Security &amp; Privacy in System Preferences .</string>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="14" id="Hyi-7L-dBb"/>
                                                         </constraints>

--- a/src/ui/osx/TogglDesktop/Features/TimeEntryList/Views/TimeEntryEmptyView/TimeEntryEmptyView.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryList/Views/TimeEntryEmptyView/TimeEntryEmptyView.swift
@@ -78,7 +78,7 @@ extension TimeEntryEmptyView {
         switch layoutType {
         case .welcome:
             iconImageView.image = NSImage(named: Constants.stopwatchImage)
-            titleLabel.stringValue = "Welcome to Toggl"
+            titleLabel.stringValue = "Welcome to Toggl Track"
             subTitleLabel.stringValue = "Time each activity you do and see where your hours go"
             loadMoreBtn.isHidden = true
             spinerView.stopAnimation(nil)

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController.xib
@@ -29,7 +29,7 @@
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wfb-M9-ix6">
                                 <rect key="frame" x="185" y="3" width="42" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Toggl" id="w7a-dF-DEb">
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Toggl Track" id="w7a-dF-DEb">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-AppStore-Info.plist
+++ b/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-AppStore-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>TogglDesktop</string>
+	<string>Toggl Track</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-AppStore-Info.plist
+++ b/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-AppStore-Info.plist
@@ -18,6 +18,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>Toggl Track</string>
+	<key>CFBundleDisplayName</key>
+	<string>Toggl Track</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-Info.plist
+++ b/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>TogglDesktop</string>
+	<string>Toggl Track</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-Info.plist
+++ b/src/ui/osx/TogglDesktop/Supporting Files/TogglDesktop-Info.plist
@@ -18,6 +18,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>Toggl Track</string>
+	<key>CFBundleDisplayName</key>
+	<string>Toggl Track</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.StoreAssociation.xml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.StoreAssociation.xml
@@ -361,7 +361,7 @@
   <ProductReservedInfo>
     <MainPackageIdentityName>TogglO.TogglDesktop</MainPackageIdentityName>
     <ReservedNames>
-      <ReservedName>Toggl Desktop</ReservedName>
+      <ReservedName>Toggl Track</ReservedName>
     </ReservedNames>
   </ProductReservedInfo>
   <AccountPackageIdentityNames>

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
@@ -13,7 +13,7 @@
     Publisher="CN=E1BE5469-4101-4334-A5A2-69B684F3BA70"/>
 
   <Properties>
-    <DisplayName>Toggl Desktop</DisplayName>
+    <DisplayName>Toggl Track</DisplayName>
     <PublisherDisplayName>Toggl OÜ</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
@@ -33,8 +33,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="Toggl Desktop"
-        Description="Toggl Desktop is a desktop app for leading time tracking tool Toggl."
+        DisplayName="Toggl Track"
+        Description="Desktop app for the leading time tracking tool Toggl Track."
         BackgroundColor="white"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">
@@ -54,7 +54,7 @@
           <desktop:StartupTask
               TaskId="TogglDesktopStartupTask"
               Enabled="false"
-              DisplayName="Toggl Desktop" />
+              DisplayName="Toggl Track" />
         </desktop:Extension>
       </Extensions>
     </Application>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Properties/AssemblyInfo.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("TogglDesktop")]
+[assembly: AssemblyTitle("Toggl Track")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Toggl")]
-[assembly: AssemblyProduct("TogglDesktop")]
+[assembly: AssemblyProduct("Toggl Track")]
 [assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Notifications/AutotrackerNotification.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Notifications/AutotrackerNotification.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:togglDesktop="clr-namespace:TogglDesktop"
              mc:Ignorable="d"
-             Title="Toggl Desktop Autotracker">
+             Title="Toggl Track Autotracker">
     <Button Style="{DynamicResource Toggl.PrimaryButton}"
             Content="Yes, start tracking"
             Click="onStartButtonClick"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/NewUserWelcomeScreen.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/NewUserWelcomeScreen.xaml
@@ -15,12 +15,12 @@
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0"
-                   Text="Welcome to&#10;Toggl Desktop!" TextAlignment="Center"
+                   Text="Welcome to&#10;Toggl Track!" TextAlignment="Center"
                    FontSize="20" FontWeight="Regular" Margin="20"/>
 
         <StackPanel Grid.Row="1">
             <TextBlock 
-                   Text="Would you like us to show you how to&#10;use Toggl Desktop to track your time?"
+                   Text="Would you like us to show you how to&#10;use Toggl Track to track your time?"
                    TextAlignment="Center" Margin="0 0 0 10"/>
             <Button Content="TAKE THE TOUR" Margin="0 0 0 20"
                     Click="startTutorialButtonClick"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -24,14 +24,14 @@ namespace TogglDesktop.ViewModels
                 { new HotKey(Key.N, ModifierKeys.Control), "New time entry" },
                 { new HotKey(Key.O, ModifierKeys.Control), "Continue last entry" },
                 { new HotKey(Key.S, ModifierKeys.Control), "Stop time entry" },
-                { new HotKey(Key.W, ModifierKeys.Control), "Hide Toggl Desktop" },
+                { new HotKey(Key.W, ModifierKeys.Control), "Hide Toggl Track" },
                 { new HotKey(Key.R, ModifierKeys.Control), "Sync" },
                 { new HotKey(Key.E, ModifierKeys.Control), "Edit time entry" },
                 { new HotKey(Key.D, ModifierKeys.Control), "Toggle manual mode" },
                 { new HotKey(Key.V, ModifierKeys.Control), "New time entry from clipboard" },
             };
 
-        private const string ShowHideTogglDescription = "Show/Hide Toggl";
+        private const string ShowHideTogglDescription = "Show/Hide Toggl Track";
         private const string ContinueStopTimerDescription = "Continue/Stop Timer";
 
         private HotKey _continueStopTimerSaved;
@@ -147,7 +147,7 @@ namespace TogglDesktop.ViewModels
         private void ClearCache()
         {
             var result = _showMessageBox(
-                "This will remove your Toggl user data from this PC and log you out of the Toggl Desktop app. " +
+                "This will remove your Toggl user data from this PC and log you out of the Toggl Track app. " +
                 "Any unsynced data will be lost.\n\nDo you want to continue?", "Clear Cache",
                 MessageBoxButton.OKCancel, "Clear cache");
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml
@@ -37,7 +37,7 @@
             <Viewbox Width="63" Height="19" Margin="0 50 0 8">
                 <ContentControl Content="{StaticResource Toggl.LogoSvg}" />
             </Viewbox>
-            <TextBlock Text="Toggl Desktop" HorizontalAlignment="Center"
+            <TextBlock Text="Toggl Track" HorizontalAlignment="Center"
                        Style="{StaticResource Toggl.TitleText}"
                        Margin="0 0 0 10"/>
             <TextBlock Style="{StaticResource Toggl.CaptionText}"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
@@ -10,7 +10,7 @@
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              mc:Ignorable="d" 
              d:DesignWidth="400"
-             Title="Toggl Desktop"
+             Title="Toggl Track"
              Style="{StaticResource Toggl.MainWindow}"
              KeyDown="OnMainWindowKeyDown">
 
@@ -89,7 +89,7 @@
                                   Command="{x:Static toggl:KeyboardShortcuts.ToggleMiniTimerVisibility}"
                                   IsCheckable="True"/>
                         <Separator Style="{StaticResource {x:Static MenuItem.SeparatorStyleKey}}"/>
-                        <MenuItem Header="Toggl Desktop Tutorial"
+                        <MenuItem Header="Toggl Track Tutorial"
                                   Command="{x:Static toggl:KeyboardShortcuts.BasicTutorial}"
                                   Icon="{StaticResource Toggl.TutorialIcon}"/>
                         <MenuItem Header="Send Feedback"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -780,8 +780,8 @@ namespace TogglDesktop
                 var description = timeEntry.Value.Description;
 
                 this.Title = string.IsNullOrEmpty(description)
-                    ? "Toggl Desktop"
-                    : description + " - Toggl Desktop";
+                    ? "Toggl Track"
+                    : description + " - Toggl Track";
 
                 if (this.IsInManualMode)
                     this.SetManualMode(false);
@@ -789,7 +789,7 @@ namespace TogglDesktop
             else
             {
                 this.trayToolTip.TimeEntryLabel = null;
-                this.Title = "Toggl Desktop";
+                this.Title = "Toggl Track";
             }
 
             var iconName = this.IsTracking ? "toggl" : "toggl_inactive";

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MessageBox.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MessageBox.xaml.cs
@@ -16,7 +16,7 @@ namespace TogglDesktop
 
         public delegate MessageBoxResult ShowMessageBoxDelegate(
             string messageText,
-            string title = "Toggl Desktop",
+            string title = "Toggl Track",
             MessageBoxButton buttons = MessageBoxButton.OK,
             string okButtonText = "OK");
 
@@ -27,7 +27,7 @@ namespace TogglDesktop
         }
 
         public static MessageBoxResult Show(Window owner, string messageText,
-            string title = "Toggl Desktop", MessageBoxButton buttons = MessageBoxButton.OK,
+            string title = "Toggl Track", MessageBoxButton buttons = MessageBoxButton.OK,
             string okButtonText = "OK")
         {
             var box = StaticObjectPool.PopOrDefault<MessageBox>()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -56,7 +56,7 @@
                                 <ColumnDefinition Width="200" />
                                 <ColumnDefinition Width="160"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Style="{StaticResource Toggl.BodyText}" VerticalAlignment="Center" Text="Show/Hide Toggl application" />
+                            <TextBlock Grid.Column="0" Grid.Row="0" Style="{StaticResource Toggl.BodyText}" VerticalAlignment="Center" Text="Show/Hide Toggl Track" />
                             <TextBlock Grid.Column="0" Grid.Row="1" Style="{StaticResource Toggl.BodyText}" VerticalAlignment="Center" Text="Continue/Stop timer" />
                             <mah:HotKeyBox Grid.Column="1" Grid.Row="0"
                                            Margin="16 0 0 0"


### PR DESCRIPTION
### 📒 Description
Rename the desktop apps from "TogglDesktop" and "Toggl Desktop" to "Toggl Track".
Corresponding `branding` repo PR (updates Chocolatey package): https://github.com/toggl/toggldesktop-branding/pull/58.

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
Almost all of the changes listed in #4238

ToDo:
- [x] Rename or delete the old Windows app shortcut during installation, not just create a new one
- Rename the macOS app (moved to #4349)
- Rename the app in Flathub
- Test Microsoft Store submission, make sure the app name is changed

### 👫 Relationships
Closes #4238.

### 🔎 Review hints
- Look if there are still any user-visible "Toggl Desktop" or "TogglDesktop" strings
- Check if you find any typos

