### PR TITLE
Improve Editor stability by removing possible nil TE (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
@@ -37,9 +37,7 @@ final class ProjectAutoCompleteTextField: AutoCompleteTextField {
     }
 
     func setTimeEntry(_ timeEntry: TimeEntryViewItem) {
-        projectCreationView.workspaceID = timeEntry.workspaceID
-        projectCreationView.timeEntryGUID = timeEntry.guid
-        projectCreationView.timeEntryIsBillable = timeEntry.billable
+        projectCreationView.setTimeEntry(guid: timeEntry.guid, workspaceID: timeEntry.workspaceID, isBillable: timeEntry.billable)
 
         if currentEditor() == nil {
             var label = timeEntry.projectLabel ?? ""

--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -48,21 +48,9 @@ final class ProjectCreationView: NSView {
 
     // MARK: Variables
 
-    var workspaceID: UInt64? {
-        didSet {
-            resetViews()
-        }
-    }
-    var timeEntryGUID: String? {
-        didSet {
-            resetViews()
-        }
-    }
-    var timeEntryIsBillable: Bool = false {
-        didSet {
-            resetViews()
-        }
-    }
+    private var workspaceID: UInt64?
+    private var timeEntryGUID: String?
+    private var timeEntryIsBillable: Bool = false
 
     private(set) var selectedWorkspace: Workspace? {
         didSet {
@@ -140,6 +128,13 @@ final class ProjectCreationView: NSView {
         setInitialProjectColors()
         updateLayoutState()
         colorPickerView.select(selectedColor)
+    }
+
+    func setTimeEntry(guid: String?, workspaceID: UInt64?, isBillable: Bool) {
+        self.timeEntryGUID = guid
+        self.workspaceID = workspaceID
+        self.timeEntryIsBillable = isBillable
+        resetViews()
     }
 
     @IBAction func cancelBtnOnTap(_ sender: Any) {
@@ -319,9 +314,9 @@ extension ProjectCreationView {
 
     fileprivate func selectDefaultWorkspace() {
         guard let workspaceID = workspaceID else { return }
-        guard let workspaces = workspaceDatasource.items as? [Workspace] else { return }
-        let index = workspaces.firstIndex(where: { $0.WID == workspaceID }) ?? 0
-        selectedWorkspace = workspaces[index]
+        guard let workspaces = workspaceDatasource.items as? [Workspace], workspaces.isEmpty == false else { return }
+        guard let index = workspaces.firstIndex(where: { $0.WID == workspaceID }) else { return }
+        selectedWorkspace = workspaces[safe: index]
         workspaceDatasource.selectRow(at: index)
     }
 

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController.swift
@@ -503,10 +503,9 @@ extension TimerViewController: AutoCompleteViewDelegate {
     }
 
     private func showProjectCreationView() {
-        projectCreationView.workspaceID = viewModel.workspaceID
-        projectCreationView.timeEntryGUID = viewModel.timeEntryGUID
-        projectCreationView.timeEntryIsBillable = viewModel.billableState == .on
-
+        projectCreationView.setTimeEntry(guid: viewModel.timeEntryGUID,
+                                         workspaceID: viewModel.workspaceID,
+                                         isBillable: viewModel.billableState == .on)
         updateProjectAutocompleteWindowContent(with: projectCreationView, height: projectCreationView.suitableHeight)
         projectCreationView.setTitleAndFocus(projectAutoCompleteView.defaultTextField.stringValue)
     }


### PR DESCRIPTION
### 📒 Description
Add code guard in some places to reduce the possibility of crashes.
Time entry on Edit screen shouldn't be `nil` - it's a possible cause of the issue.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships

### 🔎 Review hints
Please test the Edit screen. 
Especially description field - there may be a possibility of regressed issues, like time when it wasn't updating when switching between different TEs or running TE.
