### PR TITLE
Add a seconds tooltip to start and end in TE Editor (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -260,9 +260,11 @@ void TimeEntryEditorWidget::displayTimeEntryEditor(
 
     if (!ui->start->hasFocus()) {
         ui->start->setText(view->StartTimeString);
+        ui->start->setToolTip(TogglApi::formatDurationForPopup(view->Started));
     }
     if (!ui->stop->hasFocus()) {
         ui->stop->setText(view->EndTimeString);
+        ui->stop->setToolTip(TogglApi::formatDurationForPopup(view->Ended));
     }
     ui->stop->setVisible(duration >= 0);
     ui->timeSeparator->setVisible(duration >= 0);

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -567,12 +567,17 @@ bool TogglApi::stop() {
     return toggl_stop(ctx, false);
 }
 
-const QString TogglApi::formatDurationInSecondsHHMMSS(
-    const int64_t duration) {
+QString TogglApi::formatDurationInSecondsHHMMSS(
+    int64_t duration) {
     char_t *buf = toggl_format_tracking_time_duration(duration);
     QString res = toQString(buf);
     free(buf);
     return res;
+}
+
+QString TogglApi::formatDurationForPopup(
+    int64_t time) {
+    return QDateTime::fromTime_t(time).time().toString("hh:mm::ss AP");
 }
 
 bool TogglApi::continueTimeEntry(const QString guid) {

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -242,8 +242,11 @@ class TogglApi : public QObject {
 
     bool runScriptFile(const QString filename);
 
-    static const QString formatDurationInSecondsHHMMSS(
-        const int64_t duration);
+    static QString formatDurationInSecondsHHMMSS(
+        int64_t duration);
+
+    static QString formatDurationForPopup(
+        int64_t time);
 
     QRect const getWindowsFrameSetting();
     void setWindowsFrameSetting(const QRect frame);


### PR DESCRIPTION
### 📒 Description
This adds a seconds-precise tooltip to the started and ended fields in the time entry editor.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Hovering over the time entry start and end in the editor will show more precise start and end times

### 👫 Relationships
Closes #3366

### 🔎 Review hints
Just hover over the fields mentioned. Before there was no tooltip.

