### PR TITLE
Add a dialog with a link for browserless environments (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/CMakeLists.txt
+++ b/src/ui/linux/TogglDesktop/CMakeLists.txt
@@ -20,8 +20,10 @@ set(BINARY_SOURCE_FILES
     autocompletelistmodel.cpp
     autocompleteview.cpp
     clickablelabel.cpp
+    clipboarddialog.cpp
     colorpicker.cpp
     countryview.cpp
+    desktopservices.cpp
     errorviewcontroller.cpp
     feedbackdialog.cpp
     genericview.cpp
@@ -48,6 +50,7 @@ set(BINARY_SOURCE_FILES
 
     # it's better to list UI files
     aboutdialog.ui
+    clipboarddialog.ui
     colorpicker.ui
     errorviewcontroller.ui
     feedbackdialog.ui

--- a/src/ui/linux/TogglDesktop/aboutdialog.cpp
+++ b/src/ui/linux/TogglDesktop/aboutdialog.cpp
@@ -47,7 +47,7 @@ void AboutDialog::displayUpdate(const QString update_url) {
 
 void AboutDialog::on_updateButton_clicked() {
     qDebug() << "on_updateButton_clicked url=" << url;
-    QDesktopServices::openUrl(QUrl(url));
+    QMetaObject::invokeMethod(DesktopServices::instance(), "openUrl", Q_ARG(QUrl, url));
     TogglApi::instance->shutdown = true;
     qApp->exit(0);
 }

--- a/src/ui/linux/TogglDesktop/clipboarddialog.cpp
+++ b/src/ui/linux/TogglDesktop/clipboarddialog.cpp
@@ -1,0 +1,29 @@
+#include "clipboarddialog.h"
+#include "ui_clipboarddialog.h"
+
+#include <QUrl>
+#include <QClipboard>
+
+ClipboardDialog::ClipboardDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ClipboardDialog)
+{
+    ui->setupUi(this);
+}
+
+ClipboardDialog::~ClipboardDialog()
+{
+    delete ui;
+}
+
+void ClipboardDialog::showUrl(const QUrl &url) {
+    ui->url->setText(url.toString());
+    show();
+    ui->url->setFocus();
+    ui->url->selectAll();
+}
+
+void ClipboardDialog::on_copyButton_clicked() {
+    auto clipboard = QGuiApplication::clipboard();
+    clipboard->setText(ui->url->text());
+}

--- a/src/ui/linux/TogglDesktop/clipboarddialog.h
+++ b/src/ui/linux/TogglDesktop/clipboarddialog.h
@@ -1,0 +1,27 @@
+#ifndef CLIPBOARDDIALOG_H
+#define CLIPBOARDDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class ClipboardDialog;
+}
+
+class ClipboardDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit ClipboardDialog(QWidget *parent = nullptr);
+    ~ClipboardDialog();
+
+    void showUrl(const QUrl &url);
+
+private slots:
+    void on_copyButton_clicked();
+
+
+private:
+    Ui::ClipboardDialog *ui;
+};
+
+#endif // CLIPBOARDDIALOG_H

--- a/src/ui/linux/TogglDesktop/clipboarddialog.ui
+++ b/src/ui/linux/TogglDesktop/clipboarddialog.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ClipboardDialog</class>
+ <widget class="QDialog" name="ClipboardDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>412</width>
+    <height>136</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Clipboard Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>9</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Opening your web browser was not possible, please copy and open this URL manually:</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <property name="indent">
+      <number>-1</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="url">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="copyButton">
+       <property name="text">
+        <string>Copy</string>
+       </property>
+       <property name="icon">
+        <iconset theme="edit-copy">
+         <normaloff>.</normaloff>.</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ClipboardDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ClipboardDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/linux/TogglDesktop/desktopservices.cpp
+++ b/src/ui/linux/TogglDesktop/desktopservices.cpp
@@ -1,0 +1,36 @@
+#include "desktopservices.h"
+
+#include <QDesktopServices>
+#include <QDialog>
+#include <QHBoxLayout>
+#include <QLineEdit>
+
+#include "clipboarddialog.h"
+
+void DesktopServices::init(QWidget *parent) {
+    (void) instance();
+    if (m_dialog)
+        m_dialog->deleteLater();
+    QDesktopServices::setUrlHandler("http", instance(), "openUrl");
+    QDesktopServices::setUrlHandler("https", instance(), "openUrl");
+    m_dialog = new ClipboardDialog(parent);
+}
+
+ClipboardDialog *DesktopServices::dialog() {
+    if (!m_dialog)
+        init();
+    return m_dialog;
+}
+
+DesktopServices *DesktopServices::instance() {
+    static DesktopServices self = DesktopServices();
+    return &self;
+}
+
+void DesktopServices::openUrl(const QUrl &url) {
+    if (!QDesktopServices::openUrl(url)) {
+        dialog()->showUrl(url);
+    }
+}
+
+DesktopServices::DesktopServices(QObject *parent) : QObject(parent) { }

--- a/src/ui/linux/TogglDesktop/desktopservices.h
+++ b/src/ui/linux/TogglDesktop/desktopservices.h
@@ -1,0 +1,28 @@
+#ifndef DESKTOPSERVICES_H
+#define DESKTOPSERVICES_H
+
+#include <QUrl>
+
+#include "clipboarddialog.h"
+
+class DesktopServices : public QObject
+{
+    Q_OBJECT
+public:
+    static void init(QWidget *parent = nullptr);
+    static ClipboardDialog *dialog();
+    static DesktopServices *instance();
+
+public slots:
+    // IMPORTANT:
+    // It's necessary to use this function as a slot or with QMetaObject::invokeMethod
+    // because the dialog can live in a different thread than the caller (which is bad times)
+    void openUrl(const QUrl &url);
+
+private:
+    DesktopServices(QObject *parent = nullptr);
+    inline static ClipboardDialog *m_dialog { nullptr };
+
+};
+
+#endif // DESKTOPSERVICES_H

--- a/src/ui/linux/TogglDesktop/loginwidget.cpp
+++ b/src/ui/linux/TogglDesktop/loginwidget.cpp
@@ -56,7 +56,7 @@ ui(new Ui::LoginWidget) {
     connect(&oauth2, &QAbstractOAuth::authorizeWithBrowser, [=](QUrl url) {
         QUrlQuery query(url);
         url.setQuery(query);
-        QDesktopServices::openUrl(url);
+        QMetaObject::invokeMethod(DesktopServices::instance(), "openUrl", Q_ARG(QUrl, url));
     });
 
     signupVisible = true;

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -26,6 +26,7 @@
 #include "./timerwidget.h"
 #include "./errorviewcontroller.h"
 #include "./timeentrycellwidget.h"
+#include "desktopservices.h"
 
 MainWindowController::MainWindowController(
     QWidget *parent,
@@ -54,6 +55,8 @@ MainWindowController::MainWindowController(
   shortcutGroupClose(QKeySequence(Qt::Key_Left), this),
   ui_started(false) {
     ui->setupUi(this);
+
+    DesktopServices::init(this);
 
     ui->menuBar->setVisible(true);
 
@@ -564,7 +567,7 @@ void MainWindowController::displayUpdate(const QString url) {
         "Download new version?",
         "A new version of Toggl Track is available. Continue with download?",
         QMessageBox::No|QMessageBox::Yes).exec()) {
-        QDesktopServices::openUrl(QUrl(url));
+        QMetaObject::invokeMethod(DesktopServices::instance(), "openUrl", Q_ARG(QUrl, url));
         quitApp();
     }
 }

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -55,8 +55,9 @@ void on_display_online_state(
 }
 
 void on_display_url(
-    const char_t *url) {
-    QDesktopServices::openUrl(QUrl(toQString(url)));
+    const char_t *_url) {
+    QUrl url(toQString(_url));
+    QMetaObject::invokeMethod(DesktopServices::instance(), "openUrl", Q_ARG(QUrl, url));
 }
 
 void on_display_login(

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "./toggl_api.h"
+#include "desktopservices.h"
 
 class AutocompleteView;
 class GenericView;


### PR DESCRIPTION
### 📒 Description
Well, this PR adds a dialog that will theoretically open when the user has no browser set up. However, the thing is I really don't know how to properly test this because even Elementary (from the original user report) manages to open links just fine with current versions of TogglDesktop. Anyway, adding this won't (hopefully) hurt anything.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Added a backup dialog with URL display for environments without a browser

### 👫 Relationships
Closes #4465 

### 🔎 Review hints
Don't know how to test this. I'll update the PR if I find a way.

