### PR TITLE
Use new cert for MS Store app in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -546,7 +546,7 @@ jobs:
         fetch-depth: 1
     - name: Install signing key - Part 1
       run: |
-        echo "${{ secrets.CERT_WINDOWS_STORE }}" > Certificate.b64
+        echo "${{ secrets.CERT_WINDOWS_STORE_V2 }}" > Certificate.b64
         base64 -d Certificate.b64 > Certificate.pfx
       shell: bash
     - name: Install signing key - Part 2
@@ -564,7 +564,7 @@ jobs:
       shell: cmd
       run: |
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=StoreRelease /p:Platform="x86" /p:AppxPackageSigningEnabled=false /t:Clean,Build /restore -m src\ui\windows\TogglDesktop\TogglDesktop.sln
-        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=StoreRelease /p:Platform="x64" /p:UapAppxPackageBuildMode=CI /p:AppxBundle=Always /p:AppxBundlePlatforms="x86|x64" /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="322D8592D0FDB01F1C8FCA56ED3FBFAF646D3739" /p:AppxPackageDir="..\\..\\..\\..\\..\\" /t:Clean,Build /restore -m src\ui\windows\TogglDesktop\TogglDesktop.sln
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=StoreRelease /p:Platform="x64" /p:UapAppxPackageBuildMode=CI /p:AppxBundle=Always /p:AppxBundlePlatforms="x86|x64" /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="2AFAD2683749B3194CB0CB1D720900DC51AB90FE" /p:AppxPackageDir="..\\..\\..\\..\\..\\" /t:Clean,Build /restore -m src\ui\windows\TogglDesktop\TogglDesktop.sln
         dir
     - name: Upload to GitHub
       run: |


### PR DESCRIPTION
### 📒 Description
Use new cert for MS Store app in CI

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
no issues created, but the CI is broken on master

### 🔎 Review hints
You can take the certificate from the branding repo and perform the actions in the CI script
or just merge this to `master` if the code looks good and see if the CI works.

