### PR TITLE
Fix Touch Bar Start button state update for running TE (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController.swift
@@ -114,7 +114,7 @@ class TimerViewController: NSViewController {
         viewModel.onIsRunning = { [unowned self] isRunning in
             self.updateStartButton(forRunningState: isRunning)
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: kStartButtonStateChange),
-                                            object: NSNumber(value: self.startButton.state.rawValue))
+                                            object: NSNumber(value: isRunning))
         }
 
         viewModel.onDescriptionChanged = { [unowned self] description in


### PR DESCRIPTION
### 📒 Description
Fixes bug when on MacBook Touch Bar user always saw Start button, even when there was a running time entry.

Root cause: after the design update the `startButton` was not using `state` property to update between start/stop states.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships
Closes #4381

### 🔎 Review hints
