### PR TITLE
Make running Linux app against Prod and Staging possible at the same time 

### DIFF
--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1695,3 +1695,10 @@ TogglRgbColor toggl_get_adaptive_rgb_color_from_hex(
     TogglAdaptiveColor type) {
     return toggl::ColorConverter::GetRgbAdaptiveColor(to_string(hexColor), type);
 }
+
+TogglServerType toggl_get_server_type() {
+    if (toggl::urls::IsUsingStagingAsBackend())
+        return TogglServerStaging;
+    else
+        return TogglServerProduction;
+}

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -250,6 +250,11 @@ extern "C" {
         TimerEditActionTypeBillable = 1u << 4
     } TimerEditActionType;
 
+typedef enum {
+        TogglServerStaging = 0,
+        TogglServerProduction
+    } TogglServerType;
+
     // Callbacks that need to be implemented in UI
 
     typedef void (*TogglDisplayApp)(
@@ -439,6 +444,10 @@ extern "C" {
 
     TOGGL_EXPORT void toggl_set_staging_override(
         bool_t value);
+
+    // To request what server is set up in the library
+
+    TOGGL_EXPORT TogglServerType toggl_get_server_type();
 
     // Various parts of UI can tell the app to show itself.
 

--- a/src/ui/linux/TogglDesktop/singleapplication.cpp
+++ b/src/ui/linux/TogglDesktop/singleapplication.cpp
@@ -5,6 +5,8 @@
 #include <QtNetwork/QLocalSocket>
 #include <QFileInfo>
 
+#include "toggl_api.h"
+
 #define TIMEOUT_MS                (500)
 
 SingleApplication::SingleApplication(int &argc, char **argv)
@@ -14,6 +16,8 @@ SingleApplication::SingleApplication(int &argc, char **argv)
 , local_server_(nullptr) {
     server_name_ = QFileInfo(
         QCoreApplication::applicationFilePath()).fileName();
+    if (toggl_get_server_type() == TogglServerStaging)
+        server_name_.append("-staging");
 
     initLocalConnection();
 }

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -230,7 +230,10 @@ TogglApi::TogglApi(
 
     QString logPath("");
     if (logPathOverride.isEmpty()) {
-        logPath = appDir.filePath("toggldesktop.log");
+        if (toggl_get_server_type() == TogglServerStaging)
+            logPath = appDir.filePath("toggldesktop-staging.log");
+        else
+            logPath = appDir.filePath("toggldesktop.log");
     } else {
         logPath = logPathOverride;
     }
@@ -243,7 +246,10 @@ TogglApi::TogglApi(
 
     QString dbPath("");
     if (dbPathOverride.isEmpty()) {
-        dbPath = appDir.filePath("toggldesktop.db");
+        if (toggl_get_server_type() == TogglServerStaging)
+            dbPath = appDir.filePath("toggldesktop-staging.db");
+        else
+            dbPath = appDir.filePath("toggldesktop.db");
     } else {
         dbPath = dbPathOverride;
     }


### PR DESCRIPTION
### 📒 Description
In the vein of making my own life easier, this PR makes it possible to run the Staging app at the same time when the Production app is running. That especially means the logs and database will now get stored as `toggldesktop-staging` instead of just `toggldesktop` for testing versions.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
/I'm aware it doesn't merge, I'll fix it soon/
Try downloading a binary package, for example our current stable tarball version (not flatpak, that runs isolated), run it. Then run the staging app from your own build. Both should run and you should have two databases in your `~/.local/share/Toggl/Toggl Desktop`.

