### PR TITLE
Fix bug with description autocomplete empty after startup (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewModel.swift
@@ -147,8 +147,8 @@ final class TimerViewModel: NSObject {
     }
 
     func setDescriptionAutoCompleteInput(_ input: AutoCompleteInput) {
-        descriptionDataSource.setFilter("")
         descriptionDataSource.input = input
+        descriptionDataSource.setFilter("")
         input.autocompleteTableView.delegate = self
     }
 


### PR DESCRIPTION
### 📒 Description
The root cause of the bug: data source was calling methods from the input field before it was assigned to it.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships
Closes #4396

### 🔎 Review hints
