### PR TITLE
Add analytics for description shortcuts tracking (mac)

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -430,4 +430,26 @@ void Analytics::TrackTimerStart(const std::string &client_id, const TimerEditAct
     Track(client_id, category, action_str);
 }
 
+void Analytics::TrackTimerShortcut(const std::string &client_id, const TimerShortcutActionType action) {
+    std::string category = "timer-shortcut";
+    std::string action_str = "";
+
+    switch (action) {
+        case TimerShortcutActionTypeProjectSelected:
+            action_str = "project-select";
+            break;
+        case TimerShortcutActionTypeTagSelected:
+            action_str = "tag-select";
+            break;
+        case TimerShortcutActionTypeProjectCreated:
+            action_str = "project-create";
+            break;
+        case TimerShortcutActionTypeTagCreated:
+            action_str = "tag-create";
+            break;
+    }
+
+    Track(client_id, category, action_str);
+}
+
 }  // namespace toggl

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -96,6 +96,8 @@ class Analytics : public Poco::TaskManager {
     ///                 @c TimerEditActionTypeDescription is ignored for this analytics event.
     void TrackTimerStart(const std::string &client_id, const TimerEditActionType actions);
 
+    void TrackTimerShortcut(const std::string &client_id, const TimerShortcutActionType action);
+
  private:
     Poco::LocalDateTime settings_sync_date;
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -6784,6 +6784,12 @@ void Context::TrackTimerStart(TimerEditActionType actions) {
     }
 }
 
+void Context::TrackTimerShortcut(TimerShortcutActionType action) {
+    if ("production" == environment_) {
+        analytics_.TrackTimerShortcut(db_->AnalyticsClientID(), action);
+    }
+}
+
 error Context::UpdateTimeEntry(
     const std::string &GUID,
     const std::string &description,

--- a/src/context.h
+++ b/src/context.h
@@ -571,6 +571,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     void TrackTimerEdit(TimerEditActionType action);
     void TrackTimerStart(TimerEditActionType actions);
+    void TrackTimerShortcut(TimerShortcutActionType action);
 
     // Onboarding action
     void UserDidClickOnTimelineTab();

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1609,6 +1609,16 @@ void track_timer_start(
     app(context)->TrackTimerStart(actions);
 }
 
+void track_timer_shortcut(
+    void *context,
+    TimerShortcutActionType action) {
+
+    if (!context) {
+        return;
+    }
+    app(context)->TrackTimerShortcut(action);
+}
+
 bool_t toggl_update_time_entry(
     void *context,
     const char_t *guid,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -251,6 +251,13 @@ extern "C" {
         TimerEditActionTypeBillable = 1 << 4
     } TimerEditActionType;
 
+    typedef enum {
+        TimerShortcutActionTypeProjectSelected,
+        TimerShortcutActionTypeTagSelected,
+        TimerShortcutActionTypeProjectCreated,
+        TimerShortcutActionTypeTagCreated
+    } TimerShortcutActionType;
+
 typedef enum {
         TogglServerStaging = 0,
         TogglServerProduction
@@ -1265,6 +1272,10 @@ typedef enum {
     TOGGL_EXPORT void track_timer_start(
         void *context,
         TimerEditActionType actions);
+
+    TOGGL_EXPORT void track_timer_shortcut(
+        void *context,
+        TimerShortcutActionType action);
 
     TOGGL_EXPORT bool_t toggl_update_time_entry(
         void *context,

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
@@ -10,11 +10,9 @@ import Foundation
 
 class TimerDescriptionFieldHandler: NSResponder {
 
-    private enum Constants {
-        static let projectToken: Character = "@"
-        static let tagToken: Character = "#"
-
-        static let autoCompleteMinFilterLength = 2
+    enum Shortcut: Character {
+        case project = "@"
+        case tag = "#"
     }
 
     enum State: Equatable {
@@ -87,26 +85,26 @@ class TimerDescriptionFieldHandler: NSResponder {
 
     func didSelectProject() {
         if case .projectFilter = state {
-            removeShortcutQuery(for: Constants.projectToken)
+            removeShortcutQuery(for: .project)
         }
     }
 
     func didSelectTag() {
         if case .tagsFilter = state {
-            removeShortcutQuery(for: Constants.tagToken)
+            removeShortcutQuery(for: .tag)
         }
     }
 
     // MARK: - Private
 
     /// Removes from text field the text related to `shortcut`
-    private func removeShortcutQuery(for shortcut: Character) {
+    private func removeShortcutQuery(for shortcut: Shortcut) {
         guard let editor = textField.currentEditor() else { return }
 
         var text = editor.string
         let lastTypedIndex = text.index(text.startIndex, offsetBy: editor.selectedRange.location - 1)
         let rangeBeforeCursor = text[text.startIndex...lastTypedIndex]
-        if let shortcutIndex = rangeBeforeCursor.lastIndex(of: shortcut) {
+        if let shortcutIndex = rangeBeforeCursor.lastIndex(of: shortcut.rawValue) {
             let shortcutLocation = text.distance(from: text.startIndex, to: shortcutIndex)
 
             text.removeSubrange(shortcutIndex...lastTypedIndex)
@@ -153,15 +151,18 @@ class TimerDescriptionFieldHandler: NSResponder {
         let (token, query): (Character?, String)
 
         if isShortcutEnabled {
-            (token, query) = text.findTokenAndQueryMatchesForAutocomplete([Constants.projectToken, Constants.tagToken], cursorLocation)
+            (token, query) = text.findTokenAndQueryMatchesForAutocomplete(
+                [Shortcut.project, Shortcut.tag].map { $0.rawValue },
+                cursorLocation
+            )
         } else {
             (token, query) = (nil, text)
         }
 
         switch (token, query) {
-        case (Constants.projectToken, _):
+        case (Shortcut.project.rawValue, _):
             state = .projectFilter(query)
-        case (Constants.tagToken, _):
+        case (Shortcut.tag.rawValue, _):
             state = .tagsFilter(query)
         case (nil, query):
             state = .autocompleteFilter(query)

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -144,6 +144,7 @@ class TimerViewController: NSViewController {
         viewModel.onTagSelected = { [unowned self] isSelected in
             if case .tagsFilter = self.descriptionFieldHandler.state {
                 self.descriptionFieldHandler.didSelectTag()
+                self.analyticsTrackShortcutSelected(.tag)
             }
 
             self.tagsButton.isSelected = isSelected
@@ -170,6 +171,7 @@ class TimerViewController: NSViewController {
             switch self.descriptionFieldHandler.state {
             case .projectFilter:
                 self.descriptionFieldHandler.didSelectProject()
+                self.analyticsTrackShortcutSelected(.project)
             default:
                 self.closeProjectAutoComplete()
             }
@@ -615,6 +617,9 @@ extension TimerViewController: AutoCompleteViewDelegate {
         switch descriptionFieldHandler.state {
         case .tagsFilter(let filter):
             tagName = filter
+            descriptionFieldHandler.didSelectTag()
+            analyticsTrackShortcutCreated(.tag)
+
         default:
             tagName = tagsAutoCompleteView.defaultTextField.stringValue
         }
@@ -635,6 +640,8 @@ extension TimerViewController: ProjectCreationViewDelegate {
         switch descriptionFieldHandler.state {
         case .projectFilter:
             descriptionFieldHandler.didSelectProject()
+            analyticsTrackShortcutCreated(.project)
+
         default:
             closeProjectAutoComplete()
         }
@@ -645,5 +652,30 @@ extension TimerViewController: ProjectCreationViewDelegate {
 
     func projectCreationDidUpdateSize() {
         updateProjectAutocompleteWindowContent(with: projectCreationView)
+    }
+}
+
+// MARK: - Analytics
+
+extension TimerViewController {
+
+    private typealias Shortcut = TimerDescriptionFieldHandler.Shortcut
+
+    private func analyticsTrackShortcutSelected(_ shortcut: Shortcut) {
+        switch shortcut {
+        case .project:
+            DesktopLibraryBridge.shared().trackTimerShortcut(TimerShortcutActionTypeProjectSelected)
+        case .tag:
+            DesktopLibraryBridge.shared().trackTimerShortcut(TimerShortcutActionTypeTagSelected)
+        }
+    }
+
+    private func analyticsTrackShortcutCreated(_ shortcut: Shortcut) {
+        switch shortcut {
+        case .project:
+            DesktopLibraryBridge.shared().trackTimerShortcut(TimerShortcutActionTypeProjectCreated)
+        case .tag:
+            DesktopLibraryBridge.shared().trackTimerShortcut(TimerShortcutActionTypeTagCreated)
+        }
     }
 }

--- a/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.h
@@ -139,6 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)trackTimelineMenuContextType:(TimelineMenuContextType)type;
 - (void)trackTimerEditUsingAction:(TimerEditActionType)action;
 - (void)trackTimerStartUsingActions:(TimerEditActionType)actions;
+- (void)trackTimerShortcut:(TimerShortcutActionType)action;
 
 #pragma mark - General
 

--- a/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.m
@@ -479,25 +479,35 @@ void *ctx;
     toggl_track_timeline_menu_context(ctx, type);
 }
 
-- (void)trackTimerEditUsingAction:(TimerEditActionType)action {
+- (void)trackTimerEditUsingAction:(TimerEditActionType)action
+{
     track_timer_edit(ctx, action);
 }
 
-- (void)trackTimerStartUsingActions:(TimerEditActionType)actions {
+- (void)trackTimerStartUsingActions:(TimerEditActionType)actions
+{
     track_timer_start(ctx, actions);
+}
+
+- (void)trackTimerShortcut:(TimerShortcutActionType)action
+{
+    track_timer_shortcut(ctx, action);
 }
 
 #pragma mark - General
 
-- (uint64_t)defaultWorkspaceID {
+- (uint64_t)defaultWorkspaceID
+{
     return toggl_get_default_or_first_workspace_id(ctx);
 }
 
-- (void)fetchTagsForWorkspaceID:(uint64_t)workspaceID {
+- (void)fetchTagsForWorkspaceID:(uint64_t)workspaceID
+{
     toggl_fetch_tags(ctx, workspaceID);
 }
 
-- (BOOL)canSeeBillableForWorkspaceID:(uint64_t)workspaceID {
+- (BOOL)canSeeBillableForWorkspaceID:(uint64_t)workspaceID
+{
     return toggl_can_see_billable(ctx, workspaceID);
 }
 


### PR DESCRIPTION
### 📒 Description
Analytics for timer shortcuts (# and @). Category and action for analytics is taken from the issue description.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4439 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
1. Enable shortcuts feature (Go to `TimerDescriptionFieldHandler.swift` -> line 61 -> set `enableShortcuts` to `true`)
1. In `context.cc` comment the check for the environment at line 6788 - `if ("production" == environment_)`
