### PR TITLE
Upload release asset before updating appcast xml file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,15 +100,15 @@ jobs:
       with:
         name: TogglDesktop.dmg
         path: "${{ env.installer }}"
+    - name: Upload
+      if: github.event_name == 'release'
+      run: |
+        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="$installer" renameto="$installer_name"
     - name: Update Appcast
       if: github.event_name == 'release'
       run: |
         base64 -D <<< "${{ secrets.APPCAST_PRIVATE_PEM }}" > dsa_priv.pem
         bash ./dist/osx/build.sh appcast
-    - name: Upload
-      if: github.event_name == 'release'
-      run: |
-        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="$installer" renameto="$installer_name"
     - name: Update Release
       if: github.event_name == 'release'
       run: |


### PR DESCRIPTION
### 📒 Description
Upload macOS release asset before updating the appcast xml file.
No actual issues were observed, but the fix seems to make the workflow safer.

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4505

### 🔎 Review hints
Just check to see if the code makes sense