### PR TITLE
update_releases.sh: Change git username only in GA (actions)

### DIFF
--- a/dist/update_releases.sh
+++ b/dist/update_releases.sh
@@ -22,8 +22,10 @@ prepare() {
   cp dist/update_release_links.sh tmp/update_release_links.sh
   cp dist/parse_releases.sh tmp/parse_releases.sh
 
-  git config user.name "runner"
-  git config user.email "action@github.com"
+  if [[ "$GITHUB_WORKFLOW" != "" ]]; then
+    git config user.name "runner"
+    git config user.email "action@github.com"
+  fi
 }
 
 fetch_releases () {


### PR DESCRIPTION
### 📒 Description
This PR makes the `update_releases` script only change the GH username if the script is being ran from GitHub Actions.
It also seems to add a new line to the end of the file because some editors just don't like it missing.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Check if the syntax is right, run just the `prepare` function. Observe if your git username has changed for this repo. Put something in the `GITHUB_WORKFLOW` env variable and again observe if your git username has changed.
It should only change when `GITHUB_WORKFLOW` is not empty.

