### PR TITLE
Add running time entry information to system tray (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/systemtray.cpp
+++ b/src/ui/linux/TogglDesktop/systemtray.cpp
@@ -20,6 +20,9 @@ SystemTray::SystemTray(MainWindowController *parent, QIcon defaultIcon) :
     connect(TogglApi::instance, SIGNAL(displayReminder(QString,QString)),  // NOLINT
             this, SLOT(displayReminder(QString,QString)));  // NOLINT
 
+    connect(TogglApi::instance, SIGNAL(displayRunningTimerState(TimeEntryView *)), this, SLOT(displayRunningTimerState(TimeEntryView *)));
+    connect(TogglApi::instance, SIGNAL(displayStoppedTimerState()), this, SLOT(displayStoppedState()));
+
     notifications = new QDBusInterface("org.freedesktop.Notifications", "/org/freedesktop/Notifications", "org.freedesktop.Notifications", QDBusConnection::sessionBus(), this);
     notificationsPresent = notifications->isValid();
 
@@ -144,4 +147,16 @@ void SystemTray::displayIdleNotification(
 
 void SystemTray::displayReminder(QString title, QString description) {
     lastReminder = requestNotification(lastReminder, title, description);
+}
+
+void SystemTray::displayRunningTimerState(TimeEntryView *view) {
+    auto ptcLabel =
+        (view->TaskLabel.isEmpty() ? "" : view->TaskLabel + " ") +
+        (view->ProjectLabel.isEmpty() ? "" : view->ProjectLabel + " ") +
+        (view->ClientLabel.isEmpty() ? "" : view->ClientLabel + " ");
+    setToolTip(view->Description + " - " + ptcLabel + "(" + view->Duration + ")");
+}
+
+void SystemTray::displayStoppedState() {
+    setToolTip("Toggl Track");
 }

--- a/src/ui/linux/TogglDesktop/systemtray.h
+++ b/src/ui/linux/TogglDesktop/systemtray.h
@@ -6,6 +6,8 @@
 #include <QSystemTrayIcon>
 #include <QtDBus/QtDBus>
 
+#include "timeentryview.h"
+
 class MainWindowController;
 class SettingsView;
 
@@ -38,6 +40,8 @@ protected slots:
     void displayRunningTimerState(TimeEntryView *view);
     void displayStoppedState();
 
+    void updateTooltip();
+
 
 private:
     QTimer *idleHintTimer;
@@ -50,6 +54,9 @@ private:
     uint64_t lastStarted;
 
     bool notificationsPresent;
+
+    TimeEntryView *runningTimeEntry { nullptr };
+    QTimer updateTooltipTimer;
 };
 
 #endif // SYSTEMTRAY_H

--- a/src/ui/linux/TogglDesktop/systemtray.h
+++ b/src/ui/linux/TogglDesktop/systemtray.h
@@ -35,6 +35,10 @@ protected slots:
 
     void displayReminder(QString title, QString description);
 
+    void displayRunningTimerState(TimeEntryView *view);
+    void displayStoppedState();
+
+
 private:
     QTimer *idleHintTimer;
     QDBusInterface *notifications;


### PR DESCRIPTION
### 📒 Description
This PR adds running time entry information to the system tray on Linux. I opted to not implement total daily tracked time because the library doesn't expose it directly and implementing it in however way would either be a hack or it would possibly break current functionality on Windows (and probably on macOS as well).

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
Closes #2827

### 🔎 Review hints
In GNOME, you'll probably need the TopIcons Plus extension enabled to actually see the icon because GNOME developers hate the system tray (for real).
