### PR TITLE
Add tags shortcuts # feature to the timer

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/DataSource/TagDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/DataSource/TagDataSource.swift
@@ -66,7 +66,6 @@ final class TagDataSource: AutoCompleteViewDataSource {
     }
 
     private func commonSetup() {
-        tableView.allowsEmptySelection = true
         autoCompleteView?.setCreateButtonSectionHidden(true)
         autoCompleteView?.defaultTextField.placeholderString = "Find tags"
     }

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Views/HoverTableCellView.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Views/HoverTableCellView.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 class HoverTableCellView: NSTableCellView {
 
+    private var trackingArea: NSTrackingArea?
+
     // MARK: OUTLET
 
     @IBOutlet weak var contentContainerView: NSBox!
@@ -18,15 +20,15 @@ class HoverTableCellView: NSTableCellView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-
-        initCommon()
-        initTracking()
+        contentContainerView.alphaValue = 0
+        enableTracking()
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         NSCursor.arrow.set()
-        contentContainerView.animator().alphaValue = 0.0
+        contentContainerView.alphaValue = 0.0
+        enableTracking()
     }
 
     override func mouseExited(with event: NSEvent) {
@@ -41,15 +43,15 @@ class HoverTableCellView: NSTableCellView {
         contentContainerView.animator().alphaValue = 1.0
     }
 
-    fileprivate func initCommon() {
-        contentContainerView.alphaValue = 0
-    }
-
-    fileprivate func initTracking() {
-        let trackingArea = NSTrackingArea(rect: bounds,
-                                          options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited],
-                                          owner: self,
-                                          userInfo: nil)
-        addTrackingArea(trackingArea)
+    fileprivate func enableTracking() {
+        if let trackingArea = trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let tracking = NSTrackingArea(rect: bounds,
+                                      options: [.activeInActiveApp, .inVisibleRect, .mouseEnteredAndExited],
+                                      owner: self,
+                                      userInfo: nil)
+        addTrackingArea(tracking)
+        trackingArea = tracking
     }
 }

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Views/TagCell/TagCellView.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Views/TagCell/TagCellView.swift
@@ -13,7 +13,7 @@ protocol TagCellViewDelegate: class {
     func tagSelectionStateOnChange(with tag: Tag, isSelected: Bool)
 }
 
-final class TagCellView: NSTableCellView {
+final class TagCellView: HoverTableCellView {
 
     static let cellHeight: CGFloat = 34.0
 
@@ -42,14 +42,11 @@ final class TagCellView: NSTableCellView {
     @IBOutlet weak var checkButton: NSButton!
     @IBOutlet weak var nameLabel: NSTextField!
     @IBOutlet weak var backgroundView: NSBox!
-    @IBOutlet weak var hoverView: NSBox!
 
     // MARK: Public
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        initCommon()
-        initTracking()
     }
 
     override func prepareForReuse() {
@@ -57,7 +54,6 @@ final class TagCellView: NSTableCellView {
         NSCursor.arrow.set()
         isSelected = false
         checkButton.state = .off
-        hoverView.alphaValue = 0.0
     }
 
     func render(_ tag: Tag, isSelected: Bool, style: Style = .checkbox) {
@@ -100,29 +96,5 @@ final class TagCellView: NSTableCellView {
         let newState: NSControl.StateValue = checkButton.state == .on ? .off : .on
         checkButton.state = newState
         checkButtonOnChanged(self)
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        super.mouseExited(with: event)
-        NSCursor.arrow.set()
-        hoverView.animator().alphaValue = 0.0
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        super.mouseEntered(with: event)
-        NSCursor.pointingHand.set()
-        hoverView.animator().alphaValue = 1.0
-    }
-
-    private func initCommon() {
-        hoverView.alphaValue = 0.0
-    }
-
-    private func initTracking() {
-        let trackingArea = NSTrackingArea(rect: bounds,
-                                          options: [.activeInKeyWindow, .inVisibleRect, .mouseEnteredAndExited],
-                                          owner: self,
-                                          userInfo: nil)
-        addTrackingArea(trackingArea)
     }
 }

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Views/TagCell/TagCellView.xib
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Views/TagCell/TagCellView.xib
@@ -82,7 +82,7 @@
             <connections>
                 <outlet property="backgroundView" destination="Ws3-BI-x3S" id="hSq-eI-9Q4"/>
                 <outlet property="checkButton" destination="ZvV-w8-dCM" id="Rqp-WW-NUb"/>
-                <outlet property="hoverView" destination="P4q-6R-6o7" id="FqS-op-lgT"/>
+                <outlet property="contentContainerView" destination="P4q-6R-6o7" id="btw-hM-tTz"/>
                 <outlet property="nameLabel" destination="sPh-Yd-c5J" id="Hfq-ji-viJ"/>
             </connections>
             <point key="canvasLocation" x="244.5" y="-9"/>

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteInput.h
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteInput.h
@@ -33,6 +33,7 @@ typedef NS_ENUM (NSUInteger, AutoCompleteDisplayMode)
 @property (assign, nonatomic, readonly) CGFloat worksapceItemHeight;
 @property (assign, nonatomic) AutoCompleteDisplayMode displayMode;
 @property (assign, nonatomic, readonly) BOOL isListHidden;
+@property (assign, nonatomic, readonly) NSRange selectedRange;
 
 - (void)toggleList:(BOOL)isOn;
 - (void)updateDropdownWithHeight:(CGFloat)height;

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteInput.m
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteInput.m
@@ -19,7 +19,7 @@ static CGFloat maxDropdownWidth = 500;
 static CGFloat dropdownBottomPadding = 50;
 static CGFloat dropdownHorizontalPadding = 11;
 
-@interface AutoCompleteInput () <NoInteractionViewDelegate, NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate>
+@interface AutoCompleteInput () <NoInteractionViewDelegate, NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate, NSTextViewDelegate>
 @property (strong, nonatomic) AutoCompleteTable *autocompleteTableView;
 @property (strong, nonatomic) AutoCompleteTableContainer *autocompleteTableContainer;
 @property (assign, nonatomic) BOOL constraintsActive;
@@ -31,6 +31,7 @@ static CGFloat dropdownHorizontalPadding = 11;
 @property (assign, nonatomic) CGFloat itemHeight;
 @property (assign, nonatomic) CGFloat worksapceItemHeight;
 @property (nonatomic, readwrite) BOOL isListHidden;
+@property (nonatomic, readwrite) NSRange selectedRange;
 @end
 
 @implementation AutoCompleteInput
@@ -47,6 +48,7 @@ static CGFloat dropdownHorizontalPadding = 11;
 		self.wantsLayer = YES;
 		self.layer.masksToBounds = NO;
 		self.displayMode = AutoCompleteDisplayModeCompact;
+		self.selectedRange = NSMakeRange(0, 0);
 		[self initBackgroundView];
         if (@available(macOS 10.12.2, *))
         {
@@ -297,6 +299,15 @@ static CGFloat dropdownHorizontalPadding = 11;
 	[self.autocompleteTableView reloadData];
 	[self updateDropdownWithHeight:totalHeight];
 	[self toggleList:array.count > 0];
+}
+
+- (void)textViewDidChangeSelection:(NSNotification *)notification
+{
+	NSTextView *editor = (NSTextView *)self.currentEditor;
+	if (!editor) {
+		return;
+	}
+	self.selectedRange = [editor selectedRange];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -56,6 +56,7 @@ final class TimerViewModel: NSObject {
 
     private var selectedTags: [String] = [] {
         didSet {
+            guard selectedTags != oldValue else { return }
             if tagsDataSource.autoCompleteView != nil {
                 tagsDataSource.updateSelectedTags(selectedTags.map { Tag(name: $0) })
             }


### PR DESCRIPTION
### 📒 Description
Adds tags shortcuts # feature to the timer.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes

### 👫 Relationships
Closes #4438
Additionally fixes #4312 and #4476 

### 🔎 Review hints
Shortcuts feature is disabled by default. To enable it:
Go to `TimerDescriptionFieldHandler.swift` -> line 61 -> set `enableShortcuts` to `true`

