### PR TITLE
Fix Linux autocomplete focus issues

### DIFF
--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -129,17 +129,15 @@ void AutocompleteComboBox::onDropdownSelected(AutocompleteView *item) {
             emit projectSelected(item->ProjectLabel, item->ProjectID, item->ProjectColor, item->TaskLabel, item->TaskID);
             emit billableChanged(item->Billable);
             emit tagsChanged(item->Tags);
-            emit timeEntrySelected(item->Text);
-            setCurrentText(item->Description);
+            emit timeEntrySelected(item->Description);
             break;
         case 1:
             emit projectSelected(item->ProjectLabel, item->ProjectID, item->ProjectColor, item->TaskLabel, item->TaskID);
             emit billableChanged(item->Billable);
-            setCurrentText(item->ProjectLabel + (item->ClientLabel.isEmpty() ? "" : ". " + item->ClientLabel));
             break;
         case 2:
             emit projectSelected(item->Text, item->ProjectID, item->ProjectColor, QString(), 0);
-            setCurrentText(item->ProjectLabel + (item->ClientLabel.isEmpty() ? "" : ". " + item->ClientLabel));
+            emit billableChanged(item->Billable);
             break;
         default:
             break;

--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -46,6 +46,9 @@ bool AutocompleteComboBox::eventFilter(QObject *o, QEvent *e) {
         auto ke = reinterpret_cast<QKeyEvent*>(e);
         switch (ke->key()) {
         case Qt::Key_Tab:
+            cancelSelection();
+            focusNextChild();
+            break;
         case Qt::Key_Escape:
             cancelSelection();
             return true;

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -446,6 +446,7 @@ void TimeEntryEditorWidget::on_project_activated(int index) {
                                                 view->TaskID,
                                                 view->ProjectID,
                                                 "");
+        ui->project->setCurrentText(view->Text);
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -50,6 +50,8 @@ selectedProjectId(0) {
             this, SLOT(descriptionProjectSelected(QString,uint64_t,QString,QString,uint64_t)));
     connect(ui->description, SIGNAL(billableChanged(bool)),
             this, SLOT(descriptionBillableChanged(bool)));
+    connect(ui->description, SIGNAL(timeEntrySelected(QString)),
+            this, SLOT(descriptionTimeEntrySelected(QString)));
     connect(ui->description, SIGNAL(tagsChanged(QString)),
             this, SLOT(descriptionTagsChanged(QString)));
     connect(ui->description, &QComboBox::editTextChanged,
@@ -99,6 +101,7 @@ void TimerWidget::descriptionReturnPressed() {
 void TimerWidget::descriptionProjectSelected(const QString &projectName, uint64_t projectId, const QString &color, const QString &taskName, uint64_t taskId) {
     selectedProjectId = projectId;
     selectedTaskId = taskId;
+    ui->description->setCurrentText(QString());
     if (projectId && !projectName.isEmpty()) {
         ui->projectFrame->setVisible(true);
         ui->project->setText(QString("<font color=\"%1\">%2</font>").arg(color).arg(projectName));
@@ -108,6 +111,13 @@ void TimerWidget::descriptionProjectSelected(const QString &projectName, uint64_
             ui->taskFrame->setVisible(true);
             ui->task->setText(QString("<font color=\"gray\">%1</font>").arg(taskName));
         }
+        else {
+            ui->taskFrame->setVisible(false);
+        }
+    }
+    else {
+        ui->projectFrame->setVisible(false);
+        ui->taskFrame->setVisible(false);
     }
 }
 
@@ -119,6 +129,10 @@ void TimerWidget::descriptionTagsChanged(const QString &tags) {
     ui->tags->setVisible(!tags.isEmpty());
     ui->tags->setToolTip("<p style='color:white;background-color:black;'>" + tags + "</p>");
     tagsHolder = tags;
+}
+
+void TimerWidget::descriptionTimeEntrySelected(const QString &name) {
+    ui->description->setCurrentText(name);
 }
 
 void TimerWidget::clearProject() {

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -60,6 +60,7 @@ class TimerWidget : public QFrame {
     void descriptionProjectSelected(const QString &projectName, uint64_t projectId, const QString &color, const QString &taskName, uint64_t taskId);
     void descriptionBillableChanged(bool billable);
     void descriptionTagsChanged(const QString &tags);
+    void descriptionTimeEntrySelected(const QString &name);
 
     void clearProject();
     void clearTask();


### PR DESCRIPTION
### 📒 Description
This issue fixes the overall weird autocomplete behavior described partially in #4446 . It was really hard to pull this off because the way we're hacking around the combobox dropdown is probably not the right way (sorry!) and fixing one thing sometimes breaks something else (however I think it's really fine now).

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Autocomplete behavior is now more consistent

### 👫 Relationships
Closes #4446 

### 🔎 Review hints
Autocomplete dropdown is used in three places:
 * in the timer
 * in time entry editor for the description
 * in time entry editor for the project

