### PR TITLE
Fix possible NullReference

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -5003,7 +5003,9 @@ void Context::syncerActivityWrapper() {
             case STARTUP: {
                 logger.log("Syncer bootup, will attempt to determine which protocol to use");
                 //Do it here to know the type of syncing before syncerActivityWrapper() pulls the preferences
-                pullUserPreferences();
+                auto error = pullUserPreferences();
+                if (error != noError)
+                    break;
                 state = user_->AlphaFeatureSettings->IsSyncEnabled() ? state = BATCHED : LEGACY;
                 logger.log("Syncer - Syncing protocol was selected: ", (state == BATCHED ? "BATCHED" : "LEGACY"));
                 break;


### PR DESCRIPTION
### 📒 Description
There is an unsafe place where NullReference can appear while referencing AlphaFeatures sync flag.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4425 

### 🔎 Review hints
I'm not sure how to test it as the code just checks for errors appearing during pulling user preferences. Please, look at the code, it should be a safe change.

