### PR TITLE
Fix key detection for media keys on Linux

### DIFF
--- a/third_party/qxtglobalshortcut5/gui/qxtglobalshortcut_x11.cpp
+++ b/third_party/qxtglobalshortcut5/gui/qxtglobalshortcut_x11.cpp
@@ -39,6 +39,8 @@
 #endif
 #include <X11/Xlib.h>
 
+#include "xcbkeyboard.h"
+
 namespace {
 
 const QVector<quint32> maskModifiers = QVector<quint32>()
@@ -225,6 +227,11 @@ quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key)
     KeySym keysym = XStringToKeysym(QKeySequence(key).toString().toLatin1().data());
     if (keysym == NoSymbol)
         keysym = static_cast<ushort>(key);
+
+    for (int i = 0; KeyTbl[i] != 0; i += 2) {
+        if (KeyTbl[i + 1] == key)
+            keysym = KeyTbl[i];
+    }
 
     return XKeysymToKeycode(x11.display(), keysym);
 }

--- a/third_party/qxtglobalshortcut5/gui/xcbkeyboard.h
+++ b/third_party/qxtglobalshortcut5/gui/xcbkeyboard.h
@@ -1,0 +1,571 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+// Following definitions and table are taken from
+// "qt5/qtbase/src/plugins/platforms/xcb/qxcbkeyboard.cpp".
+
+#include <Qt>
+#include <X11/keysym.h>
+
+#ifndef XK_ISO_Left_Tab
+#define XK_ISO_Left_Tab         0xFE20
+#endif
+
+#ifndef XK_dead_hook
+#define XK_dead_hook            0xFE61
+#endif
+
+#ifndef XK_dead_horn
+#define XK_dead_horn            0xFE62
+#endif
+
+#ifndef XK_Codeinput
+#define XK_Codeinput            0xFF37
+#endif
+
+#ifndef XK_Kanji_Bangou
+#define XK_Kanji_Bangou         0xFF37 /* same as codeinput */
+#endif
+
+// Fix old X libraries
+#ifndef XK_KP_Home
+#define XK_KP_Home              0xFF95
+#endif
+#ifndef XK_KP_Left
+#define XK_KP_Left              0xFF96
+#endif
+#ifndef XK_KP_Up
+#define XK_KP_Up                0xFF97
+#endif
+#ifndef XK_KP_Right
+#define XK_KP_Right             0xFF98
+#endif
+#ifndef XK_KP_Down
+#define XK_KP_Down              0xFF99
+#endif
+#ifndef XK_KP_Prior
+#define XK_KP_Prior             0xFF9A
+#endif
+#ifndef XK_KP_Next
+#define XK_KP_Next              0xFF9B
+#endif
+#ifndef XK_KP_End
+#define XK_KP_End               0xFF9C
+#endif
+#ifndef XK_KP_Insert
+#define XK_KP_Insert            0xFF9E
+#endif
+#ifndef XK_KP_Delete
+#define XK_KP_Delete            0xFF9F
+#endif
+
+// the next lines are taken on 10/2009 from X.org (X11/XF86keysym.h), defining some special
+// multimedia keys. They are included here as not every system has them.
+#define XF86XK_MonBrightnessUp     0x1008FF02
+#define XF86XK_MonBrightnessDown   0x1008FF03
+#define XF86XK_KbdLightOnOff       0x1008FF04
+#define XF86XK_KbdBrightnessUp     0x1008FF05
+#define XF86XK_KbdBrightnessDown   0x1008FF06
+#define XF86XK_Standby             0x1008FF10
+#define XF86XK_AudioLowerVolume    0x1008FF11
+#define XF86XK_AudioMute           0x1008FF12
+#define XF86XK_AudioRaiseVolume    0x1008FF13
+#define XF86XK_AudioPlay           0x1008FF14
+#define XF86XK_AudioStop           0x1008FF15
+#define XF86XK_AudioPrev           0x1008FF16
+#define XF86XK_AudioNext           0x1008FF17
+#define XF86XK_HomePage            0x1008FF18
+#define XF86XK_Mail                0x1008FF19
+#define XF86XK_Start               0x1008FF1A
+#define XF86XK_Search              0x1008FF1B
+#define XF86XK_AudioRecord         0x1008FF1C
+#define XF86XK_Calculator          0x1008FF1D
+#define XF86XK_Memo                0x1008FF1E
+#define XF86XK_ToDoList            0x1008FF1F
+#define XF86XK_Calendar            0x1008FF20
+#define XF86XK_PowerDown           0x1008FF21
+#define XF86XK_ContrastAdjust      0x1008FF22
+#define XF86XK_Back                0x1008FF26
+#define XF86XK_Forward             0x1008FF27
+#define XF86XK_Stop                0x1008FF28
+#define XF86XK_Refresh             0x1008FF29
+#define XF86XK_PowerOff            0x1008FF2A
+#define XF86XK_WakeUp              0x1008FF2B
+#define XF86XK_Eject               0x1008FF2C
+#define XF86XK_ScreenSaver         0x1008FF2D
+#define XF86XK_WWW                 0x1008FF2E
+#define XF86XK_Sleep               0x1008FF2F
+#define XF86XK_Favorites           0x1008FF30
+#define XF86XK_AudioPause          0x1008FF31
+#define XF86XK_AudioMedia          0x1008FF32
+#define XF86XK_MyComputer          0x1008FF33
+#define XF86XK_LightBulb           0x1008FF35
+#define XF86XK_Shop                0x1008FF36
+#define XF86XK_History             0x1008FF37
+#define XF86XK_OpenURL             0x1008FF38
+#define XF86XK_AddFavorite         0x1008FF39
+#define XF86XK_HotLinks            0x1008FF3A
+#define XF86XK_BrightnessAdjust    0x1008FF3B
+#define XF86XK_Finance             0x1008FF3C
+#define XF86XK_Community           0x1008FF3D
+#define XF86XK_AudioRewind         0x1008FF3E
+#define XF86XK_BackForward         0x1008FF3F
+#define XF86XK_Launch0             0x1008FF40
+#define XF86XK_Launch1             0x1008FF41
+#define XF86XK_Launch2             0x1008FF42
+#define XF86XK_Launch3             0x1008FF43
+#define XF86XK_Launch4             0x1008FF44
+#define XF86XK_Launch5             0x1008FF45
+#define XF86XK_Launch6             0x1008FF46
+#define XF86XK_Launch7             0x1008FF47
+#define XF86XK_Launch8             0x1008FF48
+#define XF86XK_Launch9             0x1008FF49
+#define XF86XK_LaunchA             0x1008FF4A
+#define XF86XK_LaunchB             0x1008FF4B
+#define XF86XK_LaunchC             0x1008FF4C
+#define XF86XK_LaunchD             0x1008FF4D
+#define XF86XK_LaunchE             0x1008FF4E
+#define XF86XK_LaunchF             0x1008FF4F
+#define XF86XK_ApplicationLeft     0x1008FF50
+#define XF86XK_ApplicationRight    0x1008FF51
+#define XF86XK_Book                0x1008FF52
+#define XF86XK_CD                  0x1008FF53
+#define XF86XK_Calculater          0x1008FF54
+#define XF86XK_Clear               0x1008FF55
+#define XF86XK_ClearGrab           0x1008FE21
+#define XF86XK_Close               0x1008FF56
+#define XF86XK_Copy                0x1008FF57
+#define XF86XK_Cut                 0x1008FF58
+#define XF86XK_Display             0x1008FF59
+#define XF86XK_DOS                 0x1008FF5A
+#define XF86XK_Documents           0x1008FF5B
+#define XF86XK_Excel               0x1008FF5C
+#define XF86XK_Explorer            0x1008FF5D
+#define XF86XK_Game                0x1008FF5E
+#define XF86XK_Go                  0x1008FF5F
+#define XF86XK_iTouch              0x1008FF60
+#define XF86XK_LogOff              0x1008FF61
+#define XF86XK_Market              0x1008FF62
+#define XF86XK_Meeting             0x1008FF63
+#define XF86XK_MenuKB              0x1008FF65
+#define XF86XK_MenuPB              0x1008FF66
+#define XF86XK_MySites             0x1008FF67
+#define XF86XK_New                 0x1008FF68
+#define XF86XK_News                0x1008FF69
+#define XF86XK_OfficeHome          0x1008FF6A
+#define XF86XK_Open                0x1008FF6B
+#define XF86XK_Option              0x1008FF6C
+#define XF86XK_Paste               0x1008FF6D
+#define XF86XK_Phone               0x1008FF6E
+#define XF86XK_Reply               0x1008FF72
+#define XF86XK_Reload              0x1008FF73
+#define XF86XK_RotateWindows       0x1008FF74
+#define XF86XK_RotationPB          0x1008FF75
+#define XF86XK_RotationKB          0x1008FF76
+#define XF86XK_Save                0x1008FF77
+#define XF86XK_Send                0x1008FF7B
+#define XF86XK_Spell               0x1008FF7C
+#define XF86XK_SplitScreen         0x1008FF7D
+#define XF86XK_Support             0x1008FF7E
+#define XF86XK_TaskPane            0x1008FF7F
+#define XF86XK_Terminal            0x1008FF80
+#define XF86XK_Tools               0x1008FF81
+#define XF86XK_Travel              0x1008FF82
+#define XF86XK_Video               0x1008FF87
+#define XF86XK_Word                0x1008FF89
+#define XF86XK_Xfer                0x1008FF8A
+#define XF86XK_ZoomIn              0x1008FF8B
+#define XF86XK_ZoomOut             0x1008FF8C
+#define XF86XK_Away                0x1008FF8D
+#define XF86XK_Messenger           0x1008FF8E
+#define XF86XK_WebCam              0x1008FF8F
+#define XF86XK_MailForward         0x1008FF90
+#define XF86XK_Pictures            0x1008FF91
+#define XF86XK_Music               0x1008FF92
+#define XF86XK_Battery             0x1008FF93
+#define XF86XK_Bluetooth           0x1008FF94
+#define XF86XK_WLAN                0x1008FF95
+#define XF86XK_UWB                 0x1008FF96
+#define XF86XK_AudioForward        0x1008FF97
+#define XF86XK_AudioRepeat         0x1008FF98
+#define XF86XK_AudioRandomPlay     0x1008FF99
+#define XF86XK_Subtitle            0x1008FF9A
+#define XF86XK_AudioCycleTrack     0x1008FF9B
+#define XF86XK_Time                0x1008FF9F
+#define XF86XK_Select              0x1008FFA0
+#define XF86XK_View                0x1008FFA1
+#define XF86XK_TopMenu             0x1008FFA2
+#define XF86XK_Red                 0x1008FFA3
+#define XF86XK_Green               0x1008FFA4
+#define XF86XK_Yellow              0x1008FFA5
+#define XF86XK_Blue                0x1008FFA6
+#define XF86XK_Suspend             0x1008FFA7
+#define XF86XK_Hibernate           0x1008FFA8
+#define XF86XK_TouchpadToggle      0x1008FFA9
+#define XF86XK_TouchpadOn          0x1008FFB0
+#define XF86XK_TouchpadOff         0x1008FFB1
+#define XF86XK_AudioMicMute        0x1008FFB2
+
+
+// end of XF86keysyms.h
+
+// keyboard mapping table
+static const unsigned int KeyTbl[] = {
+
+    // misc keys
+
+    XK_Escape,                  Qt::Key_Escape,
+    XK_Tab,                     Qt::Key_Tab,
+    XK_ISO_Left_Tab,            Qt::Key_Backtab,
+    XK_BackSpace,               Qt::Key_Backspace,
+    XK_Return,                  Qt::Key_Return,
+    XK_Insert,                  Qt::Key_Insert,
+    XK_Delete,                  Qt::Key_Delete,
+    XK_Clear,                   Qt::Key_Delete,
+    XK_Pause,                   Qt::Key_Pause,
+    XK_Print,                   Qt::Key_Print,
+    0x1005FF60,                 Qt::Key_SysReq,         // hardcoded Sun SysReq
+    0x1007ff00,                 Qt::Key_SysReq,         // hardcoded X386 SysReq
+
+    // cursor movement
+
+    XK_Home,                    Qt::Key_Home,
+    XK_End,                     Qt::Key_End,
+    XK_Left,                    Qt::Key_Left,
+    XK_Up,                      Qt::Key_Up,
+    XK_Right,                   Qt::Key_Right,
+    XK_Down,                    Qt::Key_Down,
+    XK_Prior,                   Qt::Key_PageUp,
+    XK_Next,                    Qt::Key_PageDown,
+
+    // modifiers
+
+    XK_Shift_L,                 Qt::Key_Shift,
+    XK_Shift_R,                 Qt::Key_Shift,
+    XK_Shift_Lock,              Qt::Key_Shift,
+    XK_Control_L,               Qt::Key_Control,
+    XK_Control_R,               Qt::Key_Control,
+    XK_Meta_L,                  Qt::Key_Meta,
+    XK_Meta_R,                  Qt::Key_Meta,
+    XK_Alt_L,                   Qt::Key_Alt,
+    XK_Alt_R,                   Qt::Key_Alt,
+    XK_Caps_Lock,               Qt::Key_CapsLock,
+    XK_Num_Lock,                Qt::Key_NumLock,
+    XK_Scroll_Lock,             Qt::Key_ScrollLock,
+    XK_Super_L,                 Qt::Key_Super_L,
+    XK_Super_R,                 Qt::Key_Super_R,
+    XK_Menu,                    Qt::Key_Menu,
+    XK_Hyper_L,                 Qt::Key_Hyper_L,
+    XK_Hyper_R,                 Qt::Key_Hyper_R,
+    XK_Help,                    Qt::Key_Help,
+    0x1000FF74,                 Qt::Key_Backtab,        // hardcoded HP backtab
+    0x1005FF10,                 Qt::Key_F11,            // hardcoded Sun F36 (labeled F11)
+    0x1005FF11,                 Qt::Key_F12,            // hardcoded Sun F37 (labeled F12)
+
+    // numeric and function keypad keys
+
+    XK_KP_Space,                Qt::Key_Space,
+    XK_KP_Tab,                  Qt::Key_Tab,
+    XK_KP_Enter,                Qt::Key_Enter,
+    //XK_KP_F1,                 Qt::Key_F1,
+    //XK_KP_F2,                 Qt::Key_F2,
+    //XK_KP_F3,                 Qt::Key_F3,
+    //XK_KP_F4,                 Qt::Key_F4,
+    XK_KP_Home,                 Qt::Key_Home,
+    XK_KP_Left,                 Qt::Key_Left,
+    XK_KP_Up,                   Qt::Key_Up,
+    XK_KP_Right,                Qt::Key_Right,
+    XK_KP_Down,                 Qt::Key_Down,
+    XK_KP_Prior,                Qt::Key_PageUp,
+    XK_KP_Next,                 Qt::Key_PageDown,
+    XK_KP_End,                  Qt::Key_End,
+    XK_KP_Begin,                Qt::Key_Clear,
+    XK_KP_Insert,               Qt::Key_Insert,
+    XK_KP_Delete,               Qt::Key_Delete,
+    XK_KP_Equal,                Qt::Key_Equal,
+    XK_KP_Multiply,             Qt::Key_Asterisk,
+    XK_KP_Add,                  Qt::Key_Plus,
+    XK_KP_Separator,            Qt::Key_Comma,
+    XK_KP_Subtract,             Qt::Key_Minus,
+    XK_KP_Decimal,              Qt::Key_Period,
+    XK_KP_Divide,               Qt::Key_Slash,
+
+    // International input method support keys
+
+    // International & multi-key character composition
+    XK_ISO_Level3_Shift,        Qt::Key_AltGr,
+    XK_Multi_key,               Qt::Key_Multi_key,
+    XK_Codeinput,               Qt::Key_Codeinput,
+    XK_SingleCandidate,         Qt::Key_SingleCandidate,
+    XK_MultipleCandidate,       Qt::Key_MultipleCandidate,
+    XK_PreviousCandidate,       Qt::Key_PreviousCandidate,
+
+    // Misc Functions
+    XK_Mode_switch,             Qt::Key_Mode_switch,
+    XK_script_switch,           Qt::Key_Mode_switch,
+
+    // Japanese keyboard support
+    XK_Kanji,                   Qt::Key_Kanji,
+    XK_Muhenkan,                Qt::Key_Muhenkan,
+    //XK_Henkan_Mode,           Qt::Key_Henkan_Mode,
+    XK_Henkan_Mode,             Qt::Key_Henkan,
+    XK_Henkan,                  Qt::Key_Henkan,
+    XK_Romaji,                  Qt::Key_Romaji,
+    XK_Hiragana,                Qt::Key_Hiragana,
+    XK_Katakana,                Qt::Key_Katakana,
+    XK_Hiragana_Katakana,       Qt::Key_Hiragana_Katakana,
+    XK_Zenkaku,                 Qt::Key_Zenkaku,
+    XK_Hankaku,                 Qt::Key_Hankaku,
+    XK_Zenkaku_Hankaku,         Qt::Key_Zenkaku_Hankaku,
+    XK_Touroku,                 Qt::Key_Touroku,
+    XK_Massyo,                  Qt::Key_Massyo,
+    XK_Kana_Lock,               Qt::Key_Kana_Lock,
+    XK_Kana_Shift,              Qt::Key_Kana_Shift,
+    XK_Eisu_Shift,              Qt::Key_Eisu_Shift,
+    XK_Eisu_toggle,             Qt::Key_Eisu_toggle,
+    //XK_Kanji_Bangou,          Qt::Key_Kanji_Bangou,
+    //XK_Zen_Koho,              Qt::Key_Zen_Koho,
+    //XK_Mae_Koho,              Qt::Key_Mae_Koho,
+    XK_Kanji_Bangou,            Qt::Key_Codeinput,
+    XK_Zen_Koho,                Qt::Key_MultipleCandidate,
+    XK_Mae_Koho,                Qt::Key_PreviousCandidate,
+
+#ifdef XK_KOREAN
+    // Korean keyboard support
+    XK_Hangul,                  Qt::Key_Hangul,
+    XK_Hangul_Start,            Qt::Key_Hangul_Start,
+    XK_Hangul_End,              Qt::Key_Hangul_End,
+    XK_Hangul_Hanja,            Qt::Key_Hangul_Hanja,
+    XK_Hangul_Jamo,             Qt::Key_Hangul_Jamo,
+    XK_Hangul_Romaja,           Qt::Key_Hangul_Romaja,
+    //XK_Hangul_Codeinput,      Qt::Key_Hangul_Codeinput,
+    XK_Hangul_Codeinput,        Qt::Key_Codeinput,
+    XK_Hangul_Jeonja,           Qt::Key_Hangul_Jeonja,
+    XK_Hangul_Banja,            Qt::Key_Hangul_Banja,
+    XK_Hangul_PreHanja,         Qt::Key_Hangul_PreHanja,
+    XK_Hangul_PostHanja,        Qt::Key_Hangul_PostHanja,
+    //XK_Hangul_SingleCandidate,Qt::Key_Hangul_SingleCandidate,
+    //XK_Hangul_MultipleCandidate,Qt::Key_Hangul_MultipleCandidate,
+    //XK_Hangul_PreviousCandidate,Qt::Key_Hangul_PreviousCandidate,
+    XK_Hangul_SingleCandidate,  Qt::Key_SingleCandidate,
+    XK_Hangul_MultipleCandidate,Qt::Key_MultipleCandidate,
+    XK_Hangul_PreviousCandidate,Qt::Key_PreviousCandidate,
+    XK_Hangul_Special,          Qt::Key_Hangul_Special,
+    //XK_Hangul_switch,         Qt::Key_Hangul_switch,
+    XK_Hangul_switch,           Qt::Key_Mode_switch,
+#endif  // XK_KOREAN
+
+    // dead keys
+    XK_dead_grave,              Qt::Key_Dead_Grave,
+    XK_dead_acute,              Qt::Key_Dead_Acute,
+    XK_dead_circumflex,         Qt::Key_Dead_Circumflex,
+    XK_dead_tilde,              Qt::Key_Dead_Tilde,
+    XK_dead_macron,             Qt::Key_Dead_Macron,
+    XK_dead_breve,              Qt::Key_Dead_Breve,
+    XK_dead_abovedot,           Qt::Key_Dead_Abovedot,
+    XK_dead_diaeresis,          Qt::Key_Dead_Diaeresis,
+    XK_dead_abovering,          Qt::Key_Dead_Abovering,
+    XK_dead_doubleacute,        Qt::Key_Dead_Doubleacute,
+    XK_dead_caron,              Qt::Key_Dead_Caron,
+    XK_dead_cedilla,            Qt::Key_Dead_Cedilla,
+    XK_dead_ogonek,             Qt::Key_Dead_Ogonek,
+    XK_dead_iota,               Qt::Key_Dead_Iota,
+    XK_dead_voiced_sound,       Qt::Key_Dead_Voiced_Sound,
+    XK_dead_semivoiced_sound,   Qt::Key_Dead_Semivoiced_Sound,
+    XK_dead_belowdot,           Qt::Key_Dead_Belowdot,
+    XK_dead_hook,               Qt::Key_Dead_Hook,
+    XK_dead_horn,               Qt::Key_Dead_Horn,
+
+    // Special keys from X.org - This include multimedia keys,
+        // wireless/bluetooth/uwb keys, special launcher keys, etc.
+    XF86XK_Back,                Qt::Key_Back,
+    XF86XK_Forward,             Qt::Key_Forward,
+    XF86XK_Stop,                Qt::Key_Stop,
+    XF86XK_Refresh,             Qt::Key_Refresh,
+    XF86XK_Favorites,           Qt::Key_Favorites,
+    XF86XK_AudioMedia,          Qt::Key_LaunchMedia,
+    XF86XK_OpenURL,             Qt::Key_OpenUrl,
+    XF86XK_HomePage,            Qt::Key_HomePage,
+    XF86XK_Search,              Qt::Key_Search,
+    XF86XK_AudioLowerVolume,    Qt::Key_VolumeDown,
+    XF86XK_AudioMute,           Qt::Key_VolumeMute,
+    XF86XK_AudioRaiseVolume,    Qt::Key_VolumeUp,
+    XF86XK_AudioPlay,           Qt::Key_MediaPlay,
+    XF86XK_AudioStop,           Qt::Key_MediaStop,
+    XF86XK_AudioPrev,           Qt::Key_MediaPrevious,
+    XF86XK_AudioNext,           Qt::Key_MediaNext,
+    XF86XK_AudioRecord,         Qt::Key_MediaRecord,
+    XF86XK_AudioPause,          Qt::Key_MediaPause,
+    XF86XK_Mail,                Qt::Key_LaunchMail,
+    XF86XK_MyComputer,          Qt::Key_Launch0,  // ### Qt 6: remap properly
+    XF86XK_Calculator,          Qt::Key_Launch1,
+    XF86XK_Memo,                Qt::Key_Memo,
+    XF86XK_ToDoList,            Qt::Key_ToDoList,
+    XF86XK_Calendar,            Qt::Key_Calendar,
+    XF86XK_PowerDown,           Qt::Key_PowerDown,
+    XF86XK_ContrastAdjust,      Qt::Key_ContrastAdjust,
+    XF86XK_Standby,             Qt::Key_Standby,
+    XF86XK_MonBrightnessUp,     Qt::Key_MonBrightnessUp,
+    XF86XK_MonBrightnessDown,   Qt::Key_MonBrightnessDown,
+    XF86XK_KbdLightOnOff,       Qt::Key_KeyboardLightOnOff,
+    XF86XK_KbdBrightnessUp,     Qt::Key_KeyboardBrightnessUp,
+    XF86XK_KbdBrightnessDown,   Qt::Key_KeyboardBrightnessDown,
+    XF86XK_PowerOff,            Qt::Key_PowerOff,
+    XF86XK_WakeUp,              Qt::Key_WakeUp,
+    XF86XK_Eject,               Qt::Key_Eject,
+    XF86XK_ScreenSaver,         Qt::Key_ScreenSaver,
+    XF86XK_WWW,                 Qt::Key_WWW,
+    XF86XK_Sleep,               Qt::Key_Sleep,
+    XF86XK_LightBulb,           Qt::Key_LightBulb,
+    XF86XK_Shop,                Qt::Key_Shop,
+    XF86XK_History,             Qt::Key_History,
+    XF86XK_AddFavorite,         Qt::Key_AddFavorite,
+    XF86XK_HotLinks,            Qt::Key_HotLinks,
+    XF86XK_BrightnessAdjust,    Qt::Key_BrightnessAdjust,
+    XF86XK_Finance,             Qt::Key_Finance,
+    XF86XK_Community,           Qt::Key_Community,
+    XF86XK_AudioRewind,         Qt::Key_AudioRewind,
+    XF86XK_BackForward,         Qt::Key_BackForward,
+    XF86XK_ApplicationLeft,     Qt::Key_ApplicationLeft,
+    XF86XK_ApplicationRight,    Qt::Key_ApplicationRight,
+    XF86XK_Book,                Qt::Key_Book,
+    XF86XK_CD,                  Qt::Key_CD,
+    XF86XK_Calculater,          Qt::Key_Calculator,
+    XF86XK_Clear,               Qt::Key_Clear,
+    XF86XK_ClearGrab,           Qt::Key_ClearGrab,
+    XF86XK_Close,               Qt::Key_Close,
+    XF86XK_Copy,                Qt::Key_Copy,
+    XF86XK_Cut,                 Qt::Key_Cut,
+    XF86XK_Display,             Qt::Key_Display,
+    XF86XK_DOS,                 Qt::Key_DOS,
+    XF86XK_Documents,           Qt::Key_Documents,
+    XF86XK_Excel,               Qt::Key_Excel,
+    XF86XK_Explorer,            Qt::Key_Explorer,
+    XF86XK_Game,                Qt::Key_Game,
+    XF86XK_Go,                  Qt::Key_Go,
+    XF86XK_iTouch,              Qt::Key_iTouch,
+    XF86XK_LogOff,              Qt::Key_LogOff,
+    XF86XK_Market,              Qt::Key_Market,
+    XF86XK_Meeting,             Qt::Key_Meeting,
+    XF86XK_MenuKB,              Qt::Key_MenuKB,
+    XF86XK_MenuPB,              Qt::Key_MenuPB,
+    XF86XK_MySites,             Qt::Key_MySites,
+#if QT_VERSION >= 0x050400
+    XF86XK_New,                 Qt::Key_New,
+#endif
+    XF86XK_News,                Qt::Key_News,
+    XF86XK_OfficeHome,          Qt::Key_OfficeHome,
+#if QT_VERSION >= 0x050400
+    XF86XK_Open,                Qt::Key_Open,
+#endif
+    XF86XK_Option,              Qt::Key_Option,
+    XF86XK_Paste,               Qt::Key_Paste,
+    XF86XK_Phone,               Qt::Key_Phone,
+    XF86XK_Reply,               Qt::Key_Reply,
+    XF86XK_Reload,              Qt::Key_Reload,
+    XF86XK_RotateWindows,       Qt::Key_RotateWindows,
+    XF86XK_RotationPB,          Qt::Key_RotationPB,
+    XF86XK_RotationKB,          Qt::Key_RotationKB,
+    XF86XK_Save,                Qt::Key_Save,
+    XF86XK_Send,                Qt::Key_Send,
+    XF86XK_Spell,               Qt::Key_Spell,
+    XF86XK_SplitScreen,         Qt::Key_SplitScreen,
+    XF86XK_Support,             Qt::Key_Support,
+    XF86XK_TaskPane,            Qt::Key_TaskPane,
+    XF86XK_Terminal,            Qt::Key_Terminal,
+    XF86XK_Tools,               Qt::Key_Tools,
+    XF86XK_Travel,              Qt::Key_Travel,
+    XF86XK_Video,               Qt::Key_Video,
+    XF86XK_Word,                Qt::Key_Word,
+    XF86XK_Xfer,                Qt::Key_Xfer,
+    XF86XK_ZoomIn,              Qt::Key_ZoomIn,
+    XF86XK_ZoomOut,             Qt::Key_ZoomOut,
+    XF86XK_Away,                Qt::Key_Away,
+    XF86XK_Messenger,           Qt::Key_Messenger,
+    XF86XK_WebCam,              Qt::Key_WebCam,
+    XF86XK_MailForward,         Qt::Key_MailForward,
+    XF86XK_Pictures,            Qt::Key_Pictures,
+    XF86XK_Music,               Qt::Key_Music,
+    XF86XK_Battery,             Qt::Key_Battery,
+    XF86XK_Bluetooth,           Qt::Key_Bluetooth,
+    XF86XK_WLAN,                Qt::Key_WLAN,
+    XF86XK_UWB,                 Qt::Key_UWB,
+    XF86XK_AudioForward,        Qt::Key_AudioForward,
+    XF86XK_AudioRepeat,         Qt::Key_AudioRepeat,
+    XF86XK_AudioRandomPlay,     Qt::Key_AudioRandomPlay,
+    XF86XK_Subtitle,            Qt::Key_Subtitle,
+    XF86XK_AudioCycleTrack,     Qt::Key_AudioCycleTrack,
+    XF86XK_Time,                Qt::Key_Time,
+    XF86XK_Select,              Qt::Key_Select,
+    XF86XK_View,                Qt::Key_View,
+    XF86XK_TopMenu,             Qt::Key_TopMenu,
+#if QT_VERSION >= 0x050400
+    XF86XK_Red,                 Qt::Key_Red,
+    XF86XK_Green,               Qt::Key_Green,
+    XF86XK_Yellow,              Qt::Key_Yellow,
+    XF86XK_Blue,                Qt::Key_Blue,
+#endif
+    XF86XK_Bluetooth,           Qt::Key_Bluetooth,
+    XF86XK_Suspend,             Qt::Key_Suspend,
+    XF86XK_Hibernate,           Qt::Key_Hibernate,
+#if QT_VERSION >= 0x050400
+    XF86XK_TouchpadToggle,      Qt::Key_TouchpadToggle,
+    XF86XK_TouchpadOn,          Qt::Key_TouchpadOn,
+    XF86XK_TouchpadOff,         Qt::Key_TouchpadOff,
+    XF86XK_AudioMicMute,        Qt::Key_MicMute,
+#endif
+    XF86XK_Launch0,             Qt::Key_Launch2, // ### Qt 6: remap properly
+    XF86XK_Launch1,             Qt::Key_Launch3,
+    XF86XK_Launch2,             Qt::Key_Launch4,
+    XF86XK_Launch3,             Qt::Key_Launch5,
+    XF86XK_Launch4,             Qt::Key_Launch6,
+    XF86XK_Launch5,             Qt::Key_Launch7,
+    XF86XK_Launch6,             Qt::Key_Launch8,
+    XF86XK_Launch7,             Qt::Key_Launch9,
+    XF86XK_Launch8,             Qt::Key_LaunchA,
+    XF86XK_Launch9,             Qt::Key_LaunchB,
+    XF86XK_LaunchA,             Qt::Key_LaunchC,
+    XF86XK_LaunchB,             Qt::Key_LaunchD,
+    XF86XK_LaunchC,             Qt::Key_LaunchE,
+    XF86XK_LaunchD,             Qt::Key_LaunchF,
+    XF86XK_LaunchE,             Qt::Key_LaunchG,
+    XF86XK_LaunchF,             Qt::Key_LaunchH,
+
+    0,                          0
+};


### PR DESCRIPTION
### 📒 Description

Add a key table to vendored library qxtglobalshortcut5 to look up media keys

### 🕶️ Types of changes
- **Bug fix**
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes

* Fix detection of media keys on Linux

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->
Closes #4415

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

See #4415