### PR TITLE
Fix bug with in-app message not showing on app start (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Common/Extensions/NSView+Ext.swift
+++ b/src/ui/osx/TogglDesktop/Common/Extensions/NSView+Ext.swift
@@ -25,4 +25,9 @@ extension NSView {
             }
         }, context: &theView)
     }
+
+    @objc
+    func addSubviewToBack(_ view: NSView) {
+        addSubview(view, positioned: .below, relativeTo: nil)
+    }
 }

--- a/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
@@ -191,7 +191,7 @@ extern void *ctx;
             [self closeError];
 
             // Add Main View
-            [self.contentView addSubview:self.mainDashboardViewController.view];
+            [self.contentView addSubviewToBack:self.mainDashboardViewController.view];
             [self.mainDashboardViewController.view setFrame:self.contentView.bounds];
 
             // Dismiss Login


### PR DESCRIPTION
### 📒 Description
In-app message is always added to the view hierarchy before Main VC. This results in a situation when the Main VC is covering in-app message view and users do not see it.
This fix makes Main VC always a root view - adds it to the view hierarchy always below other views.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships
Closes #4458

### 🔎 Review hints
1. Setup the in-app message
1. Launch the app and see if the message is shown
