### PR TITLE
Updated colors for in-app message popup (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/InAppMessage/InAppMessageViewController.xib
+++ b/src/ui/osx/TogglDesktop/Features/InAppMessage/InAppMessageViewController.xib
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.3"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="InAppMessageViewController" customModule="TogglDesktop" customModuleProvider="target">
+        <customObject id="-2" userLabel="File's Owner" customClass="InAppMessageViewController" customModule="Toggl_Track" customModuleProvider="target">
             <connections>
                 <outlet property="actionBtn" destination="rxC-bp-Klf" id="yDx-zG-Nx1"/>
                 <outlet property="bottomContraint" destination="38f-IF-VVw" id="o4x-vS-Wa2"/>
@@ -25,16 +25,16 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView horizontalHuggingPriority="200" verticalHuggingPriority="200" horizontalCompressionResistancePriority="200" verticalCompressionResistancePriority="200" translatesAutoresizingMaskIntoConstraints="NO" id="nDz-FO-iVv">
-                    <rect key="frame" x="0.0" y="0.0" width="300" height="194"/>
+                    <rect key="frame" x="0.0" y="0.0" width="300" height="190"/>
                     <subviews>
                         <box horizontalHuggingPriority="200" verticalHuggingPriority="200" horizontalCompressionResistancePriority="200" verticalCompressionResistancePriority="200" boxType="custom" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Qhk-1x-OQQ">
-                            <rect key="frame" x="0.0" y="0.0" width="300" height="194"/>
+                            <rect key="frame" x="0.0" y="0.0" width="300" height="190"/>
                             <view key="contentView" id="imI-Xb-rTF">
-                                <rect key="frame" x="0.0" y="0.0" width="300" height="194"/>
+                                <rect key="frame" x="0.0" y="0.0" width="300" height="190"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="e67-AM-WSP">
-                                        <rect key="frame" x="265" y="159" width="30" height="30"/>
+                                        <rect key="frame" x="265" y="155" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="30" id="QcD-ht-A6c"/>
                                             <constraint firstAttribute="height" constant="30" id="oqt-7I-pnM"/>
@@ -47,7 +47,7 @@
                                             <action selector="closeBtnOnTap:" target="-2" id="YnC-iU-q9p"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rxC-bp-Klf" customClass="FlatButton" customModule="TogglDesktop" customModuleProvider="target">
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rxC-bp-Klf" customClass="FlatButton" customModule="Toggl_Track" customModuleProvider="target">
                                         <rect key="frame" x="50" y="15" width="200" height="36"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="ANq-0O-dMF"/>
@@ -64,13 +64,16 @@
                                             <userDefinedRuntimeAttribute type="color" keyPath="titleColor">
                                                 <color key="value" name="white"/>
                                             </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" name="upload-border-color"/>
+                                            </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <action selector="actionBtnOnTap:" target="-2" id="4CA-Yk-esK"/>
                                         </connections>
                                     </button>
                                     <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yDl-bB-gh4">
-                                        <rect key="frame" x="81" y="140" width="139" height="24"/>
+                                        <rect key="frame" x="81" y="137" width="139" height="23"/>
                                         <textFieldCell key="cell" alignment="center" title="20% discount" id="ySx-yX-KOZ">
                                             <font key="font" metaFont="systemBold" size="20"/>
                                             <color key="textColor" name="white"/>
@@ -78,7 +81,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IDE-mu-IVm">
-                                        <rect key="frame" x="13" y="71" width="274" height="54"/>
+                                        <rect key="frame" x="13" y="71" width="274" height="51"/>
                                         <textFieldCell key="cell" selectable="YES" alignment="center" title="Upgrade to Premium by January 15th to get 20% off Upgrade to Premium by January 15th to get 20% off" id="QAN-LX-DP6">
                                             <font key="font" metaFont="menu" size="14"/>
                                             <color key="textColor" name="white"/>
@@ -126,7 +129,10 @@
     <resources>
         <image name="in-app-message-close-btn" width="30" height="30"/>
         <namedColor name="in-app-message-background-color">
-            <color red="0.023529411764705882" green="0.66666666666666663" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.21176470588235294" green="0.12156862745098039" blue="0.25882352941176473" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="upload-border-color">
+            <color red="0.67450980392156867" green="0.67450980392156867" blue="0.67450980392156867" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="white">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/src/ui/osx/TogglDesktop/Resources/Media.xcassets/InappMessage/in-app-message-background-color.colorset/Contents.json
+++ b/src/ui/osx/TogglDesktop/Resources/Media.xcassets/InappMessage/in-app-message-background-color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xD0",
-          "green" : "0x68",
-          "red" : "0xDF"
+          "blue" : "0x42",
+          "green" : "0x1F",
+          "red" : "0x36"
         }
       },
       "idiom" : "mac"


### PR DESCRIPTION
### 📒 Description
The background color of the in-app message popup is now dark purple instead of pink.
Needs to be merged and released before we can run in-app survey about the timer.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships
Decided in this Slack thread 
https://toggl.slack.com/archives/C010950JMD0/p1599806425007700

### 🔎 Review hints
Branch `tmp/timer-survey-demo` has those colors and triggers the popup after app start.

<img width="501" alt="Screenshot 2020-09-15 at 18 53 35" src="https://user-images.githubusercontent.com/3470113/93327746-73e2ab00-f823-11ea-8124-c2bb2004a50c.png">
<img width="501" alt="Screenshot 2020-09-15 at 18 53 56" src="https://user-images.githubusercontent.com/3470113/93327771-7c3ae600-f823-11ea-94af-f46a3c79df5b.png">

