### PR TITLE
Open edit view on TE click

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -248,7 +248,6 @@ namespace TogglDesktop.ViewModels
                         Started = prevEnd.Value + 1,
                         Ended = entry.Started - 1
                     };
-                    gaps.Add(block);
                     if (block.Height > 10) // Don't display to small gaps not to obstruct the view
                         gaps.Add(block);
                 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -141,7 +141,7 @@ namespace TogglDesktop.ViewModels
             {
                 var startTime = Toggl.DateTimeFromUnix(entry.Started);
                 var height = ConvertTimeIntervalToHeight(startTime, Toggl.DateTimeFromUnix(entry.Ended));
-                var block = new TimeEntryBlock()
+                var block = new TimeEntryBlock(entry.GUID)
                 {
                     Height = height < 2 ? 2 : height,
                     VerticalOffset = ConvertTimeIntervalToHeight(new DateTime(startTime.Year, startTime.Month, startTime.Day), startTime),
@@ -319,15 +319,23 @@ namespace TogglDesktop.ViewModels
         public ulong Started { get; set; }
         public ulong Ended { get; set; }
         public ReactiveCommand<Unit, Unit> CreateTimeEntryFromBlock { get; }
+        public ReactiveCommand<Unit,Unit> OpenEditView { get; }
+        private string _timeEntryId;
 
-        public TimeEntryBlock()
+        public TimeEntryBlock(string timeEntryId)
         {
+            _timeEntryId = timeEntryId;
+            CreateTimeEntryFromBlock = ReactiveCommand.Create(() => AddNewTimeEntry());
+            OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(_timeEntryId, false, Toggl.Description));
             CreateTimeEntryFromBlock = ReactiveCommand.Create(AddNewTimeEntry);
         }
 
+        public TimeEntryBlock() : this(null) { }
+
         private void AddNewTimeEntry()
         {
-            Toggl.CreateEmptyTimeEntry(Started, Ended);
+            _timeEntryId = Toggl.CreateEmptyTimeEntry(Started, Ended);
+            Toggl.Edit(_timeEntryId, false, Toggl.Description);
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -16,7 +16,7 @@
             <sys:Double x:Key="PointOneDouble">0.1</sys:Double>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Button FontWeight="Normal" Command="{Binding OpenEditView}">
+    <Button FontWeight="Normal" Command="{Binding OpenEditView}" MinHeight="2">
         <Button.Template>
             <ControlTemplate>
                 <Grid Margin="0 0 4 0">
@@ -30,8 +30,9 @@
                            RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
                            RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">
                     </Rectangle>
-                    <Border CornerRadius="8,8,8,8" BorderThickness="0" Grid.Column="1" Margin="-10 0 0 0"
+                    <Border CornerRadius="8,8,8,8" Grid.Column="1" Margin="-10 0 0 0"
                         Visibility="{Binding ShowDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        BorderBrush="{Binding ElementName=TimeEntrySpan, Path=Fill}"
                         Background="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource PointOneDouble}}">
                         <StackPanel Height="{Binding Height}" Margin="20,0,0,0">
                             <TextBlock Text="{Binding Description}" Style="{StaticResource Toggl.CaptionBlackText}"/>
@@ -48,6 +49,18 @@
                             </DockPanel>
                             <TextBlock Text="{Binding ClientName}" Style="{StaticResource Toggl.CaptionText}"/>
                         </StackPanel>
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Style.Triggers>
+                                    <DataTrigger  Binding="{Binding IsEditViewOpened}" Value="True">
+                                        <Setter Property="BorderThickness" Value="1"></Setter>
+                                    </DataTrigger>
+                                    <DataTrigger  Binding="{Binding IsEditViewOpened}" Value="False">
+                                        <Setter Property="BorderThickness" Value="0"></Setter>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
                     </Border>
                 </Grid>
             </ControlTemplate>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -32,7 +32,7 @@
                     </Rectangle>
                     <Border CornerRadius="8,8,8,8" Grid.Column="1" Margin="-10 0 0 0"
                         Visibility="{Binding ShowDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
-                        BorderBrush="{Binding ElementName=TimeEntrySpan, Path=Fill}"
+                        BorderThickness="1"
                         Background="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource PointOneDouble}}">
                         <StackPanel Height="{Binding Height}" Margin="20,0,0,0">
                             <TextBlock Text="{Binding Description}" Style="{StaticResource Toggl.CaptionBlackText}"/>
@@ -52,11 +52,11 @@
                         <Border.Style>
                             <Style TargetType="Border">
                                 <Style.Triggers>
-                                    <DataTrigger  Binding="{Binding IsEditViewOpened}" Value="True">
-                                        <Setter Property="BorderThickness" Value="1"></Setter>
-                                    </DataTrigger>
                                     <DataTrigger  Binding="{Binding IsEditViewOpened}" Value="False">
-                                        <Setter Property="BorderThickness" Value="0"></Setter>
+                                        <Setter Property="BorderBrush" Value="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource PointOneDouble}}"></Setter>
+                                    </DataTrigger>
+                                    <DataTrigger  Binding="{Binding IsEditViewOpened}" Value="True">
+                                        <Setter Property="BorderBrush" Value="{Binding ElementName=TimeEntrySpan, Path=Fill}"></Setter>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -16,35 +16,41 @@
             <sys:Double x:Key="PointOneDouble">0.1</sys:Double>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid Margin="0 0 4 0">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
-        <Rectangle Grid.Column="0" Name ="TimeEntrySpan"
-                   Width="20" Height="{Binding Height}"
-                   Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
-                   RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
-                   RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">
-        </Rectangle>
-        <Border CornerRadius="8,8,8,8" BorderThickness="0" Grid.Column="1" Margin="-10 0 0 0"
-                Visibility="{Binding ShowDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
-                Background="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource PointOneDouble}}">
-            <StackPanel Height="{Binding Height}" Margin="20,0,0,0">
-                <TextBlock Text="{Binding Description}" Style="{StaticResource Toggl.CaptionBlackText}"/>
-                <DockPanel>
-                    <Ellipse Width="8" Height="8"
-                             DockPanel.Dock="Left"
-                             Margin="0 0 5 0"
-                             VerticalAlignment="Center"
-                             Fill="{Binding ElementName=TimeEntrySpan, Path=Fill}"
-                             Visibility="{Binding ProjectName, Converter={StaticResource EmptyStringToCollapsedConverter}}"/>
-                    <TextBlock Foreground="{Binding Color, Converter={StaticResource AdaptProjectTextColorConverter}}"
-                               Text="{Binding ProjectName}" FontSize="12"
-                               VerticalAlignment="Center"/>
-                </DockPanel>
-                <TextBlock Text="{Binding ClientName}" Style="{StaticResource Toggl.CaptionText}"/>
-            </StackPanel>
-        </Border>
-    </Grid>
+    <Button FontWeight="Normal" Command="{Binding OpenEditView}">
+        <Button.Template>
+            <ControlTemplate>
+                <Grid Margin="0 0 4 0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Rectangle Grid.Column="0" Name ="TimeEntrySpan"
+                           Width="20" Height="{Binding Height}"
+                           Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
+                           RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
+                           RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">
+                    </Rectangle>
+                    <Border CornerRadius="8,8,8,8" BorderThickness="0" Grid.Column="1" Margin="-10 0 0 0"
+                        Visibility="{Binding ShowDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        Background="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource PointOneDouble}}">
+                        <StackPanel Height="{Binding Height}" Margin="20,0,0,0">
+                            <TextBlock Text="{Binding Description}" Style="{StaticResource Toggl.CaptionBlackText}"/>
+                            <DockPanel>
+                                <Ellipse Width="8" Height="8"
+                                     DockPanel.Dock="Left"
+                                     Margin="0 0 5 0"
+                                     VerticalAlignment="Center"
+                                     Fill="{Binding ElementName=TimeEntrySpan, Path=Fill}"
+                                     Visibility="{Binding ProjectName, Converter={StaticResource EmptyStringToCollapsedConverter}}"/>
+                                <TextBlock Foreground="{Binding Color, Converter={StaticResource AdaptProjectTextColorConverter}}"
+                                       Text="{Binding ProjectName}" FontSize="12"
+                                       VerticalAlignment="Center"/>
+                            </DockPanel>
+                            <TextBlock Text="{Binding ClientName}" Style="{StaticResource Toggl.CaptionText}"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </ControlTemplate>
+        </Button.Template>
+    </Button>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
@@ -94,7 +94,7 @@
                                      FocusTimer="onFocusTimer"/>
             </TabItem>
 	        <TabItem Header="Timeline" Visibility="{Binding Path=IsTimelineViewEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <toggl:Timeline DataContext="{Binding TimelineViewModel}"/>
+                <toggl:Timeline DataContext="{Binding TimelineViewModel}" x:Name="Timeline"/>
             </TabItem>
         </TabControl>
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
@@ -196,5 +196,11 @@ namespace TogglDesktop
         {
             return false;
         }
+
+        public void DeselectTimeEntries()
+        {
+            Entries.DeselectCells();
+            Timeline.ViewModel.SelectedTEId = null;
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -547,9 +547,7 @@ namespace TogglDesktop
             this.updateEntriesListWidth();
             if (editPopup.IsVisible == false && ReferenceEquals(this.activeView, this.timerEntryListView))
             {
-                this.timerEntryListView.Entries.DeselectCells();
-                //TODO: Find a better way to undo the TE highlighting on Edit view closing
-                timerEntryListView.Timeline.ViewModel.SelectedTEId = null;
+                this.timerEntryListView.DeselectTimeEntries();
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -548,6 +548,8 @@ namespace TogglDesktop
             if (editPopup.IsVisible == false && ReferenceEquals(this.activeView, this.timerEntryListView))
             {
                 this.timerEntryListView.Entries.DeselectCells();
+                //TODO: Find a better way to undo the TE highlighting on Edit view closing
+                timerEntryListView.Timeline.ViewModel.SelectedTEId = null;
             }
         }
 


### PR DESCRIPTION
### 📒 Description
Opens Edit view on time entry click in Timeline UI.
Opens Edit view on a gap between time entries click.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
 **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4410 

### 🔎 Review hints
There is a default behavior in ScrollViewer that it brings into view the item, that has received focus. As a result, if user clicks on a time entry which is only partly visible, the scrollviewer will jump to fit it into view. I'm not sure if it's OK.

