### PR TITLE
Fix application menu entry in some distros

### DIFF
--- a/src/ui/linux/TogglDesktop/dist/com.toggl.TogglDesktop.desktop
+++ b/src/ui/linux/TogglDesktop/dist/com.toggl.TogglDesktop.desktop
@@ -1,12 +1,10 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Type=Application
 Terminal=false
 Name=Toggl Desktop
 Comment=Free Time Tracking Software
 Icon=toggldesktop
-TryExec=TogglDesktop
 Exec=TogglDesktop.sh
 Categories=Office;
 StartupNotify=false


### PR DESCRIPTION
### 📒 Description
Some distros/DEs are fussy about the desktop file not conforming to specs. That's why this PR removes the `TryExec` (unuseful for us now) and `Encoding` (deprecated) entries from it, making it work right everywhere.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue) 

### 👫 Relationships
Closes #4332

### 🔎 Review hints
Just merging this is fine, it's a tiny fix and we don't ship the `TogglDesktop` binary in the main `bin` directory of any package anymore. `TogglDesktop.sh` is there instead and it sets all paths up.

