### PR TITLE
Resizing TEs to change the start time or duration

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -451,6 +451,22 @@ public static partial class Toggl
         }
     }
 
+    public static bool SetTimeEntryStartTimeStamp(string guid, long timeStamp)
+    {
+        using (Performance.Measure("changing time entry start time stamp"))
+        {
+            return toggl_set_time_entry_start_timestamp(ctx, guid, timeStamp);
+        }
+    }
+
+    public static bool SetTimeEntryEndTimeStamp(string guid, long timeStamp)
+    {
+        using (Performance.Measure("changing time entry start time stamp"))
+        {
+            return toggl_set_time_entry_end_timestamp(ctx, guid, timeStamp);
+        }
+    }
+
     #endregion
 
     public static bool Stop(bool preventOnApp = false)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -461,7 +461,7 @@ public static partial class Toggl
 
     public static bool SetTimeEntryEndTimeStamp(string guid, long timeStamp)
     {
-        using (Performance.Measure("changing time entry start time stamp"))
+        using (Performance.Measure("changing time entry end time stamp"))
         {
             return toggl_set_time_entry_end_timestamp(ctx, guid, timeStamp);
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -284,6 +284,7 @@
       <DependentUpon>ReminderNotification.xaml</DependentUpon>
     </Compile>
     <Compile Include="ui\Notifications\TogglNotification.cs" />
+    <Compile Include="ui\Resources\TimelineConstants.cs" />
     <Compile Include="ui\Theming\Theme.cs" />
     <Compile Include="ui\Theming\ThemeResourceDictionary.cs" />
     <Compile Include="ui\Theming\ThemeType.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace TogglDesktop.Resources
+{
+    public static class TimelineConstants
+    {
+        public const int MaxActivityBlockDurationInSec = 900;
+        public const double MinTimeEntryBlockHeight = 2;
+        public const double MinResizableTimeEntryBlockHeight = 14; //Resize handles take 5 px each (10 in total)
+        public const double MinShowTEDescriptionHeight = 20;
+        public const double DescriptionOpacity = 0.2;
+        public const double TimeEntryBlockWidth = 20;
+        public const double GapBetweenOverlappingTEs = 5;
+
+        public static IReadOnlyDictionary<int, int> ScaleModes { get; } = new Dictionary<int, int>()
+        {
+            {0, 200},
+            {1, 100},
+            {2, 50},
+            {3, 25}
+        };
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -353,8 +353,10 @@ namespace TogglDesktop.ViewModels
 
     public class TimeEntryBlock : ReactiveObject
     {
+        [Reactive]
         public double VerticalOffset { get; set; }
         public double HorizontalOffset { get; set; }
+        [Reactive]
         public double Height { get; set; }
         public string Color { get; set; }
         public bool ShowDescription { get; set; }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -171,7 +171,7 @@ namespace TogglDesktop.ViewModels
             {
                 var startTime = Toggl.DateTimeFromUnix(entry.Started);
                 var height = ConvertTimeIntervalToHeight(startTime, Toggl.DateTimeFromUnix(entry.Ended), selectedScaleMode);
-                var block = new TimeEntryBlock(entry.GUID, ScaleModes[SelectedScaleMode])
+                var block = new TimeEntryBlock(entry.GUID, ScaleModes[selectedScaleMode])
                 {
                     Height = height < 2 ? 2 : height,
                     VerticalOffset = ConvertTimeIntervalToHeight(new DateTime(startTime.Year, startTime.Month, startTime.Day), startTime, selectedScaleMode),
@@ -185,8 +185,9 @@ namespace TogglDesktop.ViewModels
                     HasTag = !entry.Tags.IsNullOrEmpty(),
                     IsBillable = entry.Billable,
                     Duration = entry.DateDuration,
-                    StartEndCaption = entry.StartTimeString + " - " + entry.EndTimeString
-                };
+                    StartEndCaption = entry.StartTimeString + " - " + entry.EndTimeString,
+                    IsResizable = height >= 14 //Resize handles take 5 px each (10 in total)
+            };
                 if (entry.Started != entry.Ended)
                 {
                     timeStampsList.Add((TimeStampType.Start, block));
@@ -267,7 +268,7 @@ namespace TogglDesktop.ViewModels
                 if (prevEnd != null && entry.Started > prevEnd.Value)
                 {
                     var start = Toggl.DateTimeFromUnix(prevEnd.Value+1);
-                    var block = new TimeEntryBlock(ScaleModes[SelectedScaleMode])
+                    var block = new TimeEntryBlock(ScaleModes[selectedScaleMode])
                     {
                         Height = ConvertTimeIntervalToHeight(start, Toggl.DateTimeFromUnix(entry.Started - 1), selectedScaleMode),
                         VerticalOffset =
@@ -375,6 +376,8 @@ namespace TogglDesktop.ViewModels
 
         [Reactive]
         public bool IsEditViewOpened { get; set; }
+
+        public bool IsResizable { get; set; }
 
         private readonly double _hourHeight;
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using TogglDesktop.Resources;
 
 namespace TogglDesktop.ViewModels
 {
@@ -46,7 +47,7 @@ namespace TogglDesktop.ViewModels
             DecreaseScale = ReactiveCommand.Create(() => SelectedScaleMode = ChangeScaleMode(1));
             var scaleModeObservable = this.WhenAnyValue(x => x.SelectedScaleMode);
             scaleModeObservable.Subscribe(_ =>
-                HourHeightView = ScaleModes[SelectedScaleMode] * GetHoursInLine(SelectedScaleMode));
+                HourHeightView = TimelineConstants.ScaleModes[SelectedScaleMode] * GetHoursInLine(SelectedScaleMode));
             scaleModeObservable.Select(GetHoursListFromScale).ToPropertyEx(this, x => x.HourViews);
             scaleModeObservable.Select(mode => ConvertTimeIntervalToHeight(DateTime.Today, DateTime.Now, mode))
                 .Subscribe(h => CurrentTimeOffset = h);
@@ -75,7 +76,7 @@ namespace TogglDesktop.ViewModels
         }
 
         private int ChangeScaleMode(int value) =>
-            SelectedScaleMode + value < 0 || SelectedScaleMode + value > ScaleModes.Count - 1
+            SelectedScaleMode + value < 0 || SelectedScaleMode + value > TimelineConstants.ScaleModes.Count - 1
                 ? SelectedScaleMode
                 : SelectedScaleMode + value;
 
@@ -118,7 +119,6 @@ namespace TogglDesktop.ViewModels
             }
         }
 
-        private const int MaxActivityBlockDurationInSec = 900;
         private static List<ActivityBlock> ConvertChunksToActivityBlocks(List<Toggl.TimelineChunkView> chunks, int selectedScaleMode)
         {
             var blocks = new List<ActivityBlock>();
@@ -146,7 +146,7 @@ namespace TogglDesktop.ViewModels
                         block.ActivityDescriptions.Add(activity);
                         duration += eventDesc.Duration;
                     }
-                    block.Height = (1.0 * Math.Min(duration, MaxActivityBlockDurationInSec) * ScaleModes[selectedScaleMode]) / (60 * 60);
+                    block.Height = (1.0 * Math.Min(duration, TimelineConstants.MaxActivityBlockDurationInSec) * TimelineConstants.ScaleModes[selectedScaleMode]) / (60 * 60);
                     if (block.ActivityDescriptions.Any())
                         blocks.Add(block);
                 }
@@ -171,9 +171,9 @@ namespace TogglDesktop.ViewModels
             {
                 var startTime = Toggl.DateTimeFromUnix(entry.Started);
                 var height = ConvertTimeIntervalToHeight(startTime, Toggl.DateTimeFromUnix(entry.Ended), selectedScaleMode);
-                var block = new TimeEntryBlock(entry.GUID, ScaleModes[selectedScaleMode])
+                var block = new TimeEntryBlock(entry.GUID, TimelineConstants.ScaleModes[selectedScaleMode])
                 {
-                    Height = height < 2 ? 2 : height,
+                    Height = Math.Max(height, TimelineConstants.MinTimeEntryBlockHeight),
                     VerticalOffset = ConvertTimeIntervalToHeight(new DateTime(startTime.Year, startTime.Month, startTime.Day), startTime, selectedScaleMode),
                     Color = entry.Color,
                     Description = entry.Description.IsNullOrEmpty() ? "No Description" : entry.Description,
@@ -186,7 +186,7 @@ namespace TogglDesktop.ViewModels
                     IsBillable = entry.Billable,
                     Duration = entry.DateDuration,
                     StartEndCaption = entry.StartTimeString + " - " + entry.EndTimeString,
-                    IsResizable = height >= 14 //Resize handles take 5 px each (10 in total)
+                    IsResizable = height >= TimelineConstants.MinResizableTimeEntryBlockHeight
             };
                 if (entry.Started != entry.Ended)
                 {
@@ -218,7 +218,7 @@ namespace TogglDesktop.ViewModels
                 return res;
             });
             var offsets = new HashSet<double>();
-            var curOffset = 0;
+            var curOffset = 0d;
             var usedNumOfOffsets = 0;
             TimeEntryBlock prevLayerBlock = null;
             foreach (var item in timeStampsList)
@@ -228,9 +228,9 @@ namespace TogglDesktop.ViewModels
                     if (!offsets.Any())
                     {
                         offsets.Add(curOffset);
-                        curOffset += 25;
+                        curOffset += TimelineConstants.TimeEntryBlockWidth+TimelineConstants.GapBetweenOverlappingTEs;
                     }
-                    if (usedNumOfOffsets > 0 || item.Block.Height < 20)
+                    if (usedNumOfOffsets > 0 || item.Block.Height < TimelineConstants.MinShowTEDescriptionHeight)
                     {
                         item.Block.ShowDescription = false;
                         if (prevLayerBlock != null)
@@ -255,7 +255,7 @@ namespace TogglDesktop.ViewModels
         public static double ConvertTimeIntervalToHeight(DateTime start, DateTime end, int scaleMode)
         {
             var timeInterval = (end - start).TotalMinutes;
-            return timeInterval * ScaleModes[scaleMode] / 60;
+            return timeInterval * TimelineConstants.ScaleModes[scaleMode] / 60;
         }
 
         private static List<TimeEntryBlock> GenerateGapTimeEntryBlocks(List<Toggl.TogglTimeEntryView> timeEntries, int selectedScaleMode)
@@ -268,7 +268,7 @@ namespace TogglDesktop.ViewModels
                 if (prevEnd != null && entry.Started > prevEnd.Value)
                 {
                     var start = Toggl.DateTimeFromUnix(prevEnd.Value+1);
-                    var block = new TimeEntryBlock(ScaleModes[selectedScaleMode])
+                    var block = new TimeEntryBlock(TimelineConstants.ScaleModes[selectedScaleMode])
                     {
                         Height = ConvertTimeIntervalToHeight(start, Toggl.DateTimeFromUnix(entry.Started - 1), selectedScaleMode),
                         VerticalOffset =
@@ -285,14 +285,6 @@ namespace TogglDesktop.ViewModels
             
             return gaps;
         }
-
-        public static IReadOnlyDictionary<int, int> ScaleModes { get; } = new Dictionary<int, int>()
-        {
-            {0, 200},
-            {1, 100},
-            {2, 50},
-            {3, 25}
-        };
 
         [Reactive] 
         public int SelectedScaleMode { get; private set; } = 0;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -376,13 +376,12 @@ namespace TogglDesktop.ViewModels
         [Reactive]
         public bool IsEditViewOpened { get; set; }
 
-        private double _hourHeight;
+        private readonly double _hourHeight;
 
         public TimeEntryBlock(string timeEntryId, int hourHeight)
         {
             _hourHeight = hourHeight;
             TimeEntryId = timeEntryId;
-            CreateTimeEntryFromBlock = ReactiveCommand.Create(() => AddNewTimeEntry());
             OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(TimeEntryId, false, Toggl.Description));
             CreateTimeEntryFromBlock = ReactiveCommand.Create(AddNewTimeEntry);
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -77,6 +77,30 @@
                             </Style>
                         </Border.Style>
                     </Border>
+                    <Thumb VerticalAlignment="Top"
+                           HorizontalAlignment="Stretch"
+                           Grid.Column="0" Grid.ColumnSpan="2"
+                           Cursor="SizeNS"
+                           Name="ThumbTop"
+                           DragDelta="OnThumbTopDragDelta">
+                        <Thumb.Template>
+                            <ControlTemplate>
+                                <Rectangle Fill="Transparent" Height="5"/>
+                            </ControlTemplate>
+                        </Thumb.Template>
+                    </Thumb>
+                    <Thumb VerticalAlignment="Bottom"
+                           HorizontalAlignment="Stretch"
+                           Grid.Column="0" Grid.ColumnSpan="2"
+                           Cursor="SizeNS"
+                           Name="ThumbBottom"
+                           DragDelta="OnThumbBottomDragDelta">
+                        <Thumb.Template>
+                            <ControlTemplate>
+                                <Rectangle Fill="Transparent" Height="5"/>
+                            </ControlTemplate>
+                        </Thumb.Template>
+                    </Thumb>
                 </Grid>
             </ControlTemplate>
         </Button.Template>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -82,7 +82,8 @@
                            Grid.Column="0" Grid.ColumnSpan="2"
                            Cursor="SizeNS"
                            Name="ThumbTop"
-                           DragDelta="OnThumbTopDragDelta">
+                           DragDelta="OnThumbTopDragDelta"
+                           DragCompleted="OnThumbTopDragCompleted">
                         <Thumb.Template>
                             <ControlTemplate>
                                 <Rectangle Fill="Transparent" Height="5"/>
@@ -94,7 +95,8 @@
                            Grid.Column="0" Grid.ColumnSpan="2"
                            Cursor="SizeNS"
                            Name="ThumbBottom"
-                           DragDelta="OnThumbBottomDragDelta">
+                           DragDelta="OnThumbBottomDragDelta"
+                           DragCompleted="OnThumbBottomDragCompleted">
                         <Thumb.Template>
                             <ControlTemplate>
                                 <Rectangle Fill="Transparent" Height="5"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -4,8 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:converters="clr-namespace:TogglDesktop.Converters"
+             xmlns:res="clr-namespace:TogglDesktop.Resources"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimeEntryBlock, IsDesignTimeCreatable=False}">
@@ -13,10 +13,9 @@
         <ResourceDictionary>
             <converters:RectangleHeightToRadiusConverter x:Key="HeightToRadiusConverter"/>
             <converters:BrushOpacityConverter x:Key="BrushOpacityConverter"/>
-            <sys:Double x:Key="DescriptionOpacity">0.2</sys:Double>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Button FontWeight="Normal" Command="{Binding OpenEditView}" MinHeight="2" Margin="0 0 4 0" Height="{Binding Height}">
+    <Button FontWeight="Normal" Command="{Binding OpenEditView}" MinHeight="{x:Static res:TimelineConstants.MinTimeEntryBlockHeight}" Margin="0 0 4 0" Height="{Binding Height}">
         <Button.Template>
             <ControlTemplate>
                 <Grid>
@@ -26,15 +25,14 @@
                     </Grid.ColumnDefinitions>
                     <Border Grid.Column="1" CornerRadius="8,8,8,8" Background="{DynamicResource Toggl.Background}" Margin="-10 0 0 0"/>
                     <Rectangle Grid.Column="0" Name ="TimeEntrySpan"
-                               Width="20"
+                               Width="{x:Static res:TimelineConstants.TimeEntryBlockWidth}"
                                Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
                                RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
                                RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">
                     </Rectangle>
                     <Border CornerRadius="0,8,8,0" Margin="-10 0 0 0" Grid.Column="1"
                             BorderThickness="1"
-                            Background="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource DescriptionOpacity}}"
-                            MinHeight="2"
+                            Background="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={x:Static res:TimelineConstants.DescriptionOpacity}}"
                             Visibility="{Binding ShowDescription, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel Height="{Binding Height}" Margin="20,0,0,0">
                             <TextBlock Text="{Binding Description}" Style="{StaticResource Toggl.CaptionBlackText}"/>
@@ -68,7 +66,7 @@
                         </StackPanel>
                         <Border.Style>
                             <Style TargetType="Border">
-                                <Setter Property="BorderBrush" Value="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={StaticResource DescriptionOpacity}}"/>
+                                <Setter Property="BorderBrush" Value="{Binding ElementName=TimeEntrySpan, Path=Fill, Converter={StaticResource BrushOpacityConverter},ConverterParameter={x:Static res:TimelineConstants.DescriptionOpacity}}"/>
                                 <Style.Triggers>
                                     <DataTrigger  Binding="{Binding IsEditViewOpened}" Value="True">
                                         <Setter Property="BorderBrush" Value="{Binding ElementName=TimeEntrySpan, Path=Fill}"></Setter>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -82,6 +82,7 @@
                            Grid.Column="0" Grid.ColumnSpan="2"
                            Cursor="SizeNS"
                            Name="ThumbTop"
+                           Visibility="{Binding IsResizable, Converter={StaticResource BooleanToVisibilityConverter}}"
                            DragDelta="OnThumbTopDragDelta"
                            DragCompleted="OnThumbTopDragCompleted">
                         <Thumb.Template>
@@ -95,6 +96,7 @@
                            Grid.Column="0" Grid.ColumnSpan="2"
                            Cursor="SizeNS"
                            Name="ThumbBottom"
+                           Visibility="{Binding IsResizable, Converter={StaticResource BooleanToVisibilityConverter}}"
                            DragDelta="OnThumbBottomDragDelta"
                            DragCompleted="OnThumbBottomDragCompleted">
                         <Thumb.Template>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
 {
@@ -7,9 +9,27 @@ namespace TogglDesktop
     /// </summary>
     public partial class TimelineTimeEntryBlock : UserControl
     {
+        public TimeEntryBlock ViewModel
+        {
+            get => DataContext as TimeEntryBlock;
+            set => DataContext = value;
+        }
+
         public TimelineTimeEntryBlock()
         {
             InitializeComponent();
+
+        }
+
+        private void OnThumbBottomDragDelta(object sender, DragDeltaEventArgs e)
+        {
+            ViewModel.Height += e.VerticalChange;
+        }
+
+        private void OnThumbTopDragDelta(object sender, DragDeltaEventArgs e)
+        {
+            ViewModel.VerticalOffset += e.VerticalChange;
+            ViewModel.Height -= e.VerticalChange;
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
@@ -23,13 +23,17 @@ namespace TogglDesktop
 
         private void OnThumbBottomDragDelta(object sender, DragDeltaEventArgs e)
         {
-            ViewModel.Height += e.VerticalChange;
+            if (ViewModel.Height + e.VerticalChange > 0)
+                ViewModel.Height += e.VerticalChange;
         }
 
         private void OnThumbTopDragDelta(object sender, DragDeltaEventArgs e)
         {
-            ViewModel.VerticalOffset += e.VerticalChange;
-            ViewModel.Height -= e.VerticalChange;
+            if (ViewModel.Height + e.VerticalChange > 0)
+            {
+                ViewModel.VerticalOffset += e.VerticalChange;
+                ViewModel.Height -= e.VerticalChange;
+            }
         }
 
         private void OnThumbTopDragCompleted(object sender, DragCompletedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
@@ -29,7 +29,7 @@ namespace TogglDesktop
 
         private void OnThumbTopDragDelta(object sender, DragDeltaEventArgs e)
         {
-            if (ViewModel.Height + e.VerticalChange > 0)
+            if (ViewModel.Height - e.VerticalChange > 0)
             {
                 ViewModel.VerticalOffset += e.VerticalChange;
                 ViewModel.Height -= e.VerticalChange;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml.cs
@@ -31,5 +31,15 @@ namespace TogglDesktop
             ViewModel.VerticalOffset += e.VerticalChange;
             ViewModel.Height -= e.VerticalChange;
         }
+
+        private void OnThumbTopDragCompleted(object sender, DragCompletedEventArgs e)
+        {
+            ViewModel.ChangeStartTime();
+        }
+
+        private void OnThumbBottomDragCompleted(object sender, DragCompletedEventArgs e)
+        {
+            ViewModel.ChangeEndTime();
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -9,6 +9,7 @@
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:TogglDesktop.Behaviors"
              xmlns:converters="clr-namespace:TogglDesktop.Converters"
+             xmlns:res="clr-namespace:TogglDesktop.Resources"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimelineViewModel, IsDesignTimeCreatable=False}">
@@ -203,7 +204,7 @@
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Button Style="{StaticResource Toggl.Timeline.GapButton}" Height="{Binding Height}" Width="20"
+                                <Button Style="{StaticResource Toggl.Timeline.GapButton}" Height="{Binding Height}" Width="{x:Static res:TimelineConstants.TimeEntryBlockWidth}"
                                         Command="{Binding CreateTimeEntryFromBlock}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using DynamicData.Binding;
 using ReactiveUI;
+using TogglDesktop.Resources;
 using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
@@ -37,7 +38,7 @@ namespace TogglDesktop
 
                 ViewModel?.WhenAnyValue(x => x.SelectedScaleMode).Buffer(2, 1)
                     .ObserveOn(RxApp.MainThreadScheduler)
-                    .Select(b => (double)TimelineViewModel.ScaleModes[b[1]] / TimelineViewModel.ScaleModes[b[0]])
+                    .Select(b => (double)TimelineConstants.ScaleModes[b[1]] / TimelineConstants.ScaleModes[b[0]])
                     .Subscribe(ratio => SetMainViewScrollOffset(MainViewScroll.VerticalOffset * ratio))
                     .DisposeWith(_disposable);
                 ViewModel?.WhenValueChanged(x => x.IsTodaySelected)


### PR DESCRIPTION
### 📒 Description
Introduce the possibility to resize the TEs (from the top or the bottom) to change its duration or duration+start time.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4434 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

There is a problem for very small TEs: it's not possible to click on them to open edit view, because the resize handles take all its size. On the other hand it would be annoying if edit view opened when user tries to resize a TE. On MacOS it's done vice versa, it's not possible to resize very small TEs (at least I couldn't do that). Not sure which solution is better.