### PR TITLE
Change default TE duration to 1 hour

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/TimelineDashboardViewController.swift
@@ -585,7 +585,7 @@ extension TimelineDashboardViewController: TimelineCollectionViewDelegate {
         }
 
         // Create
-        let defaultDuration: TimeInterval = 1
+        let defaultDuration: TimeInterval = 60 * 60 // 1 hour
         startNewTimeEntry(at: startTime, ended: startTime + defaultDuration)
 
         // Onboarding
@@ -605,6 +605,11 @@ extension TimelineDashboardViewController: TimelineCollectionViewDelegate {
         closeAllPopovers()
         datasource.createdDraggingTimeEntry(withStartTime: startTime, endTime: endTime)
         startNewTimeEntry(at: startTime, ended: endTime)
+    }
+
+    func timelineDidClick(with startTime: TimeInterval) {
+        closeAllPopovers()
+        timelineShouldCreateEmptyEntry(with: startTime)
     }
 }
 


### PR DESCRIPTION
### 📒 Description
Detect clicks and click-drags for tiny durations and create a TE with a default duration of 1 hour instead. This is consistent with the Calendar view implementation in the web app.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4445 

### 🔎 Review hints
Check the code
Test out the UX

Not sure if it's a good way to detect clicks, please comment if you think you know a better way