### PR TITLE
Sync the flatpak manifest with flathub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,11 +332,13 @@ jobs:
     - name: Install Flatpak KDE SDK
       run: |
         sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install --system -y flathub org.kde.Platform//5.12
-        sudo flatpak install --system -y flathub org.kde.Sdk//5.12
+        sudo flatpak install --system -y flathub org.kde.Platform//5.15
+        sudo flatpak install --system -y flathub org.kde.Sdk//5.15
     - name: Build Linux Flatpak package - KDE based
       run: |
+        TAG_NAME=$(./dist/get-tag-name.sh)
         pushd dist/linux/flatpak
+        sed -i "s/VERSION_PLACEHOLDER/${TAG_NAME/v/}/" com.toggl.TogglDesktop.json
         sudo flatpak-builder --repo=flatpak-repo --force-clean flatpak-build com.toggl.TogglDesktop.json
         flatpak build-bundle flatpak-repo com.toggl.TogglDesktop.flatpak com.toggl.TogglDesktop
         mv com.toggl.TogglDesktop.flatpak ../../..

--- a/dist/linux/flatpak/com.toggl.TogglDesktop.json
+++ b/dist/linux/flatpak/com.toggl.TogglDesktop.json
@@ -1,7 +1,7 @@
 {
     "id": "com.toggl.TogglDesktop",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.12",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "rename-icon": "toggldesktop",
     "command": "TogglDesktop.sh",
@@ -13,7 +13,22 @@
         "--share=network",
         "--share=ipc",
         "--talk-name=org.kde.StatusNotifierWatcher",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=com.canonical.indicator.application",
+        "--talk-name=org.ayatana.indicator.application",
+        "--talk-name=org.freedesktop.portal.Fcitx",
+        "--talk-name=org.freedesktop.ScreenSaver",
+        "--talk-name=org.gnome.Mutter.IdleMonitor",
+        "--own-name=org.kde.StatusNotifierItem-1-1",
+        "--own-name=org.kde.StatusNotifierItem-2-1",
+        "--own-name=org.kde.StatusNotifierItem-3-1",
+        "--own-name=org.kde.StatusNotifierItem-4-1",
+        "--own-name=org.kde.StatusNotifierItem-5-1",
+        "--own-name=org.kde.StatusNotifierItem-6-1",
+        "--own-name=org.kde.StatusNotifierItem-7-1",
+        "--own-name=org.kde.StatusNotifierItem-8-1",
+        "--own-name=org.kde.StatusNotifierItem-9-1",
+        "--system-talk-name=org.freedesktop.login1"
     ],
     "modules": [
         {
@@ -31,16 +46,15 @@
             "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
-                "-DTOGGL_VERSION=7.4.528",
-                "-DTOGGL_VERSION_RELEASE_DATE=2019-08-22",
+                "-DTOGGL_VERSION=VERSION_PLACEHOLDER",
                 "-DTOGGL_PRODUCTION_BUILD=ON",
                 "-DTOGGL_ALLOW_UPDATE_CHECK=ON"
             ],
             "sources": [
                 {
                     "type": "git",
-                    "url": "http://github.com/toggl/toggldesktop",
-                    "tag": "v7.4.528"
+                    "url": "http://github.com/toggl-open-source/toggldesktop",
+                    "tag": "vVERSION_PLACEHOLDER"
                 }
             ]
         }


### PR DESCRIPTION
### 📒 Description
Due to an error I made quite a while ago, the Flatpak version we're hosting here on GitHub has not been updated since 7.4.528 (and the same version has been built over and over again). That's not a huge deal because only a handful of users were getting the package from this page (and there are no links to it anywhere) but it's good for the occasional test and pointing the users to it when they want to test a new feature or a bug fix.
This PR not only fixes that but also includes all the updates and improvements I did to the manifest in the Flathub repository.

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- The Flatpak package on GitHub is now actually updated

### 👫 Relationships
Closes #4521 

### 🔎 Review hints
https://github.com/toggl-open-source/toggldesktop/actions/runs/302034905 
This build actually used this new manifest, you can see the build passed (and nothing was uploaded anywhere because I used an existing tag)

