### PR TITLE
Stop macOS timer survey

### DIFF
--- a/releases/message.json
+++ b/releases/message.json
@@ -1,7 +1,7 @@
 {
     "id": 5,
     "from": 1600925481,
-    "to": 1602288000,
+    "to": 1601301350,
     "type": 0,
     "appversion": "7.5.286",
     "title": "How is your experience using the updated Timer?",


### PR DESCRIPTION
### 📒 Description
This will stop currently running in-app message about the new timer survey on macOS.

### 🕶️ Types of changes
-

### 🤯 List of changes

### 👫 Relationships
Related to #4456

### 🔎 Review hints
