### PR TITLE
Hide record activity switch in Preferences if Timeline UI enabled

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -71,6 +71,7 @@ namespace TogglDesktop.ViewModels
                 x => x.ProxyHost,
                 proxyHost => Uri.CheckHostName(proxyHost) != UriHostNameType.Unknown,
                 "Please, enter a valid host");
+            Toggl.OnDisplayTimelineUI += isEnabled => IsTimelineViewEnabled = isEnabled;
         }
 
         public ICommand ClearCacheCommand { get; }
@@ -87,6 +88,9 @@ namespace TogglDesktop.ViewModels
 
         [Reactive]
         public string ProxyHost { get; set; }
+
+        [Reactive]
+        public bool IsTimelineViewEnabled { get; private set; }
 
         public void ResetRecordedShortcuts()
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -211,12 +211,14 @@
                                            Text="minutes" />
                             </StackPanel>
                         </Grid>
-                        <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 24 0 0"
-                                   Text="Record activity" />
-                        <TextBlock Style="{DynamicResource Toggl.CaptionText}" Margin="0 4 0 0"
-                                   Text="You'll have a timeline of all activity on your computer with a breakdown of time spent on applications and websites. Only you can access this data." />
-                        <mah:ToggleSwitch Margin="0 14 0 0"
-                                          Name="recordTimelineCheckBox" x:FieldModifier="private" />
+                        <StackPanel Visibility="{Binding IsTimelineViewEnabled, Converter={StaticResource BooleanInvertToVisibilityConverter}}">
+                            <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 24 0 0"
+                                       Text="Record activity" />
+                            <TextBlock Style="{DynamicResource Toggl.CaptionText}" Margin="0 4 0 0"
+                                       Text="You'll have a timeline of all activity on your computer with a breakdown of time spent on applications and websites. Only you can access this data." />
+                            <mah:ToggleSwitch Margin="0 14 0 0"
+                                              Name="recordTimelineCheckBox" x:FieldModifier="private" />
+                        </StackPanel>
                         <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 24 0 0"
                                    Text="Stop timer automatically" />
                         <TextBlock Style="{DynamicResource Toggl.CaptionText}" Margin="0 4 0 0"


### PR DESCRIPTION
### 📒 Description
Sets record activity block visibility to false in Preferences if Timeline UI enabled.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4417 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

