### PR TITLE
Fix errors when updating tags in the local database

### DIFF
--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -40,6 +40,7 @@ using Poco::Data::Keywords::useRef;
 using Poco::Data::Keywords::limit;
 using Poco::Data::Keywords::into;
 using Poco::Data::Keywords::now;
+using Poco::Data::Keywords::bind;
 
 Database::Database(const std::string &db_path)
     : session_(nullptr)
@@ -2033,7 +2034,7 @@ error Database::saveModel(
                           useRef(model->StartTime()),
                           useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
-                          useRef(model->Tags()),
+                          bind(model->Tags()),
                           useRef(model->CreatedWith()),
                           useRef(model->DeletedAt()),
                           useRef(model->UpdatedAt()),
@@ -2048,7 +2049,7 @@ error Database::saveModel(
                           useRef(model->DurationInSeconds.GetPrevious()),
                           useRef(model->Description.GetPrevious()),
                           useRef(model->CreatedWith.GetPrevious()),
-                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
+                          bind(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           useRef(model->LocalID()),
                           now;
             } else {

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -2092,7 +2092,7 @@ error Database::saveModel(
                           useRef(model->StartTime()),
                           useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
-                          useRef(model->Tags()),
+                          bind(model->Tags()),
                           useRef(model->CreatedWith()),
                           useRef(model->DeletedAt()),
                           useRef(model->UpdatedAt()),
@@ -2107,7 +2107,7 @@ error Database::saveModel(
                           useRef(model->DurationInSeconds.GetPrevious()),
                           useRef(model->Description.GetPrevious()),
                           useRef(model->CreatedWith.GetPrevious()),
-                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
+                          bind(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           useRef(model->LocalID()),
                           now;
             }
@@ -2161,7 +2161,7 @@ error Database::saveModel(
                           useRef(model->StartTime()),
                           useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
-                          useRef(model->Tags()),
+                          bind(model->Tags()),
                           useRef(model->CreatedWith()),
                           useRef(model->DeletedAt()),
                           useRef(model->UpdatedAt()),
@@ -2176,7 +2176,7 @@ error Database::saveModel(
                           useRef(model->DurationInSeconds.GetPrevious()),
                           useRef(model->Description.GetPrevious()),
                           useRef(model->CreatedWith.GetPrevious()),
-                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
+                          bind(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           now;
             } else {
                 *session_ <<
@@ -2208,7 +2208,7 @@ error Database::saveModel(
                           useRef(model->StartTime()),
                           useRef(model->StopTime()),
                           useRef(model->DurationInSeconds()),
-                          useRef(model->Tags()),
+                          bind(model->Tags()),
                           useRef(model->CreatedWith()),
                           useRef(model->DeletedAt()),
                           useRef(model->UpdatedAt()),
@@ -2223,7 +2223,7 @@ error Database::saveModel(
                           useRef(model->DurationInSeconds.GetPrevious()),
                           useRef(model->Description.GetPrevious()),
                           useRef(model->CreatedWith.GetPrevious()),
-                          useRef(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
+                          bind(TimeEntry::TagsVectorToString(model->TagNames.GetPrevious())),
                           now;
             }
             error err = last_error("saveTimeEntry");


### PR DESCRIPTION
### 📒 Description
Fix errors when updating tags in the local database

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Copy the tags string instead of using the error-prone `useRef` on a `static thread_local` string.

### 👫 Relationships
Closes #4366
Related to #3461 (not the original issue, but most of the support cases in the comments of that issue)

### 🔎 Review hints
Test that #4366 is fixed.
Test that there are no performance issues when there are many tags in the time entry.
