### PR TITLE
Fix billable when applying description autocomplete

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewModel.swift
@@ -294,9 +294,9 @@ final class TimerViewModel: NSObject {
             workspaceID = DesktopLibraryBridge.shared().defaultWorkspaceID()
             timeEntry.workspaceID = workspaceID
         }
-        let canSeeBillable = DesktopLibraryBridge.shared().canSeeBillable(forWorkspaceID: workspaceID)
+        timeEntry.canSeeBillable = DesktopLibraryBridge.shared().canSeeBillable(forWorkspaceID: workspaceID)
 
-        if canSeeBillable {
+        if timeEntry.canSeeBillable {
             billableState = timeEntry.billable ? .on : .off
         } else {
             billableState = .unavailable


### PR DESCRIPTION
### 📒 Description
Fixes a possible issue when the app incorrectly believes the billable feature is not available for the user.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4466

### 🔎 Review hints
1. In Preferences, select the default project which belongs to the free workspace
2. Start an empty timer
3. Focus the description field in the Timer
4. Open autocomplete
5a. Pick a TE which has a billable flag on
5b. Pick a project which is billable by default

Expected result:
A billable flag should be on