### PR TITLE
Fix wrong delete usage in bugsnag-qt 

### DIFF
--- a/third_party/bugsnag-qt/bugsnag.h
+++ b/third_party/bugsnag-qt/bugsnag.h
@@ -357,7 +357,7 @@ class BUGSNAGQTSHARED_EXPORT Bugsnag : public QObject {
                         << ", status code " << statusCode
                            << ", content " << QString(b);
         }
-        delete reply;
+        reply->deleteLater();
     }
 };
 


### PR DESCRIPTION
### 📒 Description
So, after much painful debugging and weird backtraces, I found the source of this issue. The `reply` pointer in bugsnag-qt shouldn't have been deleted directly but after it has been processed completely, in the event loop. This PR fixes this issue and a crash that has been associated with it:

https://doc.qt.io/qt-5/qnetworkaccessmanager.html#finished

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Fix a crash happening with DNS problems

### 👫 Relationships
Closes #4253 

### 🔎 Review hints
Reproducer is described in #4253

