### PR TITLE
Fix description label color on Touch Bar (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/TouchBar/TimeEntryScrubberItem.xib
+++ b/src/ui/osx/TogglDesktop/Features/TouchBar/TimeEntryScrubberItem.xib
@@ -18,7 +18,7 @@
                     <rect key="frame" x="4" y="28" width="69" height="15"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" title="Description" id="WiE-03-2mE">
                         <font key="font" metaFont="label" size="12"/>
-                        <color key="textColor" name="black-text-color"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>


### PR DESCRIPTION
### 📒 Description
Changes description label color to the default white color on Touch Bar UI.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships
Closes #4382 

### 🔎 Review hints
