### PR TITLE
Select the first tab in preferences always (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -41,7 +41,10 @@ PreferencesDialog::~PreferencesDialog() {
 void PreferencesDialog::displaySettings(const bool open,
                                         SettingsView *settings) {
     if (open) {
+        bool wasVisible = isVisible();
         show();
+        if (!wasVisible)
+            ui->tabWidget->setCurrentIndex(0);
     }
 
     ui->useSystemProxySettings->setChecked(settings->AutodetectProxy);


### PR DESCRIPTION
### 📒 Description
There's this annoying feature in Qt creator that changes the selected tab in a tab widget to whatever you had opened last when viewing the UI in the IDE (which is actually reasonable but I never realize I have changed the value). This PR just makes sure the first tab is shown always, regardless of what is set in the UI file.

### 🔎 Review hints
First tab in the preferences window should be selected (the UI file default is now the second one) 
