### PR TITLE
Make List tab opened when Timeline UI is disabled

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerEntryListViewViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerEntryListViewViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive.Linq;
 using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -12,6 +13,8 @@ namespace TogglDesktop.ViewModels
             this.WhenValueChanged(x => SelectedTab)
                 .Subscribe(value => Toggl.SetActiveTab(value));
             Toggl.OnDisplayTimelineUI += isEnabled => IsTimelineViewEnabled = isEnabled;
+            this.WhenAnyValue(x => x.IsTimelineViewEnabled)
+                .Where(enabled => !enabled).Subscribe(_ => SelectedTab = 0);
         }
 
         [Reactive] 


### PR DESCRIPTION
### 📒 Description
If timeline ui alpha feature is disabled, make List tab always opened even if Timeline UI tab was previously selected.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4418 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

