### PR TITLE
Check if dbus-launch exists before running it (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop.sh
+++ b/src/ui/linux/TogglDesktop.sh
@@ -16,7 +16,8 @@ fi
 # Xubuntu, i3 and Cinnamon tray icon fix
 XDG=$XDG_CURRENT_DESKTOP
 
-if [[ "$XDG" = "X-Cinnamon" || "$XDG" = "XFCE" || "$XDG" = "Pantheon" || "$XDG" = "i3" || "$XDG" = "LXDE" || "$XDG" = "MATE" || "$XDG" = "Budgie:GNOME" ]]; then
+if command -v dbus-launch &> /dev/null && \
+    [[ "$XDG" = "X-Cinnamon" || "$XDG" = "XFCE" || "$XDG" = "Pantheon" || "$XDG" = "i3" || "$XDG" = "LXDE" || "$XDG" = "MATE" || "$XDG" = "Budgie:GNOME" ]]; then
   DBUS_SESSION_BUS_ADDRESS=""
   dbus-launch $dirname/$appname "$@" &
 else


### PR DESCRIPTION
### 📒 Description
On some distros, there's no `dbus-launch` for some reason (and I don't really understand why we're using it anyway but it doesn't harm anything so whatever). This PR will not run it in case it's not present (which seems to be the case in Linux Mint)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Fixed a crash when running without dbus-launch

### 👫 Relationships
Fixes #3357 (not just related to snaps)

### 🔎 Review hints
You can try renaming `/usr/bin/dbus-launch` to something else for a bit and see if it works right. You'll also maybe have to `export XDG_CURRENT_DESKTOP=XFCE` or something else (from the list in the same condition I modified in this PR) to observe the difference.

