### PR TITLE
Allow disabling SSL certificate verification (Windows)

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -286,6 +286,9 @@ void GoogleAnalyticsSettingsEvent::runTask() {
 
     setActionInt("color_theme-", settings.color_theme);
     makeReq();
+
+    setActionBool("force_ignore_cert-", settings.force_ignore_cert);
+    makeReq();
 }
 
 void GoogleAnalyticsSettingsEvent::setActionBool(const std::string &type, bool value) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -823,6 +823,7 @@ void Context::updateUI(const UIElements &what) {
             HTTPClient::Config.UseProxy = use_proxy;
             HTTPClient::Config.ProxySettings = proxy;
             HTTPClient::Config.AutodetectProxy = settings_.autodetect_proxy;
+            HTTPClient::Config.SetIgnoreCert(("development" == environment_) || settings_.force_ignore_cert);
         }
 
         if (what.display_unsynced_items && user_) {
@@ -2360,7 +2361,7 @@ void Context::SetEnvironment(const std::string &value) {
     logger.debug("SetEnvironment " + value);
     environment_ = value;
 
-    TogglClient::GetInstance().SetIgnoreCert(("development" == environment_));
+    TogglClient::GetInstance().SetIgnoreCert(("development" == environment_) || settings_.force_ignore_cert);
     urls::SetRequestsAllowed("test" != environment_);
 
     // stopping heavy tasks for better unit tests performance/speed

--- a/src/context.cc
+++ b/src/context.cc
@@ -823,7 +823,7 @@ void Context::updateUI(const UIElements &what) {
             HTTPClient::Config.UseProxy = use_proxy;
             HTTPClient::Config.ProxySettings = proxy;
             HTTPClient::Config.AutodetectProxy = settings_.autodetect_proxy;
-            HTTPClient::Config.SetIgnoreCert(("development" == environment_) || settings_.force_ignore_cert);
+            TogglClient::GetInstance().SetIgnoreCert(("development" == environment_) || settings_.force_ignore_cert);
         }
 
         if (what.display_unsynced_items && user_) {
@@ -2054,6 +2054,15 @@ error Context::SetSettingsActiveTab(const uint8_t active_tab) {
 error Context::SetSettingsColorTheme(const uint8_t color_theme) {
     return applySettingsSaveResultToUI(
         db()->SetSettingsColorTheme(color_theme));
+}
+
+error Context::SetSettingsForceIgnoreCert(const bool_t force_ignore_cert) {
+    error err = applySettingsSaveResultToUI(
+        db()->SetSettingsForceIgnoreCert(force_ignore_cert));
+    if (err == noError) {
+        TogglClient::GetInstance().SetIgnoreCert(("development" == environment_) || force_ignore_cert);
+    }
+    return err;
 }
 
 error Context::SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes) {

--- a/src/context.h
+++ b/src/context.h
@@ -173,6 +173,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error SetSettingsColorTheme(const uint8_t color_theme);
 
+    error SetSettingsForceIgnoreCert(const bool_t force_ignore_cert);
+
     error SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes);
 
     error SetSettingsFocusOnShortcut(const bool focus_on_shortcut);

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -423,7 +423,8 @@ error Database::LoadSettings(Settings *settings) {
                   "remind_fri, remind_sat, remind_sun, autotrack, "
                   "open_editor_on_shortcut, has_seen_beta_offering, "
                   "pomodoro, pomodoro_minutes, "
-                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep, show_touch_bar, active_tab, color_theme "
+                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep, show_touch_bar, active_tab, color_theme, "
+                  "force_ignore_cert "
                   "from settings "
                   "limit 1",
                   into(settings->use_idle_detection),

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -862,6 +862,10 @@ error Database::SetSettingsColorTheme(const uint8_t &color_theme) {
     return setSettingsValue("color_theme", color_theme);
 }
 
+error Database::SetSettingsForceIgnoreCert(const bool &force_ignore_cert) {
+    return setSettingsValue("force_ignore_cert", force_ignore_cert);
+}
+
 template<typename T>
 error Database::setSettingsValue(
     const std::string &field_name,

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -458,6 +458,7 @@ error Database::LoadSettings(Settings *settings) {
                   into(settings->show_touch_bar),
                   into(settings->active_tab),
                   into(settings->color_theme),
+                  into(settings->force_ignore_cert),
                   limit(1),
                   now;
     } catch(const Poco::Exception& exc) {

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -131,6 +131,8 @@ class TOGGL_INTERNAL_EXPORT Database {
 
     error SetSettingsColorTheme(const uint8_t &color_theme);
 
+    error SetSettingsForceIgnoreCert(const bool& force_ignore_cert);
+
     error SetSettingsRemindTimes(
         const std::string &remind_starts,
         const std::string &remind_ends);

--- a/src/database/migrations.cc
+++ b/src/database/migrations.cc
@@ -1381,6 +1381,14 @@ error Migrations::migrateSettings() {
         return err;
     }
 
+    err = db_->Migrate(
+        "settings.force_ignore_cert",
+        "ALTER TABLE settings "
+        "ADD COLUMN force_ignore_cert INTEGER NOT NULL DEFAULT 0;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/model/settings.cc
+++ b/src/model/settings.cc
@@ -39,6 +39,7 @@ Json::Value Settings::SaveToJSON(int) const {
     json["show_touch_bar"] = show_touch_bar;
     json["active_tab"] = active_tab;
     json["color_theme"] = color_theme;
+    json["force_ignore_cert"] = force_ignore_cert;
     return json;
 }
 
@@ -75,7 +76,8 @@ std::string Settings::String() const {
        << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep
        << " show_touch_bar=" << show_touch_bar
        << " active_tab=" << active_tab
-       << " color_theme=" << color_theme;
+       << " color_theme=" << color_theme
+       << " force_ignore_cert=" << force_ignore_cert;
 
     return ss.str();
 }
@@ -111,7 +113,8 @@ bool Settings::IsSame(const Settings &other) const {
             && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep)
             && (show_touch_bar == other.show_touch_bar)
             && (active_tab == other.active_tab)
-            && (color_theme == other.color_theme));
+            && (color_theme == other.color_theme)
+            && (force_ignore_cert == other.force_ignore_cert));
 }
 
 std::string Settings::ModelName() const {

--- a/src/model/settings.h
+++ b/src/model/settings.h
@@ -47,7 +47,8 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     , stop_entry_on_shutdown_sleep(false)
     , show_touch_bar(true)
     , active_tab(0)
-    , color_theme(0) {}
+    , color_theme(0)
+    , force_ignore_cert(false) {}
 
     virtual ~Settings() {}
 
@@ -82,6 +83,7 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     bool show_touch_bar;
     Poco::UInt8 active_tab;
     Poco::UInt8 color_theme;
+    bool force_ignore_cert;
 
     bool IsSame(const Settings &other) const;
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -365,6 +365,12 @@ bool_t toggl_set_proxy_settings(void *context,
     return toggl::noError == app(context)->SetProxySettings(use_proxy, proxy);
 }
 
+bool_t toggl_set_settings_ignore_cert(
+    void *context,
+    const bool_t ignore) {
+    return toggl::noError == app(context)->SetSettingsForceIgnoreCert(ignore);
+}
+
 void toggl_set_cacert_path(
     void *,
     const char_t *path) {
@@ -1710,15 +1716,6 @@ TogglServerType toggl_get_server_type() {
         return TogglServerStaging;
     else
         return TogglServerProduction;
-}
-
-void toggl_set_ignore_cert(
-    const bool_t ignore) {
-    toggl::TogglClient::GetInstance().SetIgnoreCert(ignore);
-}
-
-bool_t toggl_ignore_cert() {
-    return toggl::TogglClient::GetInstance().Config.IgnoreCert();
 }
 
 void toggl_on_timeline_ui_enabled(void *context, TogglDisplayTimelineUI cb) {

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1712,6 +1712,15 @@ TogglServerType toggl_get_server_type() {
         return TogglServerProduction;
 }
 
+void toggl_set_ignore_cert(
+    const bool_t ignore) {
+    toggl::TogglClient::GetInstance().SetIgnoreCert(ignore);
+}
+
+bool_t toggl_ignore_cert() {
+    return toggl::TogglClient::GetInstance().Config.IgnoreCert();
+}
+
 void toggl_on_timeline_ui_enabled(void *context, TogglDisplayTimelineUI cb) {
     app(context)->UI()->OnDisplayTimelineUI(cb);
 }

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -194,6 +194,7 @@ extern "C" {
         bool_t ShowTouchBar;
         uint8_t ActiveTab;
         uint8_t ColorTheme;
+        bool_t ForceIgnoreCert;
     } TogglSettingsView;
 
     typedef struct {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -453,6 +453,12 @@ typedef enum {
 
     TOGGL_EXPORT TogglServerType toggl_get_server_type();
 
+    // Ignoring SSL verification can be turned on in the UI
+    TOGGL_EXPORT void toggl_set_ignore_cert(
+        const bool_t ignore);
+
+    TOGGL_EXPORT bool_t toggl_ignore_cert();
+
     // Various parts of UI can tell the app to show itself.
 
     TOGGL_EXPORT void toggl_show_app(

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1300,10 +1300,6 @@ typedef enum {
     TOGGL_EXPORT TogglHsvColor toggl_get_adaptive_hsv_color(
        TogglRgbColor rgbColor,
        TogglAdaptiveColor type);
-    
-    TOGGL_EXPORT TogglHsvColor toggl_get_adaptive_hsv_color(
-        TogglRgbColor rgbColor,
-        TogglAdaptiveColor type);
 
     TOGGL_EXPORT bool_t toggl_get_identity_provider_sso(
         void *context,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -243,11 +243,11 @@ extern "C" {
     } TimelineMenuContextType;
 
     typedef enum {
-        TimerEditActionTypeDescription = 1u << 0,
-        TimerEditActionTypeDuration = 1u << 1,
-        TimerEditActionTypeProject = 1u << 2,
-        TimerEditActionTypeTags = 1u << 3,
-        TimerEditActionTypeBillable = 1u << 4
+        TimerEditActionTypeDescription = 1 << 0,
+        TimerEditActionTypeDuration = 1 << 1,
+        TimerEditActionTypeProject = 1 << 2,
+        TimerEditActionTypeTags = 1 << 3,
+        TimerEditActionTypeBillable = 1 << 4
     } TimerEditActionType;
 
 typedef enum {
@@ -1325,7 +1325,7 @@ typedef enum {
         TogglAdaptiveColor type);
 
     TOGGL_EXPORT void toggl_on_timeline_ui_enabled(
-        void* context,
+        void *context,
         TogglDisplayTimelineUI cb);
 
 #undef TOGGL_EXPORT

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -455,10 +455,9 @@ typedef enum {
     TOGGL_EXPORT TogglServerType toggl_get_server_type();
 
     // Ignoring SSL verification can be turned on in the UI
-    TOGGL_EXPORT void toggl_set_ignore_cert(
+    TOGGL_EXPORT bool_t toggl_set_settings_ignore_cert(
+        void *context,
         const bool_t ignore);
-
-    TOGGL_EXPORT bool_t toggl_ignore_cert();
 
     // Various parts of UI can tell the app to show itself.
 

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -483,6 +483,7 @@ TogglSettingsView *settings_view_item_init(
     view->ShowTouchBar = settings.show_touch_bar;
     view->ActiveTab = settings.active_tab;
     view->ColorTheme = settings.color_theme;
+    view->ForceIgnoreCert = settings.force_ignore_cert;
     return view;
 }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1521,11 +1521,6 @@ public static partial class Toggl
         return toggl_get_active_tab(ctx);
     }
 
-    public static bool IsTimelineUiEnabled()
-    {
-        return toggl_is_timeline_ui_enabled(ctx);
-    }
-
     public static bool SetTimelineRecordingEnabled(bool recordTimeline)
     {
         return toggl_timeline_toggle_recording(ctx, recordTimeline);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -300,17 +300,7 @@ public static partial class Toggl
     {
         toggl_reset_enable_SSO(ctx);
     }
-
-    public static bool GetIgnoreCert()
-    {
-        return toggl_ignore_cert();
-    }
-
-    public static void SetIgnoreCert(bool ignore)
-    {
-        toggl_set_ignore_cert(ignore);
-    }
-
+    
     public static bool GoogleSignup(string access_token, long country_id)
     {
         return toggl_google_signup(ctx, access_token, Convert.ToUInt64(country_id));
@@ -579,6 +569,11 @@ public static partial class Toggl
         }
 
         if (!toggl_set_settings_color_theme(ctx, settings.ColorTheme))
+        {
+            return false;
+        }
+
+        if (!toggl_set_settings_ignore_cert(ctx, settings.ForceIgnoreCert))
         {
             return false;
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -301,6 +301,16 @@ public static partial class Toggl
         toggl_reset_enable_SSO(ctx);
     }
 
+    public static bool GetIgnoreCert()
+    {
+        return toggl_ignore_cert();
+    }
+
+    public static void SetIgnoreCert(bool ignore)
+    {
+        toggl_set_ignore_cert(ignore);
+    }
+
     public static bool GoogleSignup(string access_token, long country_id)
     {
         return toggl_google_signup(ctx, access_token, Convert.ToUInt64(country_id));

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -315,6 +315,8 @@ public         bool StopEntryOnShutdownSleep;
 public         bool ShowTouchBar;
 public         byte ActiveTab;
 public         byte ColorTheme;
+[MarshalAs(UnmanagedType.I1)]
+public         bool ForceIgnoreCert;
 
 public override string ToString()
 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -705,13 +705,11 @@ private static extern TogglServerType toggl_get_server_type();
 
     // Ignoring SSL verification can be turned on in the UI
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-private static extern void toggl_set_ignore_cert(
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_ignore_cert(
+        IntPtr context,
 [MarshalAs(UnmanagedType.I1)]
         bool ignore);
-
-[DllImport(dll, CharSet = charset, CallingConvention = convention)]
-[return:MarshalAs(UnmanagedType.I1)]
-private static extern bool toggl_ignore_cert();
 
     // Various parts of UI can tell the app to show itself.
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -398,6 +398,21 @@ public enum    TimelineMenuContextType
         TimelineMenuContextTypeChangeLastEntryStartTime
 }
 
+public enum    TimerEditActionType
+{
+        TimerEditActionTypeDescription = 1 << 0,
+        TimerEditActionTypeDuration = 1 << 1,
+        TimerEditActionTypeProject = 1 << 2,
+        TimerEditActionTypeTags = 1 << 3,
+        TimerEditActionTypeBillable = 1 << 4
+}
+
+public enum    TogglServerType
+{
+        TogglServerStaging = 0,
+        TogglServerProduction
+}
+
     // Callbacks that need to be implemented in UI
 
 [UnmanagedFunctionPointer(convention)]
@@ -681,6 +696,21 @@ private static extern void toggl_set_staging_override(
 [MarshalAs(UnmanagedType.I1)]
         bool value);
 
+    // To request what server is set up in the library
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern TogglServerType toggl_get_server_type();
+
+    // Ignoring SSL verification can be turned on in the UI
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_ignore_cert(
+[MarshalAs(UnmanagedType.I1)]
+        bool ignore);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_ignore_cert();
+
     // Various parts of UI can tell the app to show itself.
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
@@ -779,11 +809,6 @@ private static extern void toggl_toggle_entries_group(
 private static extern void toggl_on_timeline(
         IntPtr context,
         TogglDisplayTimeline cb);
-
-[DllImport(dll, CharSet = charset, CallingConvention = convention)]
-private static extern void toggl_on_timeline_ui_enabled(
-        IntPtr context,
-        TogglDisplayTimelineUI cb);
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
 private static extern void toggl_on_mini_timer_autocomplete(
@@ -1201,6 +1226,17 @@ private static extern bool toggl_discard_time_and_continue(
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
 [return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_can_see_billable(
+        IntPtr context,
+        Int64 workspaceID);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_fetch_tags(
+        IntPtr context,
+        Int64 workspaceID);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
 private static extern bool toggl_set_settings_remind_days(
         IntPtr context,
 [MarshalAs(UnmanagedType.I1)]
@@ -1599,6 +1635,10 @@ private static extern UInt64 toggl_get_default_task_id(
         IntPtr context);
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern UInt64 toggl_get_default_or_first_workspace_id(
+        IntPtr context);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
 [return:MarshalAs(UnmanagedType.I1)]
 private static extern bool toggl_set_update_channel(
         IntPtr context,
@@ -1839,6 +1879,16 @@ private static extern void track_expand_all_days(
         IntPtr context);
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void track_timer_edit(
+        IntPtr context,
+        TimerEditActionType action);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void track_timer_start(
+        IntPtr context,
+        TimerEditActionType actions);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
 [return:MarshalAs(UnmanagedType.I1)]
 private static extern bool toggl_update_time_entry(
         IntPtr context,
@@ -1921,9 +1971,9 @@ private static extern TogglRgbColor toggl_get_adaptive_rgb_color_from_hex(
         TogglAdaptiveColor type);
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-[return:MarshalAs(UnmanagedType.I1)]
-private static extern bool toggl_is_timeline_ui_enabled(
-        IntPtr context);
+private static extern void toggl_on_timeline_ui_enabled(
+        IntPtr context,
+        TogglDisplayTimelineUI cb);
 
 
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -73,9 +73,6 @@ namespace TogglDesktop.ViewModels
                 proxyHost => Uri.CheckHostName(proxyHost) != UriHostNameType.Unknown,
                 "Please, enter a valid host");
             Toggl.OnDisplayTimelineUI += isEnabled => IsTimelineViewEnabled = isEnabled;
-            this.WhenValueChanged(x => x.IsIgnoreCertEnabled)
-                .ObserveOn(RxApp.TaskpoolScheduler)
-                .Subscribe(ignore => Toggl.SetIgnoreCert(ignore));
         }
 
         public ICommand ClearCacheCommand { get; }
@@ -112,11 +109,6 @@ namespace TogglDesktop.ViewModels
             ShowHideToggl = _showHideTogglSaved;
             _continueStopTimerSaved = LoadHotKey(Toggl.GetKeyStart, Toggl.GetKeyModifierStart);
             ContinueStopTimer = _continueStopTimerSaved;
-        }
-
-        public void LoadIgnoreCert()
-        {
-            IsIgnoreCertEnabled = Toggl.GetIgnoreCert();
         }
 
         public void SetSavedProxyHost(String savedProxyHost)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/PreferencesWindowViewModel.cs
@@ -10,6 +10,7 @@ using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 using ValidationHelper = ReactiveUI.Validation.Helpers.ValidationHelper;
 using static TogglDesktop.MessageBox;
+using DynamicData.Binding;
 
 namespace TogglDesktop.ViewModels
 {
@@ -72,6 +73,9 @@ namespace TogglDesktop.ViewModels
                 proxyHost => Uri.CheckHostName(proxyHost) != UriHostNameType.Unknown,
                 "Please, enter a valid host");
             Toggl.OnDisplayTimelineUI += isEnabled => IsTimelineViewEnabled = isEnabled;
+            this.WhenValueChanged(x => x.IsIgnoreCertEnabled)
+                .ObserveOn(RxApp.TaskpoolScheduler)
+                .Subscribe(ignore => Toggl.SetIgnoreCert(ignore));
         }
 
         public ICommand ClearCacheCommand { get; }
@@ -92,6 +96,9 @@ namespace TogglDesktop.ViewModels
         [Reactive]
         public bool IsTimelineViewEnabled { get; private set; }
 
+        [Reactive]
+        public bool IsIgnoreCertEnabled { get; set; }
+
         public void ResetRecordedShortcuts()
         {
             ShowHideToggl = _showHideTogglSaved;
@@ -105,6 +112,11 @@ namespace TogglDesktop.ViewModels
             ShowHideToggl = _showHideTogglSaved;
             _continueStopTimerSaved = LoadHotKey(Toggl.GetKeyStart, Toggl.GetKeyModifierStart);
             ContinueStopTimer = _continueStopTimerSaved;
+        }
+
+        public void LoadIgnoreCert()
+        {
+            IsIgnoreCertEnabled = Toggl.GetIgnoreCert();
         }
 
         public void SetSavedProxyHost(String savedProxyHost)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -414,7 +414,8 @@
                                    Text="Ignore SSL verification" />
                     <TextBlock Style="{DynamicResource Toggl.CaptionText}"  Margin="0 4 0 0"
                                    Text="NOT RECOMMENDED, this can make the app vulnerable to man-in-the-middle attacks." />
-                    <mah:ToggleSwitch Margin="0 8 0 0" IsChecked="{Binding IsIgnoreCertEnabled}"/>
+                    <mah:ToggleSwitch x:Name="ignoreCertificateToggleSwitch" x:FieldModifier="private"
+                                      Margin="0 8 0 0" />
                     
                 </StackPanel>
             </TabItem>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -408,6 +408,15 @@
                                          Name="proxyPasswordBox" x:FieldModifier="private"/>
                         </Grid>
                     </StackPanel>
+
+                    <TextBlock Style="{DynamicResource Toggl.BodyText}"
+                               Margin="0 30 0 0"
+                                   Text="Ignore SSL verification" />
+                    <TextBlock Style="{DynamicResource Toggl.CaptionText}"  Margin="0 4 0 0"
+                                   Text="NOT RECOMMENDED, this can make the app vulnerable to man-in-the-middle attacks." />
+                    <mah:ToggleSwitch Name="ignoreSSLVerificationToggleSwitch" x:FieldModifier="private"
+                                      Margin="0 8 0 0" />
+                    
                 </StackPanel>
             </TabItem>
         </TabControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -414,8 +414,7 @@
                                    Text="Ignore SSL verification" />
                     <TextBlock Style="{DynamicResource Toggl.CaptionText}"  Margin="0 4 0 0"
                                    Text="NOT RECOMMENDED, this can make the app vulnerable to man-in-the-middle attacks." />
-                    <mah:ToggleSwitch Name="ignoreSSLVerificationToggleSwitch" x:FieldModifier="private"
-                                      Margin="0 8 0 0" />
+                    <mah:ToggleSwitch Margin="0 8 0 0" IsChecked="{Binding IsIgnoreCertEnabled}"/>
                     
                 </StackPanel>
             </TabItem>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -153,6 +153,7 @@ namespace TogglDesktop
             #endregion
 
             ViewModel.LoadShortcutsFromSettings();
+            ViewModel.LoadIgnoreCert();
             ViewModel.SetSavedProxyHost(settings.ProxyHost);
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -126,6 +126,7 @@ namespace TogglDesktop
             this.proxyPortTextBox.Text = settings.ProxyPort.ToString();
             this.proxyUsernameTextBox.Text = settings.ProxyUsername;
             this.proxyPasswordBox.Password = settings.ProxyPassword;
+            this.ignoreCertificateToggleSwitch.IsChecked = settings.ForceIgnoreCert;
 
             #endregion
 
@@ -153,7 +154,6 @@ namespace TogglDesktop
             #endregion
 
             ViewModel.LoadShortcutsFromSettings();
-            ViewModel.LoadIgnoreCert();
             ViewModel.SetSavedProxyHost(settings.ProxyHost);
         }
 
@@ -282,6 +282,7 @@ namespace TogglDesktop
                 ProxyPort = toULong(this.proxyPortTextBox.Text),
                 ProxyUsername = this.proxyUsernameTextBox.Text,
                 ProxyPassword = this.proxyPasswordBox.Password,
+                ForceIgnoreCert = isChecked(this.ignoreCertificateToggleSwitch),
 
                 #endregion
 


### PR DESCRIPTION
### 📒 Description
This PR adds a feature to allow disabling SSL certificate verification in the Windows app.

### 🕶️ Types of changes
 - **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] New library setting (saving and retrieving from database, analytics tracking)
- [x] New API method to save the setting
- [x] Added new setting to Windows app Preferences (Proxy tab)

### 👫 Relationships
Closes #4452 

### 🔎 Review hints

Debug mode:
- SSL verification should remain off at all times

Release mode:
- SSL verification should be on by default
- When turning on and saving the "Ignore SSL verification" setting the SSL verification should be off
- The "Ignore SSL verification" setting should be persisted between app starts

One suggested way to test SSL verification 
- use Fiddler and turn on Tools->Options->HTTPS->Decrypt HTTPS traffic
- open Toggl Track -> Preferences and make sure Proxy->Use system proxy settings is on
- Toggl Track would now fail to connect due to certificate verification error (unless SSL verification is off)