### PR TITLE
Activity blocks and TEs placing

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -15,6 +15,54 @@ namespace TogglDesktop
 {
 public static partial class Toggl
 {
+    #region Data types
+
+    public class TimelineEventView
+    {
+        public string Title;
+        public string Filename;
+        public Int64 Duration;
+        public string DurationString;
+        public bool Header;
+        // references subevents
+        public List<TimelineEventView> SubEvents;
+
+        public TimelineEventView(TogglTimelineEventView eventView)
+        {
+            Title = eventView.Title;
+            Filename = eventView.Filename;
+            Duration = eventView.Duration;
+            DurationString = eventView.DurationString;
+            Header = eventView.Header;
+            SubEvents = marshalList<TimelineEventView, TogglTimelineEventView>(eventView.Event, n => n.Event, t => new TimelineEventView(t));
+        }
+    }
+
+    public class TimelineChunkView
+    {
+        public UInt64 Started;
+        public UInt64 Ended;
+        public string StartTimeString;
+        public string EndTimeString;
+        public List<TimelineEventView> Events;
+
+        public TimelineChunkView(TogglTimelineChunkView chunk)
+        {
+            Started = chunk.Started;
+            Ended = chunk.Ended;
+            StartTimeString = chunk.StartTimeString;
+            EndTimeString = chunk.EndTimeString;
+            Events = marshalList<TimelineEventView, TogglTimelineEventView>(chunk.FirstEvent, n => n.Next, t => new TimelineEventView(t));
+        }
+
+        public override string ToString()
+        {
+            return EndTimeString;
+        }
+    }
+
+    #endregion
+
     #region constants and static fields
 
     public const string Project = "project";
@@ -173,7 +221,7 @@ public static partial class Toggl
 
     public delegate void DisplayTimeline(
         bool open, string date,
-        List<TogglTimelineChunkView> first,
+        List<TimelineChunkView> first,
         List<TogglTimeEntryView> firstTimeEntry,
         ulong startDay,
         ulong endDay);
@@ -1254,9 +1302,10 @@ public static partial class Toggl
         return marshalList<TogglCountryView>(first, n => n.Next);
     }
 
-    private static List<TogglTimelineChunkView> convertToTimelineChunkList(IntPtr first)
+    private static List<TimelineChunkView> convertToTimelineChunkList(IntPtr first)
     {
-        return marshalList<TogglTimelineChunkView>(first, n => n.Next);
+        return marshalList<TimelineChunkView, TogglTimelineChunkView>(first,
+            n => n.Next, t => new TimelineChunkView(t));
     }
 
     #endregion
@@ -1284,13 +1333,26 @@ public static partial class Toggl
         return (T)Marshal.PtrToStructure(pointer, typeof(T));
     }
 
-    #endregion
+    private static List<T> marshalList<T, K>(IntPtr node, Func<K, IntPtr> getNext, Func<K, T> cast)
+    {
+        var list = new List<T>();
 
-    #endregion
+        while (node != IntPtr.Zero)
+        {
+            var t = (K)Marshal.PtrToStructure(node, typeof(K));
+            list.Add(cast(t));
+            node = getNext(t);
+        }
 
-    #region getting/setting global shortcuts
+        return list;
+    }
+        #endregion
 
-    public static void SetKeyStart(string key)
+        #endregion
+
+        #region getting/setting global shortcuts
+
+        public static void SetKeyStart(string key)
     {
         toggl_set_key_start(ctx, key);
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1555,6 +1555,11 @@ public static partial class Toggl
     {
         toggl_view_timeline_data(ctx);
     }
+
+    public static string CreateEmptyTimeEntry(ulong started, ulong ended)
+    {
+        return toggl_create_empty_time_entry(ctx, started, ended);
+    }
     #endregion
 
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -34,7 +34,7 @@ public static partial class Toggl
             Duration = eventView.Duration;
             DurationString = eventView.DurationString;
             Header = eventView.Header;
-            SubEvents = marshalList<TimelineEventView, TogglTimelineEventView>(eventView.Event, n => n.Event, t => new TimelineEventView(t));
+            SubEvents = marshalList<TimelineEventView, TogglTimelineEventView>(eventView.Event, n => n.Next, t => new TimelineEventView(t));
         }
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1346,13 +1346,13 @@ public static partial class Toggl
 
         return list;
     }
-        #endregion
+    #endregion
 
-        #endregion
+    #endregion
 
-        #region getting/setting global shortcuts
+    #region getting/setting global shortcuts
 
-        public static void SetKeyStart(string key)
+    public static void SetKeyStart(string key)
     {
         toggl_set_key_start(ctx, key);
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -764,9 +764,6 @@
     <PackageReference Include="Onova">
       <Version>2.5.2</Version>
     </PackageReference>
-    <PackageReference Include="OptimizedPriorityQueue">
-      <Version>5.0.0</Version>
-    </PackageReference>
     <PackageReference Include="ReactiveUI.Fody">
       <Version>11.4.1</Version>
     </PackageReference>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -253,6 +253,7 @@
     <Compile Include="ui\Converters\HasAnyFlagToVisibilityConverter.cs" />
     <Compile Include="ui\Converters\IsSelectableItemConverter.cs" />
     <Compile Include="ui\Converters\PopupAlignmentAwareConverter.cs" />
+    <Compile Include="ui\Converters\RectangleHeightToRadiusConverter.cs" />
     <Compile Include="ui\Converters\StringFormatIfNotEmptyConverter.cs" />
     <Compile Include="ui\Converters\BytesToStringConverter.cs" />
     <Compile Include="ui\Converters\EnumEqualToVisibilityConverter.cs" />
@@ -754,6 +755,9 @@
     </PackageReference>
     <PackageReference Include="Onova">
       <Version>2.5.2</Version>
+    </PackageReference>
+    <PackageReference Include="OptimizedPriorityQueue">
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="ReactiveUI.Fody">
       <Version>11.4.1</Version>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -241,12 +241,16 @@
     <Compile Include="ui\controls\TimeEntryLabel.xaml.cs">
       <DependentUpon>TimeEntryLabel.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ui\controls\TimelineTimeEntryBlock.xaml.cs">
+      <DependentUpon>TimelineTimeEntryBlock.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ui\controls\TrayToolTipControl.xaml.cs">
       <DependentUpon>TrayToolTipControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="ui\Converters\AdaptProjectColorConverter.cs" />
     <Compile Include="ui\Converters\AndConverter.cs" />
     <Compile Include="ui\Converters\BooleanInvertToVisibilityConverter.cs" />
+    <Compile Include="ui\Converters\BrushOpacityConverter.cs" />
     <Compile Include="ui\Converters\CapitalizeConverter.cs" />
     <Compile Include="ui\Converters\EmptyListToCollapsedConverter.cs" />
     <Compile Include="ui\Converters\EmptyStringToCollapsedConverter.cs" />
@@ -482,6 +486,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="ui\controls\AutotrackerSettings.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ui\controls\TimelineTimeEntryBlock.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BrushOpacityConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BrushOpacityConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace TogglDesktop.Converters
+{
+    public class BrushOpacityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is SolidColorBrush brush && parameter is double opacity)
+            {
+                var newBrush = new SolidColorBrush(brush.Color)
+                {
+                    Opacity = opacity
+                };
+                newBrush.Freeze();
+                return newBrush;
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/RectangleHeightToRadiusConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/RectangleHeightToRadiusConverter.cs
@@ -11,7 +11,7 @@ namespace TogglDesktop.Converters
             if (parameter == null || !(value is double)) return 0;
             var height = (double)value;
             if (height >= 15) return parameter.ToString() == "RadiusX" ? 15 : 7;
-            if (height >= 5) return parameter.ToString() == "RadiusX" ? 15 : 2;
+            if (height >= 6) return parameter.ToString() == "RadiusX" ? 4 : 15;
             return 0;
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/RectangleHeightToRadiusConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/RectangleHeightToRadiusConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace TogglDesktop.Converters
+{
+    public class RectangleHeightToRadiusConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (parameter == null || !(value is double)) return 0;
+            var height = (double)value;
+            if (height >= 15) return parameter.ToString() == "RadiusX" ? 15 : 7;
+            if (height >= 5) return parameter.ToString() == "RadiusX" ? 15 : 2;
+            return 0;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
@@ -345,4 +345,25 @@
             </Trigger>
         </Style.Triggers>
     </Style>
+
+    <Style TargetType="Button" x:Key="Toggl.Timeline.GapButton">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Grid>
+                        <Rectangle Stroke="{DynamicResource Toggl.LightGrayBrush}"
+                                   StrokeDashArray="1 1"
+                                   StrokeThickness="2"
+                                   Fill="Transparent"
+                                   RadiusX="15"
+                                   RadiusY="7">
+                        </Rectangle>
+                        <Viewbox Stretch="None">
+                            <Path Opacity="0.348" Fill="{DynamicResource Toggl.DarkGrayBrush}" Data="M9.437 4.844v1.312h-3.28v3.281H4.843V6.156H1.562V4.844h3.282V1.561h1.312v3.281h3.281z"/>
+                        </Viewbox>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -75,27 +76,15 @@ namespace TogglDesktop.ViewModels
                     {
                         var activity = new ActivityDescription()
                         {
-                            SubActivities = new List<string>()
+                            ActivityTitle = eventDesc.Header ? Path.GetFileName(eventDesc.Filename) : eventDesc.Title
                         };
-                        var title = eventDesc.Title;
-                        foreach (var subEvent in eventDesc.SubEvents)
-                        {
-                            if (subEvent.Title.IsNullOrEmpty()) continue;
-                            activity.SubActivities.Add(eventDesc.DurationString + " " + subEvent.Title);
-                            if (title.IsNullOrEmpty())
-                                title = subEvent.Title;
-                        }
-                        if (!title.IsNullOrEmpty())
-                        {
-                            activity.ActivityTitle = eventDesc.DurationString + " " + title;
-                            block.ActivityDescriptions.Add(activity);
-                        }
+                        activity.SubActivities = eventDesc.Header
+                            ? eventDesc.SubEvents.Select(e => e.DurationString + " " + e.Title).ToList()
+                            : new List<string>() {eventDesc.DurationString + " " + eventDesc.Title}; 
+                        block.ActivityDescriptions.Add(activity);
                         duration += eventDesc.Duration;
                     }
-                    var height = (1.0 * duration * _hourHeight) / (60 * 60);
-                    if (height < 10) height = 10;
-                    if (height > 50) height = 50;
-                    block.Height = height;
+                    block.Height = (1.0 * duration * _hourHeight) / (60 * 60); ;
                     if (block.ActivityDescriptions.Any())
                         blocks.Add(block);
                 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -66,6 +66,7 @@ namespace TogglDesktop.ViewModels
                         TimeInterval = chunk.StartTimeString+" - "+chunk.EndTimeString,
                         ActivityDescriptions = new List<ActivityDescription>()
                     };
+                    long duration = 0;
                     foreach (var eventDesc in chunk.Events)
                     {
                         var activity = new ActivityDescription()
@@ -85,7 +86,12 @@ namespace TogglDesktop.ViewModels
                             activity.ActivityTitle = eventDesc.DurationString + " " + title;
                             block.ActivityDescriptions.Add(activity);
                         }
+                        duration += eventDesc.Duration;
                     }
+                    var height = (1.0 * duration * _hourHeight) / (60 * 60);
+                    if (height < 10) height = 10;
+                    if (height > 50) height = 50;
+                    block.Height = height;
                     if (block.ActivityDescriptions.Any())
                         blocks.Add(block);
                 }
@@ -161,7 +167,7 @@ namespace TogglDesktop.ViewModels
                     if (!offsets.Any())
                     {
                         offsets.Add(curOffset);
-                        curOffset += 20;
+                        curOffset += 25;
                     }
                     if (usedNumOfOffsets > 0 || item.Block.Height < 20)
                         item.Block.ShowDescription = false;
@@ -208,7 +214,7 @@ namespace TogglDesktop.ViewModels
                         Ended = entry.Started-1
                     });
                 }
-                prevEnd = entry.Ended;
+                prevEnd = !prevEnd.HasValue || entry.Ended > prevEnd ? entry.Ended : prevEnd;
             }
 
             GapTimeEntryBlocks = null;
@@ -247,6 +253,7 @@ namespace TogglDesktop.ViewModels
         {
             public double Offset { get; set; }
             public string TimeInterval { get; set; }
+            public double Height { get; set; }
             public List<ActivityDescription> ActivityDescriptions { get; set; }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -106,7 +106,11 @@ namespace TogglDesktop.ViewModels
                 {
                     Height = height < 2 ? 2 : height,
                     VerticalOffset = ConvertTimeIntervalToHeight(new DateTime(startTime.Year, startTime.Month, startTime.Day), startTime),
-                    Color = entry.Color
+                    Color = entry.Color,
+                    Description = entry.Description,
+                    ProjectName = entry.ProjectLabel,
+                    ClientName = entry.ClientLabel,
+                    ShowDescription = true
                 };
                 queue.Enqueue((false, block), entry.Started);
                 queue.Enqueue((true, block), entry.Ended);
@@ -115,12 +119,16 @@ namespace TogglDesktop.ViewModels
 
             var offsets = new HashSet<double>();
             var curOffset = 0;
+            var usedNumOfOffsets = 0;
             while (queue.Count>0)
             {
                 var item = queue.Dequeue();
                 if (item.IsEnd)
                 {
                     offsets.Add(item.Block.HorizontalOffset);
+                    if (usedNumOfOffsets > 1 || item.Block.Height<20)
+                        item.Block.ShowDescription = false;
+                    usedNumOfOffsets--;
                 }
                 else
                 {
@@ -129,9 +137,11 @@ namespace TogglDesktop.ViewModels
                         offsets.Add(curOffset);
                         curOffset += 20;
                     }
-
+                    if (usedNumOfOffsets > 0 || item.Block.Height < 20)
+                        item.Block.ShowDescription = false;
                     item.Block.HorizontalOffset = offsets.Min();
                     offsets.Remove(offsets.Min());
+                    usedNumOfOffsets++;
                 }
             }
 
@@ -169,14 +179,6 @@ namespace TogglDesktop.ViewModels
         [Reactive]
         public List<TimeEntryBlock> TimeEntryBlocks { get; private set; }
 
-        public class TimeEntryBlock
-        {
-            public double VerticalOffset { get; set; }
-            public double HorizontalOffset { get; set; }
-            public double Height { get; set; }
-            public string Color { get; set; }
-        }
-
         public class ActivityBlock
         {
             public double Offset { get; set; }
@@ -190,5 +192,17 @@ namespace TogglDesktop.ViewModels
 
             public List<string> SubActivities { get; set; }
         }
+    }
+
+    public class TimeEntryBlock
+    {
+        public double VerticalOffset { get; set; }
+        public double HorizontalOffset { get; set; }
+        public double Height { get; set; }
+        public string Color { get; set; }
+        public bool ShowDescription { get; set; }
+        public string Description { get; set; }
+        public string ProjectName { get; set; }
+        public string ClientName { get; set; }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -30,10 +30,28 @@ namespace TogglDesktop.ViewModels
             }
         }
 
-        private void HandleDisplayTimeline(bool open, string date, List<Toggl.TogglTimelineChunkView> first, List<Toggl.TogglTimeEntryView> firstTimeEntry, ulong startDay, ulong endDay)
+        private void HandleDisplayTimeline(bool open, string date, List<Toggl.TimelineChunkView> first, List<Toggl.TogglTimeEntryView> firstTimeEntry, ulong startDay, ulong endDay)
         {
             SelectedDate = Toggl.DateTimeFromUnix(startDay);
             TimeEntries = firstTimeEntry;
+            ConvertChunksToIntervals(first);
+        }
+
+        public void ConvertChunksToIntervals(List<Toggl.TimelineChunkView> chunks)
+        {
+            var offsets = new List<double>();
+            foreach (var chunk in chunks)
+            {
+                var offset = 0d;
+                if (chunk.Events.Any())
+                {
+                    var start = Toggl.DateTimeFromUnix(chunk.Started);
+                    offset = (start - new DateTime(start.Year, start.Month, start.Day)).TotalMinutes;
+                }
+                offsets.Add((offset * 24 * 200) / (24 * 60));
+                
+            }
+            ActivityBlockOffsets = offsets;
         }
 
         [Reactive] 
@@ -52,5 +70,8 @@ namespace TogglDesktop.ViewModels
 
         [Reactive]
         public List<Toggl.TogglTimeEntryView> TimeEntries { get; private set; }
+
+        [Reactive]
+        public List<double> ActivityBlockOffsets { get; private set; }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -1,0 +1,50 @@
+﻿<UserControl x:Class="TogglDesktop.TimelineTimeEntryBlock"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:converters="clr-namespace:TogglDesktop.Converters"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800"
+             d:DataContext="{d:DesignInstance viewModels:TimeEntryBlock, IsDesignTimeCreatable=False}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <converters:RectangleHeightToRadiusConverter x:Key="HeightToRadiusConverter"/>
+            <converters:BrushOpacityConverter x:Key="BrushOpacityConverter"/>
+            <sys:Double x:Key="PointOneDouble">0.1</sys:Double>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid Margin="0 0 14 0">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Rectangle Grid.Column="0" Name ="TimeEntrySpan"
+                   Width="15" Height="{Binding Height}"
+                   Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
+                   RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
+                   RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">
+        </Rectangle>
+        <Border CornerRadius="8,8,8,8" BorderThickness="0" Grid.Column="1" Margin="-10 0 0 0"
+                Visibility="{Binding ShowDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
+                Background="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource PointOneDouble}}">
+            <StackPanel Height="{Binding Height}" Margin="20,0,0,0">
+                <TextBlock Text="{Binding Description}" Style="{StaticResource Toggl.CaptionBlackText}"/>
+                <DockPanel>
+                    <Ellipse Width="8" Height="8"
+                             DockPanel.Dock="Left"
+                             Margin="0 0 5 0"
+                             VerticalAlignment="Center"
+                             Fill="{Binding ElementName=TimeEntrySpan, Path=Fill}"
+                             Visibility="{Binding ProjectName, Converter={StaticResource EmptyStringToCollapsedConverter}}"/>
+                    <TextBlock Foreground="{Binding Color, Converter={StaticResource AdaptProjectTextColorConverter}}"
+                               Text="{Binding ProjectName}" FontSize="12"
+                               VerticalAlignment="Center"/>
+                </DockPanel>
+                <TextBlock Text="{Binding ClientName}" Style="{StaticResource Toggl.CaptionText}"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -16,7 +16,7 @@
             <sys:Double x:Key="PointOneDouble">0.1</sys:Double>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid Margin="0 0 14 0">
+    <Grid Margin="0 0 4 0">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -22,7 +22,7 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Rectangle Grid.Column="0" Name ="TimeEntrySpan"
-                   Width="15" Height="{Binding Height}"
+                   Width="20" Height="{Binding Height}"
                    Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
                    RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
                    RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace TogglDesktop
+{
+    /// <summary>
+    /// Interaction logic for TimelineTimeEntryBlock.xaml
+    /// </summary>
+    public partial class TimelineTimeEntryBlock : UserControl
+    {
+        public TimelineTimeEntryBlock()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -6,12 +6,17 @@
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
              xmlns:togglDesktop="clr-namespace:TogglDesktop"
+             xmlns:converters="clr-namespace:TogglDesktop.Converters"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
-             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimelineViewModel, IsDesignTimeCreatable=False}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <converters:RectangleHeightToRadiusConverter x:Key="HeightToRadiusConverter"/>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid MinHeight="100">
         <Grid Background="{DynamicResource Toggl.Background}">
             <Grid.RowDefinitions>
@@ -131,7 +136,28 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                     <GridSplitter Grid.Column="1" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Left" Width="1" Background="{DynamicResource Toggl.TimelineSeparatorBrush}"/>
-                    <Canvas Grid.Row="1" Grid.Column="2" Background="Transparent"/>
+                    <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=TimeEntryBlocks}" Margin="10 0 0 0">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Rectangle Width="15" Height="{Binding Height}" Panel.ZIndex="1" 
+                                           Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
+                                           RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
+                                           RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">
+                                </Rectangle>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding HorizontalOffset}" />
+                                <Setter Property="Canvas.Top" Value="{Binding VerticalOffset}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                    </ItemsControl>
                     <GridSplitter Grid.Column="3" Grid.Row="1" Width="1">
                         <GridSplitter.Style>
                             <Style TargetType="{x:Type GridSplitter}">
@@ -224,7 +250,7 @@
         </Grid>
         <TextBlock Text="No entries here... Go ahead and track some time!" Width="125" HorizontalAlignment="Center"
                    VerticalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center" Margin="0 100 0 0"
-                   Visibility="{Binding TimeEntries, Converter={StaticResource EmptyListToVisibleConverter}}"
+                   Visibility="{Binding TimeEntryBlocks, Converter={StaticResource EmptyListToVisibleConverter}}"
                    MouseWheel="HandleScrollViewerMouseWheel"/>
         <TextBlock Text="No activity was recorded yet..." HorizontalAlignment="Right"
                    VerticalAlignment="Center" TextAlignment="Center" Margin="0 100 10 0"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -6,10 +6,8 @@
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
              xmlns:togglDesktop="clr-namespace:TogglDesktop"
-             xmlns:converters="clr-namespace:TogglDesktop.Converters"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimelineViewModel, IsDesignTimeCreatable=False}">
@@ -142,6 +140,25 @@
                             <DataTemplate>
                                 <togglDesktop:TimelineTimeEntryBlock Panel.ZIndex="1" DataContext="{Binding Path=.}"
                                                                      Width="{Binding ElementName=MainViewGrid, Path=ColumnDefinitions[2].ActualWidth}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding HorizontalOffset}" />
+                                <Setter Property="Canvas.Top" Value="{Binding VerticalOffset}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                    </ItemsControl>
+                    <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=GapTimeEntryBlocks}" Margin="10 0 0 0">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button Style="{StaticResource Toggl.Timeline.GapButton}" Height="{Binding Height}" Width="15"
+                                        Command="{Binding CreateTimeEntryFromBlock}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                         <ItemsControl.ItemContainerStyle>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -8,9 +8,15 @@
              xmlns:togglDesktop="clr-namespace:TogglDesktop"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
+             xmlns:converters="clr-namespace:TogglDesktop.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimelineViewModel, IsDesignTimeCreatable=False}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <converters:RectangleHeightToRadiusConverter x:Key="HeightToRadiusConverter"/>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid MinHeight="100">
         <Grid Background="{DynamicResource Toggl.Background}">
             <Grid.RowDefinitions>
@@ -94,7 +100,7 @@
                           SnapsToDevicePixels="True"
                           PreviewMouseWheel="HandleScrollViewerMouseWheel"
                           Name="MainViewScroll">
-                <Grid  Background="{DynamicResource Toggl.CardBackground}">
+                <Grid  Background="{DynamicResource Toggl.CardBackground}" Name ="MainViewGrid">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
@@ -157,7 +163,7 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Button Style="{StaticResource Toggl.Timeline.GapButton}" Height="{Binding Height}" Width="15"
+                                <Button Style="{StaticResource Toggl.Timeline.GapButton}" Height="{Binding Height}" Width="20"
                                         Command="{Binding CreateTimeEntryFromBlock}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -212,8 +218,11 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Rectangle Width="20" Height="40" RadiusX="20" RadiusY="10" Panel.ZIndex="1" 
-                                           Fill="{DynamicResource Toggl.ActivityBlockBrush}"
+                                <Rectangle Width="20" Height="{Binding Height}"
+                                           RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
+                                           RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}"
+                                           Panel.ZIndex="1" 
+                                           Fill="{DynamicResource Toggl.AccentBrush}"
                                            MouseEnter="OnActivityMouseEnter"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -219,6 +219,8 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Rectangle Width="20" Height="{Binding Height}"
+                                           MinHeight="6"
+                                           MaxHeight="50"
                                            RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
                                            RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}"
                                            Panel.ZIndex="1" 
@@ -233,13 +235,14 @@
                             </Style>
                         </ItemsControl.ItemContainerStyle>
                     </ItemsControl>
-                    <Popup DataContext="{Binding SelectedActivityBlock}" Grid.Row="1" Grid.Column="4"
+                    <Popup DataContext="{Binding SelectedActivityBlock}"
+                           Grid.Row="1" Grid.Column="4"
                            Placement="Left"
                            StaysOpen="False"
                            HorizontalOffset="-5"
-                           Name="ActivityBlockPopup"
-                           MaxWidth="170">
-                        <Border BorderBrush="{DynamicResource Toggl.PopupBorderBrush}" BorderThickness="1">
+                           MaxWidth="270"
+                           Name="ActivityBlockPopup">
+                        <Border BorderBrush="{DynamicResource Toggl.PopupBorderBrush}" BorderThickness="1" Focusable="False">
                             <Border.Effect>
                                 <DropShadowEffect ShadowDepth="1" BlurRadius="4" Direction="270" Opacity="0.2" Color="Black" />
                             </Border.Effect>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -139,13 +139,13 @@
                     <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=TimeEntryBlocks}" Margin="10 0 0 0">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <Canvas />
+                                <Canvas Name="TimeEntryCanvas" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <togglDesktop:TimelineTimeEntryBlock Panel.ZIndex="1" DataContext="{Binding Path=.}"
-                                                                     Width="{Binding ElementName=MainViewGrid, Path=ColumnDefinitions[2].ActualWidth}"/>
+                                                                     Width="{Binding ElementName=TimeEntryCanvas, Path=ActualWidth}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                         <ItemsControl.ItemContainerStyle>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -6,9 +6,9 @@
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
              xmlns:togglDesktop="clr-namespace:TogglDesktop"
-             xmlns:converters="clr-namespace:TogglDesktop.Converters"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimelineViewModel, IsDesignTimeCreatable=False}">
@@ -168,7 +168,7 @@
                             </Style>
                         </GridSplitter.Style>
                     </GridSplitter>
-                    <ItemsControl Grid.Row="1" Grid.Column="4" ItemsSource="{Binding Path=ActivityBlockOffsets}">
+                    <ItemsControl Grid.Row="1" Grid.Column="4" ItemsSource="{Binding Path=ActivityBlocks}" Name="ActivityBlocks">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <Canvas />
@@ -176,16 +176,49 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Rectangle Width="20" Height="40" RadiusX="20" RadiusY="10" Panel.ZIndex="1" Fill="{DynamicResource Toggl.ActivityBlockBrush}"></Rectangle>
+                                <Rectangle Width="20" Height="40" RadiusX="20" RadiusY="10" Panel.ZIndex="1" 
+                                           Fill="{DynamicResource Toggl.ActivityBlockBrush}"
+                                           MouseEnter="OnActivityMouseEnter"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                         <ItemsControl.ItemContainerStyle>
                             <Style TargetType="ContentPresenter">
                                 <Setter Property="Canvas.Left" Value="25" />
-                                <Setter Property="Canvas.Top" Value="{Binding Path=.}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Path=Offset}" />
                             </Style>
                         </ItemsControl.ItemContainerStyle>
                     </ItemsControl>
+                    <Popup DataContext="{Binding SelectedActivityBlock}" Grid.Row="1" Grid.Column="4"
+                           Placement="Left"
+                           StaysOpen="False"
+                           HorizontalOffset="-5"
+                           Name="ActivityBlockPopup"
+                           MaxWidth="170">
+                        <Border BorderBrush="{DynamicResource Toggl.PopupBorderBrush}" BorderThickness="1">
+                            <Border.Effect>
+                                <DropShadowEffect ShadowDepth="1" BlurRadius="4" Direction="270" Opacity="0.2" Color="Black" />
+                            </Border.Effect>
+                            <StackPanel Background="{DynamicResource Toggl.CardBackground}">
+                                <TextBlock FontSize="12" Text="{Binding TimeInterval}" Margin="9 8 9 5"/>
+                                <ItemsControl ItemsSource="{Binding ActivityDescriptions}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding ActivityTitle}" Margin="9 0 9 0" TextTrimming="CharacterEllipsis"/>
+                                                <ItemsControl ItemsSource="{Binding SubActivities}" Margin="9 0 9 5">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Style="{StaticResource Toggl.BodyGrayishText}" Text="{Binding Path=.}" TextTrimming="CharacterEllipsis"/>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+                    </Popup>
                 </Grid>
             </ScrollViewer>
         </Grid>
@@ -195,7 +228,7 @@
                    MouseWheel="HandleScrollViewerMouseWheel"/>
         <TextBlock Text="No activity was recorded yet..." HorizontalAlignment="Right"
                    VerticalAlignment="Center" TextAlignment="Center" Margin="0 100 10 0"
-                   Visibility="{Binding ActivityBlockOffsets, Converter={StaticResource EmptyListToVisibleConverter}}"
+                   Visibility="{Binding ActivityBlocks, Converter={StaticResource EmptyListToVisibleConverter}}"
                    MouseWheel="HandleScrollViewerMouseWheel">
             <TextBlock.LayoutTransform>
                 <RotateTransform Angle="90"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -9,14 +9,10 @@
              xmlns:converters="clr-namespace:TogglDesktop.Converters"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimelineViewModel, IsDesignTimeCreatable=False}">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <converters:RectangleHeightToRadiusConverter x:Key="HeightToRadiusConverter"/>
-        </ResourceDictionary>
-    </UserControl.Resources>
     <Grid MinHeight="100">
         <Grid Background="{DynamicResource Toggl.Background}">
             <Grid.RowDefinitions>
@@ -144,11 +140,8 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Rectangle Width="15" Height="{Binding Height}" Panel.ZIndex="1" 
-                                           Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
-                                           RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
-                                           RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">
-                                </Rectangle>
+                                <togglDesktop:TimelineTimeEntryBlock Panel.ZIndex="1" DataContext="{Binding Path=.}"
+                                                                     Width="{Binding ElementName=MainViewGrid, Path=ColumnDefinitions[2].ActualWidth}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                         <ItemsControl.ItemContainerStyle>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -6,6 +6,7 @@
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
              xmlns:togglDesktop="clr-namespace:TogglDesktop"
+             xmlns:converters="clr-namespace:TogglDesktop.Converters"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              mc:Ignorable="d" 
@@ -167,7 +168,24 @@
                             </Style>
                         </GridSplitter.Style>
                     </GridSplitter>
-                    <Canvas Grid.Row="1" Grid.Column="4"/>
+                    <ItemsControl Grid.Row="1" Grid.Column="4" ItemsSource="{Binding Path=ActivityBlockOffsets}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Rectangle Width="20" Height="40" RadiusX="20" RadiusY="10" Panel.ZIndex="1" Fill="{DynamicResource Toggl.ActivityBlockBrush}"></Rectangle>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="25" />
+                                <Setter Property="Canvas.Top" Value="{Binding Path=.}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                    </ItemsControl>
                 </Grid>
             </ScrollViewer>
         </Grid>
@@ -177,7 +195,7 @@
                    MouseWheel="HandleScrollViewerMouseWheel"/>
         <TextBlock Text="No activity was recorded yet..." HorizontalAlignment="Right"
                    VerticalAlignment="Center" TextAlignment="Center" Margin="0 100 10 0"
-                   Visibility="{Binding TimeEntries, Converter={StaticResource EmptyListToVisibleConverter}}"
+                   Visibility="{Binding ActivityBlockOffsets, Converter={StaticResource EmptyListToVisibleConverter}}"
                    MouseWheel="HandleScrollViewerMouseWheel">
             <TextBlock.LayoutTransform>
                 <RotateTransform Angle="90"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -210,7 +210,7 @@
                             </Style>
                         </GridSplitter.Style>
                     </GridSplitter>
-                    <ItemsControl Grid.Row="1" Grid.Column="4" ItemsSource="{Binding Path=ActivityBlocks}" Name="ActivityBlocks">
+                    <ItemsControl Grid.Row="1" Grid.Column="4" ItemsSource="{Binding Path=ActivityBlocks}" x:Name="ActivityBlocks">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <Canvas />
@@ -238,10 +238,11 @@
                     <Popup DataContext="{Binding SelectedActivityBlock}"
                            Grid.Row="1" Grid.Column="4"
                            Placement="Left"
-                           StaysOpen="False"
+                           StaysOpen="True"
                            HorizontalOffset="-5"
                            MaxWidth="270"
-                           Name="ActivityBlockPopup">
+                           Name="ActivityBlockPopup"
+                           IsOpen="{Binding ElementName=ActivityBlocks, Path=IsMouseOver, Mode=OneWay}">
                         <Border BorderBrush="{DynamicResource Toggl.PopupBorderBrush}" BorderThickness="1" Focusable="False">
                             <Border.Effect>
                                 <DropShadowEffect ShadowDepth="1" BlurRadius="4" Direction="270" Opacity="0.2" Color="Black" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -32,7 +32,6 @@ namespace TogglDesktop
         private void HandleScrollViewerMouseWheel(object sender, MouseWheelEventArgs e)
         {
             MainViewScroll.ScrollToVerticalOffset(MainViewScroll.VerticalOffset - e.Delta);
-            ActivityBlockPopup.IsOpen = false;
             e.Handled = true;
         }
 
@@ -43,7 +42,6 @@ namespace TogglDesktop
                 ViewModel.SelectedActivityBlock = curBlock;
                 ActivityBlockPopup.PlacementTarget = uiElement;
                 ActivityBlockPopup.VerticalOffset = uiElement.Height/2;
-                ActivityBlockPopup.IsOpen = true;
             }
         }
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Navigation;
 using TogglDesktop.ViewModels;
@@ -31,7 +32,19 @@ namespace TogglDesktop
         private void HandleScrollViewerMouseWheel(object sender, MouseWheelEventArgs e)
         {
             MainViewScroll.ScrollToVerticalOffset(MainViewScroll.VerticalOffset - e.Delta);
+            ActivityBlockPopup.IsOpen = false;
             e.Handled = true;
+        }
+
+        private void OnActivityMouseEnter(object sender, MouseEventArgs e)
+        {
+            if (sender is FrameworkElement uiElement && uiElement.DataContext is TimelineViewModel.ActivityBlock curBlock)
+            {
+                ViewModel.SelectedActivityBlock = curBlock;
+                ActivityBlockPopup.PlacementTarget = uiElement;
+                ActivityBlockPopup.VerticalOffset = uiElement.Height/2;
+                ActivityBlockPopup.IsOpen = true;
+            }
         }
     }
 }


### PR DESCRIPTION
### 📒 Description
Implements displaying activity blocks and popup with info on each activity block hover.
Add basic Time Entry pills visualization with an algorithm for laying them out when TEs overlap.
Add creating TEs from gaps.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4370 

### 🔎 Review hints
What should be tested:
 - Activity blocks placing. The color is just static for now. The height depends on duration, but the min possible is 10 and max is 50.
- TEs placing including overlapping case. The description panel is implemented, but does not include all the info yet. It does not contain duration text, and also I assume, there must be also some tags, etc. I'll check it out later with MacOS and include in the next PR.
- Placing gaps between TEs must work correctly. Also it must be possible to create a TE from gap, but opening the edit TE panel is not part of this PR.

