### PR TITLE
Add an option to ignore SSL on Linux

### DIFF
--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -109,6 +109,8 @@ void PreferencesDialog::displaySettings(const bool open,
         cs = "Record shortcut";
     }
     ui->continueStopButton->setText(cs);
+
+    ui->sslCheckbox->setChecked(settings->ForceIgnoreCert);
 }
 
 void PreferencesDialog::displayLogin(const bool open,
@@ -209,7 +211,11 @@ void PreferencesDialog::on_reminderEndTimeEdit_editingFinished() {
     TogglApi::instance->setSettingsRemindTimes(
         ui->reminderStartTimeEdit->time(),
         ui->reminderEndTimeEdit->time()
-    );
+                );
+}
+
+void PreferencesDialog::on_sslCheckbox_clicked() {
+    TogglApi::instance->setSettingsIgnoreCert(ui->sslCheckbox->isChecked());
 }
 
 void PreferencesDialog::on_continueStopButton_clicked() {

--- a/src/ui/linux/TogglDesktop/preferencesdialog.h
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.h
@@ -57,6 +57,7 @@ class PreferencesDialog : public QDialog {
     void on_showHideButton_clicked();
     void on_reminderStartTimeEdit_editingFinished();
     void on_reminderEndTimeEdit_editingFinished();
+    void on_sslCheckbox_clicked();
     void keyPressEvent(QKeyEvent *event);
     void keyReleaseEvent(QKeyEvent *event);
     void saveCurrentShortcut();

--- a/src/ui/linux/TogglDesktop/preferencesdialog.ui
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <attribute name="title">
@@ -248,9 +248,9 @@
      </widget>
      <widget class="QWidget" name="tab_proxy">
       <attribute name="title">
-       <string>Proxy</string>
+       <string>Network</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QCheckBox" name="useSystemProxySettings">
          <property name="text">
@@ -319,6 +319,48 @@
           </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="sslLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="sslCheckbox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">margin-right: -2.5px</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="sslLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Ignore SSL certificate validation&lt;br&gt;&lt;span style=&quot;font-size:8pt; color:#aa0000;&quot;&gt;NOT RECOMMENDED, this can make the app vulnerable to man-in-the-middle attacks.&lt;/span&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer">

--- a/src/ui/linux/TogglDesktop/preferencesdialog.ui
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <attribute name="title">
@@ -276,7 +276,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="hostLabel">
             <property name="text">
-             <string>&amp;Host</string>
+             <string>Host</string>
             </property>
            </widget>
           </item>

--- a/src/ui/linux/TogglDesktop/settingsview.h
+++ b/src/ui/linux/TogglDesktop/settingsview.h
@@ -46,6 +46,7 @@ class SettingsView : public QObject {
         result->RemindStartTime = QTime::fromString(toQString(view->RemindStarts), "HH:mm");
         result->RemindEndTime = QTime::fromString(toQString(view->RemindEnds), "HH:mm");
         result->StopEntryOnShutdownSleep = view->StopEntryOnShutdownSleep;
+        result->ForceIgnoreCert = view->ForceIgnoreCert;
         return result;
     }
 
@@ -79,6 +80,7 @@ class SettingsView : public QObject {
     QTime RemindStartTime;
     QTime RemindEndTime;
     bool StopEntryOnShutdownSleep;
+    bool ForceIgnoreCert;
 };
 
 #endif  // SRC_UI_LINUX_TOGGLDESKTOP_SETTINGSVIEW_H_

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -509,6 +509,10 @@ bool TogglApi::setSettingsStopEntryOnShutdown(const bool stop_entry) {
     return toggl_set_settings_stop_entry_on_shutdown_sleep(ctx, stop_entry);
 }
 
+bool TogglApi::setSettingsIgnoreCert(bool ignore) {
+    return toggl_set_settings_ignore_cert(ctx, ignore);
+}
+
 void TogglApi::stopEntryOnShutdown() {
     toggl_os_shutdown(ctx);
 }

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -210,6 +210,8 @@ class TogglApi : public QObject {
     void stopEntryOnShutdown();
     bool setSettingsStopEntryOnShutdown(const bool stop_entry);
 
+    bool setSettingsIgnoreCert(bool ignore);
+
     void toggleTimelineRecording(
         const bool recordTimeline);
 


### PR DESCRIPTION
### 📒 Description
As a part of #3315, this PR adds an option to access the new API method in Linux.

And, since it's slightly related, fixes two small issues in preferences: wrong selected tab and a typo (?) in the Proxy tab.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- It's possible to turn off SSL verification in case of connection issues

### 👫 Relationships
Closes #4451

### 🔎 Review hints
Due to UI file changes, it may be necessary to completely rebuild the whole project instead of just an incremental build.
Otherwise, this should be a pretty standard small PR
