### PR TITLE
Improve Linux keyboard shortcuts and document them

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -52,6 +52,8 @@ MainWindowController::MainWindowController(
   shortcutConfirm(QKeySequence(Qt::CTRL + Qt::Key_Return), this),
   shortcutGroupOpen(QKeySequence(Qt::Key_Right), this),
   shortcutGroupClose(QKeySequence(Qt::Key_Left), this),
+  shortcutOpenEditor(QKeySequence(Qt::CTRL + Qt::Key_E), this),
+  shortcutJumpToList(QKeySequence(Qt::SHIFT + Qt::Key_Down), this),
   ui_started(false) {
     ui->setupUi(this);
 
@@ -363,6 +365,19 @@ void MainWindowController::onShortcutGroupClose() {
     }
 }
 
+void MainWindowController::onShortcutOpenEditor() {
+    if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
+        // Won't do anything if there's no running TE
+        TogglApi::instance->editRunningTimeEntry("");
+    }
+}
+
+void MainWindowController::onShortcutJumpToList() {
+    if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
+        ui->timeEntryListWidget->focusTimeEntryList();
+    }
+}
+
 void MainWindowController::setShortcuts() {
     showHide = new QxtGlobalShortcut(this);
     connect(showHide, SIGNAL(activated()),
@@ -386,6 +401,10 @@ void MainWindowController::setShortcuts() {
             this, &MainWindowController::onShortcutGroupOpen);
     connect(&shortcutGroupClose, &QShortcut::activated,
             this, &MainWindowController::onShortcutGroupClose);
+    connect(&shortcutOpenEditor, &QShortcut::activated,
+            this, &MainWindowController::onShortcutOpenEditor);
+    connect(&shortcutJumpToList, &QShortcut::activated,
+            this, &MainWindowController::onShortcutJumpToList);
 }
 
 void MainWindowController::connectMenuActions() {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -100,6 +100,8 @@ class MainWindowController : public QMainWindow {
     void onShortcutConfirm();
     void onShortcutGroupOpen();
     void onShortcutGroupClose();
+    void onShortcutOpenEditor();
+    void onShortcutJumpToList();
 
  private:
     Ui::MainWindowController *ui;
@@ -133,6 +135,8 @@ class MainWindowController : public QMainWindow {
     QShortcut shortcutConfirm;
     QShortcut shortcutGroupOpen;
     QShortcut shortcutGroupClose;
+    QShortcut shortcutOpenEditor;
+    QShortcut shortcutJumpToList;
 
     void readSettings();
     void writeSettings();

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -121,6 +121,28 @@ bool TimeEntryCellWidget::eventFilter(QObject *watched, QEvent *event) {
         if (fe->reason() == Qt::TabFocusReason || fe->reason() == Qt::BacktabFocusReason)
             focusInEvent(fe);
     }
+    if (event->type() == QEvent::KeyPress) {
+        auto ke = reinterpret_cast<QKeyEvent*>(event);
+        if (watched == ui->dataFrame) {
+            if (ke->key() == Qt::Key_Space) {
+                TogglApi::instance->continueTimeEntry(guid);
+                event->accept();
+                return true;
+            }
+            else if (ke->key() == Qt::Key_Delete || ke->key() == Qt::Key_Backspace) {
+                if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
+                    QMessageBox::Question,
+                    "Delete this time entry?",
+                    "Deleted time entries cannot be restored.",
+                    QMessageBox::Ok|QMessageBox::Cancel).exec()) {
+                    TogglApi::instance->deleteTimeEntry(guid);
+                }
+            }
+            else if (ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) {
+                TogglApi::instance->editTimeEntry(guid, "description");
+            }
+        }
+    }
     return QWidget::eventFilter(watched, event);
 }
 

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -20,6 +20,7 @@ groupOpen(false),
 groupName(""),
 timeEntry(nullptr) {
     ui->setupUi(this);
+    setFocusProxy(ui->dataFrame);
     ui->dataFrame->installEventFilter(this);
     setStyleSheet(
         "* { font-size: 13px }"

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -130,7 +130,7 @@ void TimeEntryCellWidget::focusInEvent(QFocusEvent *event) {
 void TimeEntryCellWidget::setupGroupedMode(TimeEntryView *view) {
     // Grouped Mode Setup
     group = view->Group;
-    QString style = "#dataFrame{border-right:2px solid palette(alternate-base);border-bottom:2px solid palette(alternate-base);background-color: palette(base);}";
+    QString style = "#dataFrame{border-right:2px solid palette(alternate-base);border-bottom:2px solid palette(alternate-base);background-color: palette(base);}\n #dataFrame:focus{background-color: palette(highlight);}";
     QString count = "";
     QString continueIcon = ":/images/continue_light.svg";
     QString descriptionStyle = "border:none;";

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -10,11 +10,6 @@
 TimeEntryListWidget::TimeEntryListWidget(QStackedWidget *parent) : QWidget(parent),
 ui(new Ui::TimeEntryListWidget) {
     ui->setupUi(this);
-
-    connect(ui->list, &QListWidget::currentRowChanged, [=](int row) {
-        qCritical() << row;
-    });
-
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
 
@@ -22,6 +17,7 @@ ui(new Ui::TimeEntryListWidget) {
             this, SLOT(displayTimeEntryList(bool,QVector<TimeEntryView*>,bool)));  // NOLINT
 
     ui->blankView->setVisible(false);
+    ui->list->setFocusPolicy(Qt::NoFocus);
 }
 
 TimeEntryListWidget::~TimeEntryListWidget() {
@@ -45,6 +41,13 @@ TimeEntryCellWidget *TimeEntryListWidget::highlightedCell() {
 
 TimerWidget *TimeEntryListWidget::timer() {
     return ui->timer;
+}
+
+void TimeEntryListWidget::focusTimeEntryList() {
+    if (!highlightedCell()) {
+        ui->list->setFocus();
+        focusNextChild();
+    }
 }
 
 void TimeEntryListWidget::displayLogin(

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -7,6 +7,8 @@
 #include "./timerwidget.h"
 #include "./timeentrycellwidget.h"
 
+#include <QKeyEvent>
+
 TimeEntryListWidget::TimeEntryListWidget(QStackedWidget *parent) : QWidget(parent),
 ui(new Ui::TimeEntryListWidget) {
     ui->setupUi(this);
@@ -47,6 +49,15 @@ void TimeEntryListWidget::focusTimeEntryList() {
     if (!highlightedCell()) {
         ui->list->setFocus();
         focusNextChild();
+    }
+}
+
+void TimeEntryListWidget::keyPressEvent(QKeyEvent *event) {
+    if (event->type() == QEvent::KeyPress) {
+        auto ke = reinterpret_cast<QKeyEvent*>(event);
+        if (ke->key() == Qt::Key_Space) {
+            event->accept();
+        }
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.h
@@ -34,6 +34,9 @@ class TimeEntryListWidget : public QWidget {
  public slots:
     void focusTimeEntryList();
 
+ protected:
+    virtual void keyPressEvent(QKeyEvent *event) override;
+
  private slots:  // NOLINT
 
     void displayLogin(

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.h
@@ -31,6 +31,9 @@ class TimeEntryListWidget : public QWidget {
     TimeEntryCellWidget *highlightedCell();
     TimerWidget *timer();
 
+ public slots:
+    void focusTimeEntryList();
+
  private slots:  // NOLINT
 
     void displayLogin(

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -180,7 +180,8 @@ void TimerWidget::displayRunningTimerState(
 
     ui->start->setText("Stop");
     ui->start->setStyleSheet(
-        "background-color: #FF897A; color: #000000; font-weight:bold; border:none;");
+        "#start{background-color: #FF897A; color: #000000; font-weight:bold; border:none;}\n"
+        "#start:focus{border: 2px solid #FF897A; outline: 1px dotted black; outline-offset: 0.5px}");
 
     QString description = (te->Description.length() > 0) ?
                           te->Description : "(no description)";
@@ -259,7 +260,8 @@ void TimerWidget::displayStoppedTimerState() {
 
     ui->start->setText("Start");
     ui->start->setStyleSheet(
-        "background-color: #DF68D0; color: #000000; font-weight:bold; border:none;");
+        "#start{background-color: #DF68D0; color: #000000; font-weight:bold; border:none;}\n"
+        "#start:focus{border: 2px solid #DF68D0; outline: 1px dotted black; outline-offset: 0.5px}");
 
     if (!ui->description->hasFocus()) {
         ui->description->setEditText(descriptionPlaceholder);

--- a/src/ui/linux/TogglDesktop/timerwidget.ui
+++ b/src/ui/linux/TogglDesktop/timerwidget.ui
@@ -450,7 +450,7 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true">background-color: #DF68D0; color: #000000; font-weight:bold; border:none;</string>
+      <string notr="true"/>
      </property>
      <property name="text">
       <string>Start</string>


### PR DESCRIPTION
### 📒 Description
This PR improves our current keyboard flow and makes it more like what we have on other platforms (especially Windows).

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Keyboard shortcuts are now more consistent with the Windows version

### 👫 Relationships
Closes #2260 
Closes #3601 

### 🔎 Review hints
The following keyboard shortcuts should be implemented (this text will be added to the Support pages as well):

#### Current Time entry manipulation
* Ctrl+N creates a new time entry and displays the Toggl Track window
* Ctrl+S stops a running time entry
* Ctrl+O continues a previous time entry
* Ctrl+E open running entry in edit popup. This can also be used to immediately edit an Entry created with Ctrl-N.
* Ctrl+R- sync data

#### Switching between timer and Time entry list
* SHIFT+DOWN – Focuses the Time entry list

#### Moving within Time entries after you switch to them using above shortcuts
* UP/DOWN – switch between selected time entry
* ENTER – open the edit view of selected time entry
* SPACE –  continue the selected time entry
* BACKSPACE – delete the selected time entry

#### Collapse/expand data
 * LEFT ARROW – collapses current day’s time entries (or the day you have navigated to)
 * RIGHT ARROW – expands all time entries for the day (or the day you have navigated to)

### **NOT IMPLEMENTED:**
* ESC – If the edit popup is opened it always closes the popup (event if the listing is focused). If edit popup is not opened and the entries list is focused it will switch the focus to Timer.
  * Not sure how to handle this, we don't support closing the dialog without writing changes
* Ctrl+W minimize app to tray
  * Hard to do consistently and reliably with the current app, could be added with the new UI at some point
* Ctrl+D changes between timer and manual mode
  * Manual mode is not implemented in the Linux version
* CTRL+LEFT ARROW – collapses all days
  * Not worth it before the redesign
* CTRL+RIGHT ARROW – expands all days
  * Not worth it before the redesign