### PR TITLE
Adds onboarding popup to introduce description shortcuts feature to users

### DIFF
--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -3860,7 +3860,7 @@ error Database::LoadOnboardingState(const Poco::UInt64 &UID, OnboardingState *st
                   "select local_id, user_id, created_at, open_timeline_tab_count, edit_timeline_tab_count, is_use_timeline_record, is_use_manual_mode, "
                   "is_present_new_user_onboarding, is_present_new_user_second_time_onboarding, is_present_old_user_onboarding, is_present_old_user_second_time_onboarding, is_present_manual_mode_onboarding, is_present_timeline_tab_onboarding, "
                   "is_present_edit_timeentry_onboarding, is_present_timeline_timeentry_onboarding, is_present_timeline_view_onboarding, is_present_timeline_activity_onboarding, "
-                  "is_present_recode_activity_onboarding "
+                  "is_present_recode_activity_onboarding, is_present_text_shortcuts_onboarding "
                   "from onboarding_states "
                   "where user_id = :uid "
                   "limit 1",
@@ -3882,6 +3882,7 @@ error Database::LoadOnboardingState(const Poco::UInt64 &UID, OnboardingState *st
                   into(state->isPresentTimelineView),
                   into(state->isPresentTimelineActivity),
                   into(state->isPresentRecordActivity),
+                  into(state->isPresentTextShortcuts),
                   useRef(UID),
                   limit(1),
                   now;
@@ -3910,7 +3911,8 @@ error Database::SetOnboardingState(const Poco::UInt64 &UID, OnboardingState *sta
             "is_present_old_user_onboarding = :is_present_old_user_onboarding, is_present_old_user_second_time_onboarding = :is_present_old_user_second_time_onboarding, "
             "is_present_manual_mode_onboarding = :is_present_manual_mode_onboarding, is_present_timeline_tab_onboarding = :is_present_timeline_tab_onboarding, "
             "is_present_edit_timeentry_onboarding = :is_present_edit_timeentry_onboarding, is_present_timeline_timeentry_onboarding = :is_present_timeline_timeentry_onboarding, is_present_timeline_view_onboarding = :is_present_timeline_view_onboarding, is_present_timeline_activity_onboarding = :is_present_timeline_activity_onboarding, "
-            "is_present_recode_activity_onboarding = :is_present_recode_activity_onboarding "
+            "is_present_recode_activity_onboarding = :is_present_recode_activity_onboarding, "
+            "is_present_text_shortcuts_onboarding = :is_present_text_shortcuts_onboarding "
             "where local_id = :local_id AND user_id = :uid",
             useRef(state->openTimelineTabCount),
             useRef(state->editOnTimelineCount),
@@ -3927,6 +3929,7 @@ error Database::SetOnboardingState(const Poco::UInt64 &UID, OnboardingState *sta
             useRef(state->isPresentTimelineView),
             useRef(state->isPresentTimelineActivity),
             useRef(state->isPresentRecordActivity),
+            useRef(state->isPresentTextShortcuts),
             useRef(state->local_id),
             useRef(UID),
             now;
@@ -3937,11 +3940,11 @@ error Database::SetOnboardingState(const Poco::UInt64 &UID, OnboardingState *sta
             "edit_timeline_tab_count, is_use_timeline_record, is_use_manual_mode, "
             "is_present_new_user_onboarding, is_present_new_user_second_time_onboarding, is_present_old_user_onboarding, is_present_old_user_second_time_onboarding, is_present_manual_mode_onboarding, is_present_timeline_tab_onboarding, "
             "is_present_edit_timeentry_onboarding, is_present_timeline_timeentry_onboarding, is_present_timeline_view_onboarding, is_present_timeline_activity_onboarding, "
-            "is_present_recode_activity_onboarding) "
+            "is_present_recode_activity_onboarding, is_present_text_shortcuts_onboarding) "
             "values(:user_id, :created_at, :open_timeline_tab_count, :edit_timeline_tab_count, :is_use_timeline_record, :is_use_manual_mode, "
             ":is_present_new_user_onboarding, :is_present_new_user_second_time_onboarding, :is_present_old_user_onboarding, :is_present_old_user_second_time_onboarding, :is_present_manual_mode_onboarding, :is_present_timeline_tab_onboarding, "
             ":is_present_edit_timeentry_onboarding, :is_present_timeline_timeentry_onboarding, :is_present_timeline_view_onboarding, :is_present_timeline_activity_onboarding, "
-            ":is_present_recode_activity_onboarding) ",
+            ":is_present_recode_activity_onboarding, :is_present_text_shortcuts_onboarding) ",
             useRef(UID),
             useRef(state->createdAt),
             useRef(state->openTimelineTabCount),
@@ -3959,6 +3962,7 @@ error Database::SetOnboardingState(const Poco::UInt64 &UID, OnboardingState *sta
             useRef(state->isPresentTimelineView),
             useRef(state->isPresentTimelineActivity),
             useRef(state->isPresentRecordActivity),
+            useRef(state->isPresentTextShortcuts),
             now;
 
             error err = last_error("SetOnboardingState");

--- a/src/database/migrations.cc
+++ b/src/database/migrations.cc
@@ -1418,6 +1418,15 @@ error Migrations::migrateOnboardingStates() {
     if (err != noError) {
         return err;
     }
+
+    err = db_->Migrate(
+        "onboarding_states.is_present_text_shortcuts_onboarding",
+        "ALTER TABLE onboarding_states "
+        "ADD COLUMN is_present_text_shortcuts_onboarding integer not null default 0;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/onboarding_service.cpp
+++ b/src/onboarding_service.cpp
@@ -118,6 +118,10 @@ void OnboardingService::OpenApp() {
     if (handleTimelineTabOnboarding()) {
         return;
     }
+
+    if (handleTextShortcutsOnboarding()) {
+        return;
+    }
 }
 
 void OnboardingService::StopTimeEntry() {
@@ -410,6 +414,21 @@ bool OnboardingService::handleOldUserOnboarding() {
             sync();
             return true;
         }
+    }
+    return false;
+}
+
+bool OnboardingService::handleTextShortcutsOnboarding() {
+    /*
+     Present Onboarding for # and @ shortcuts on Timer
+
+     > For all users who tracked at least 3 TEs and haven't yet saw shortcuts onboarding
+     */
+    if (!state->isPresentTextShortcuts && state->timeEntryTotal >= 3) {
+        state->isPresentTextShortcuts = true;
+        _callback(OnboardingTypeTextShortcuts);
+        sync();
+        return true;
     }
     return false;
 }

--- a/src/onboarding_service.h
+++ b/src/onboarding_service.h
@@ -33,7 +33,8 @@ enum OnboardingType {
     OnboardingTypeTimelineTimeEntry,
     OnboardingTypeTimelineView,
     OnboardingTypeTimelineActivity,
-    OnboardingTypeRecordActivity
+    OnboardingTypeRecordActivity,
+    OnboardingTypeTextShortcuts
 };
 
 class TOGGL_INTERNAL_EXPORT OnboardingState {
@@ -58,7 +59,8 @@ class TOGGL_INTERNAL_EXPORT OnboardingState {
     , isPresentTimelineTimeEntry(false)
     , isPresentTimelineView(false)
     , isPresentTimelineActivity(false)
-    , isPresentRecordActivity(false) {}
+    , isPresentRecordActivity(false)
+    , isPresentTextShortcuts(false) {}
 
     Poco::Int64 local_id;
     Poco::Int64 user_id;
@@ -82,6 +84,7 @@ class TOGGL_INTERNAL_EXPORT OnboardingState {
     bool isPresentTimelineView;
     bool isPresentTimelineActivity;
     bool isPresentRecordActivity;
+    bool isPresentTextShortcuts;
 };
 
 class TOGGL_INTERNAL_EXPORT OnboardingService {
@@ -131,6 +134,7 @@ class TOGGL_INTERNAL_EXPORT OnboardingService {
     bool handleTimelineTabOnboarding();
     bool handleNewUserOnboarding();
     bool handleOldUserOnboarding();
+    bool handleTextShortcutsOnboarding();
     void getFirstTimeEntryCreatedAtFromUser(User *user);
 };
 }

--- a/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
@@ -444,19 +444,22 @@ extern void *ctx;
 
 #pragma mark - Onboarding
 
-- (void)startOnboardingNotification:(NSNotification *) noti
+- (void)startOnboardingNotification:(NSNotification *)notification
 {
     [OnboardingServiceObjc
-     handleOnboardingNotification:noti
+     handleOnboardingNotification:notification
      atView:^NSView * _Nullable(enum OnboardingHint hint) {
         return [self getOnboardingViewWithHint:hint];
-     }
+    }
+     positioningRect:^NSRect(enum OnboardingHint hint, NSRect originalRect) {
+        return [self positioningRectForHint:hint originalRect:originalRect];
+    }
      switchTo:^(enum OnboardingPresentViewTab tab) {
         [self.mainDashboardViewController switchToTab:tab];
     }];
 }
 
-- (NSView * __nullable) getOnboardingViewWithHint:(OnboardingHint) hint
+- (NSView * __nullable)getOnboardingViewWithHint:(OnboardingHint) hint
 {
     switch (hint) {
         case OnboardingHintNewUser:
@@ -477,12 +480,24 @@ extern void *ctx;
             return self.mainDashboardViewController.timelineController.activityContainerView;
         case OnboardingHintRecordActivity:
             return self.mainDashboardViewController.timelineController.recordActivityContainerView;
+        case OnboardingHintTextShortcuts:
+            return self.mainDashboardViewController.timerController.shortcutsOnboardingView;
         default:
             return nil;
 	}
 }
 
--(void) handleContinueSignInNotification:(NSNotification *) noti
+- (NSRect)positioningRectForHint:(OnboardingHint)hint originalRect:(NSRect)originalRect
+{
+    switch (hint) {
+        case OnboardingHintTextShortcuts:
+            return [self.mainDashboardViewController.timerController shortcutsOnboardingPositioningRect];
+        default:
+            return originalRect;
+    }
+}
+
+- (void)handleContinueSignInNotification:(NSNotification *) noti
 {
     if (self.loginViewController.view.superview != nil)
     {

--- a/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingContentViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingContentViewController.swift
@@ -18,7 +18,7 @@ final class OnboardingContentViewController: NSViewController {
     // MARK: Public
 
     func config(with payload: OnboardingPayload) {
-        self.titleTextField.stringValue = payload.title
+        self.titleTextField.attributedStringValue = payload.title
     }
 
     @IBAction func exitBtnOnClick(_ sender: Any) {

--- a/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingContentViewController.xib
+++ b/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingContentViewController.xib
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="OnboardingContentViewController" customModule="TogglDesktop" customModuleProvider="target">
+        <customObject id="-2" userLabel="File's Owner" customClass="OnboardingContentViewController" customModule="Toggl_Track" customModuleProvider="target">
             <connections>
                 <outlet property="titleTextField" destination="jYZ-L3-Wrw" id="2fG-7V-rBd"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
@@ -20,8 +20,8 @@
             <subviews>
                 <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="jYZ-L3-Wrw">
                     <rect key="frame" x="13" y="15" width="86" height="15"/>
-                    <textFieldCell key="cell" selectable="YES" title="Multiline Label" id="5Mi-HB-13h">
-                        <font key="font" metaFont="label" size="12"/>
+                    <textFieldCell key="cell" selectable="YES" enabled="NO" title="Multiline Label" id="5Mi-HB-13h">
+                        <font key="font" metaFont="cellTitle"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingService+Objc.swift
+++ b/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingService+Objc.swift
@@ -26,6 +26,7 @@ import Foundation
     ///   - switchTo: A block to ask the view controller switch to the certain tab
     @objc class func handleOnboardingNotification(_ noti: Notification,
                                                   atView: (OnboardingHint) -> NSView?,
+                                                  positioningRect: @escaping (OnboardingHint, NSRect) -> NSRect,
                                                   switchTo: (OnboardingPresentViewTab) -> Void) {
         guard let number = noti.object as? NSNumber else { return }
         guard let hint = OnboardingHint(rawValue: number.intValue) else {
@@ -41,8 +42,9 @@ import Foundation
         switchTo(presentView)
 
         // Present
-        print("✅ Present onboarding hint = \(hint.debuggingName)")
-        let payload = OnboardingPayload(hint: hint, view: view)
+        print("✅ Present onboarding hint = \(hint.debugDescription)")
+        var payload = OnboardingPayload(hint: hint, view: view)
+        payload.positioningRect = positioningRect
         OnboardingService.shared.present(payload)
     }
 
@@ -55,7 +57,8 @@ import Foundation
         case .editTimeEntry,
              .manualMode,
              .newUser,
-             .oldUser:
+             .oldUser,
+             .textShortcuts:
             return .timeEntry
         case .recordActivity,
              .timelineActivity,

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.h
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.h
@@ -16,5 +16,7 @@
 
 - (void)startButtonClicked;
 - (void)focusTimer;
+- (NSView *)shortcutsOnboardingView;
+- (NSRect)shortcutsOnboardingPositioningRect;
 
 @end

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.m
@@ -111,6 +111,14 @@ extern void *ctx;
     }
 }
 
+- (NSView *)shortcutsOnboardingView {
+    return [self.timerViewController shortcutsOnboardingView];
+}
+
+- (NSRect)shortcutsOnboardingPositioningRect {
+    return [self.timerViewController shortcutsOnboardingPositioningRect];
+}
+
 - (IBAction)addEntryBtnOnTap:(id)sender
 {
     [self addButtonClicked];

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
@@ -59,7 +59,7 @@ class TimerDescriptionFieldHandler: NSResponder {
     /// - Parameters:
     ///   - textField: Text field that will be sending event to this handler
     ///   - enableShortcuts: Pass `true` to enable project (@) and tags (#) shortcuts feature
-    init(textField: AutoCompleteInput, enableShortcuts: Bool = false) {
+    init(textField: AutoCompleteInput, enableShortcuts: Bool = true) {
         self.textField = textField
         self.isShortcutEnabled = enableShortcuts
         super.init()

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -39,8 +39,8 @@ class TimerViewController: NSViewController {
     }
 
     private enum Constants {
-        static let emptyProjectButtonTooltip = NSLocalizedString("Select project", comment: "Tooltip for timer project button")
-        static let emptyTagsButtonTooltip = NSLocalizedString("Select tags", comment: "Tooltip for timer tags button")
+        static let emptyProjectButtonTooltip = NSLocalizedString("Select project (@)", comment: "Tooltip for timer project button")
+        static let emptyTagsButtonTooltip = NSLocalizedString("Select tags (#)", comment: "Tooltip for timer tags button")
         static let billableOnTooltip = NSLocalizedString("Billable", comment: "Tooltip for timer billable button when On")
         static let billableOffTooltip = NSLocalizedString("Non-billable", comment: "Tooltip for timer billable button when Off")
         static let billableUnavailableTooltip = NSLocalizedString("Billable rates is not on your plan",

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -62,6 +62,7 @@ class TimerViewController: NSViewController {
     @IBOutlet weak var projectButton: SelectableButton!
     @IBOutlet weak var tagsButton: SelectableButton!
     @IBOutlet weak var billableButton: SelectableButton!
+    @IBOutlet weak var buttonsStackView: NSStackView!
 
     // MARK: - Lifecycle
 
@@ -218,6 +219,21 @@ class TimerViewController: NSViewController {
     @objc
     func triggerStartStopAction() {
         viewModel.startStopAction()
+    }
+
+    @objc
+    func shortcutsOnboardingView() -> NSView {
+        return buttonsStackView
+    }
+
+    @objc
+    func shortcutsOnboardingPositioningRect() -> NSRect {
+        // onboarding for shortcuts is presented between projectButton and tagsButton
+        // that's why resulting rect should contain only those two buttons
+        // !!!: we assume that buttons order won't change: project | tags | billable
+        var rect = buttonsStackView.bounds
+        rect.size.width = tagsButton.frame.maxX
+        return rect
     }
 
     // MARK: - Actions

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -10,6 +10,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="TimerViewController" customModule="Toggl_Track" customModuleProvider="target">
             <connections>
                 <outlet property="billableButton" destination="lkp-Tv-GfR" id="ADf-Ah-y0P"/>
+                <outlet property="buttonsStackView" destination="f3m-Ax-U74" id="MiL-8N-Bay"/>
                 <outlet property="descriptionContainerBox" destination="hG9-dZ-2ec" id="u09-Ec-oG5"/>
                 <outlet property="descriptionTextField" destination="ecT-b1-LZO" id="sXf-8p-YKn"/>
                 <outlet property="durationContainerBox" destination="gmz-ld-awU" id="TDb-In-h3a"/>


### PR DESCRIPTION
### 📒 Description
This PR adds new onboarding type - Text Shortcuts. 
<img width="585" alt="Screenshot 2020-10-08 at 18 28 46" src="https://user-images.githubusercontent.com/3470113/95856030-124e2780-0d62-11eb-9d3a-ef4a54f8b6f5.png">
This onboarding is presented for all users who tracked at least 3 TEs and haven't yet saw shortcuts onboarding.

Tooltip for project button is changed to "Select project (@)" and tag button - "Select tags (#)"

Finally, the shortcuts feature itself is now enabled by default because this is the last planned PR before the feature release.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4442

### 🔎 Review hints
1. Build and run the app to see the onboarding popup. The priority of the shortcuts onboarding is currently the lowest among ones that are triggered on application start, so you may need to restart the app few times.
1. Test if migration is done correctly. New field is added to `onboarding_states` table - `is_present_text_shortcuts_onboarding`.
