### PR TITLE
Adapt autocomplete dropdown for app size updates (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/AutoCompleteInput.h
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/AutoCompleteInput.h
@@ -35,7 +35,6 @@ typedef NS_ENUM (NSUInteger, AutoCompleteDisplayMode)
 
 - (void)toggleTableViewWithNumberOfItem:(NSInteger)numberOfItem;
 - (void)updateDropdownWithHeight:(CGFloat)height;
-- (void)setPos:(int)posy;
 - (void)hide;
 - (void)resetTable;
 - (void)showAutoComplete:(BOOL)show;

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController.swift
@@ -81,9 +81,6 @@ class TimerViewController: NSViewController {
     override func viewDidAppear() {
         super.viewDidAppear()
 
-        let viewFrameInWindowCoords = view.convert(view.bounds, to: nil)
-        descriptionTextField.setPos(Int32(viewFrameInWindowCoords.origin.y))
-
         // !!!: we're passing views into view model - refactor this someday
         // this is needed because current Autocomplete functionality
         // is tightly coupled with text input views

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -714,7 +714,7 @@
 		3C6B2480203E01D60063FC08 /* AutoCompleteTableCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoCompleteTableCell.m; sourceTree = "<group>"; };
 		3C6B2481203E01D80063FC08 /* AutoCompleteInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutoCompleteInput.h; sourceTree = "<group>"; };
 		3C6B2482203E01D80063FC08 /* AutoCompleteTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutoCompleteTable.h; sourceTree = "<group>"; };
-		3C6B2483203E01D90063FC08 /* AutoCompleteInput.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoCompleteInput.m; sourceTree = "<group>"; };
+		3C6B2483203E01D90063FC08 /* AutoCompleteInput.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoCompleteInput.m; sourceTree = "<group>"; usesTabs = 1; };
 		3C6B2484203E01D90063FC08 /* AutoCompleteTable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoCompleteTable.m; sourceTree = "<group>"; };
 		3C6B2485203E01D90063FC08 /* AutoCompleteTableCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AutoCompleteTableCell.xib; sourceTree = "<group>"; };
 		3C6B24A2203FC8200063FC08 /* LiteAutoCompleteDataSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LiteAutoCompleteDataSource.h; sourceTree = "<group>"; };


### PR DESCRIPTION
### 📒 Description
Now autocomplete dropdown width does not depend on the description field width.
It has max width of 500pt. It stays at this width if app is fullscreen or just has large size.
If app window width is smaller than max width, dropdown size will take app window width as a max value (excluding some padding).
Dropdown height is also calculated differently and updates on layout change.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships
Closes #4395 

### 🔎 Review hints
Test autocomplete dropdown in various app screen size conditions
