### PR TITLE
Set scroll to first time entry

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -904,7 +904,12 @@ public static partial class Toggl
     public static event DisplayInAppNotification OnDisplayInAppNotification = delegate { };
     public static readonly BehaviorSubject<UpdateStatus> OnUpdateDownloadStatus
         = new BehaviorSubject<UpdateStatus>(new UpdateStatus());
-    public static event DisplayTimeline OnTimeline = delegate { };
+
+    public static readonly BehaviorSubject<List<TimelineChunkView>> TimelineChunks =
+        new BehaviorSubject<List<TimelineChunkView>>(new List<TimelineChunkView>());
+
+    public static readonly BehaviorSubject<List<TogglTimeEntryView>> TimelineTimeEntries =
+        new BehaviorSubject<List<TogglTimeEntryView>>(new List<TogglTimeEntryView>());
     public static event DisplayTimelineUI OnDisplayTimelineUI = delegate { };
     private static void listenToLibEvents()
     {
@@ -1156,8 +1161,10 @@ public static partial class Toggl
         {
             using (Performance.Measure("Calling OnTimeline"))
             {
-                OnTimeline(open, date, convertToTimelineChunkList(first), convertToTimeEntryList(firstTimeEntry),
-                    startDay, endDay);
+                var chunks = convertToTimelineChunkList(first);
+                var timeEntries = convertToTimeEntryList(firstTimeEntry);
+                TimelineChunks.OnNext(chunks);
+                TimelineTimeEntries.OnNext(timeEntries);
             }
         });
         toggl_on_timeline_ui_enabled(ctx, isEnabled =>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -910,6 +910,8 @@ public static partial class Toggl
 
     public static readonly BehaviorSubject<List<TogglTimeEntryView>> TimelineTimeEntries =
         new BehaviorSubject<List<TogglTimeEntryView>>(new List<TogglTimeEntryView>());
+    
+    public static readonly BehaviorSubject<DateTime> TimelineSelectedDate = new BehaviorSubject<DateTime>(DateTime.Today);
     public static event DisplayTimelineUI OnDisplayTimelineUI = delegate { };
     private static void listenToLibEvents()
     {
@@ -1161,6 +1163,7 @@ public static partial class Toggl
         {
             using (Performance.Measure("Calling OnTimeline"))
             {
+                TimelineSelectedDate.OnNext(DateTimeFromUnix(startDay));
                 var chunks = convertToTimelineChunkList(first);
                 var timeEntries = convertToTimeEntryList(firstTimeEntry);
                 TimelineChunks.OnNext(chunks);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -30,7 +30,11 @@ namespace TogglDesktop.ViewModels
 
             this.WhenAnyValue(x => x.SelectedDate)
                 .ObserveOn(RxApp.TaskpoolScheduler)
-                .Subscribe(HandleSelectedDateChanged);
+                .Subscribe(LoadMoreIfNeeded);
+
+            this.WhenAnyValue(x => x.SelectedDate)
+                .ObserveOn(RxApp.TaskpoolScheduler)
+                .Subscribe(_ => HideEditViewIfNeeded());
 
             Toggl.TimelineSelectedDate
                 .Select(dateTime => dateTime.Date == DateTime.Today.Date)
@@ -89,12 +93,16 @@ namespace TogglDesktop.ViewModels
 
         private static int GetHoursInLine(int scaleMode) => scaleMode != 3 ? 1 : 2;
 
-        private void HandleSelectedDateChanged(DateTime date)
+        private void LoadMoreIfNeeded(DateTime date)
         {
             if (date < _lastDateLoaded)
             {
                 Toggl.LoadMore();
             }
+        }
+
+        private void HideEditViewIfNeeded()
+        {
             if (SelectedForEditTEId != null)
                 Toggl.Edit(SelectedForEditTEId, false, "");
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -65,7 +65,6 @@ namespace TogglDesktop.ViewModels
             this.WhenAnyValue(x => x.SelectedForEditTEId, x => x.TimeEntryBlocks)
                 .ObserveOn(RxApp.TaskpoolScheduler).Subscribe(_ =>
                 TimeEntryBlocks?.ForEach(te => te.IsEditViewOpened = SelectedForEditTEId == te.TimeEntryId));
-            HourViews = GetHoursListFromScale(SelectedScaleMode);
             Observable.Timer(TimeSpan.Zero,TimeSpan.FromMinutes(1))
                 .Select(_ => ConvertTimeIntervalToHeight(DateTime.Today, DateTime.Now, SelectedScaleMode))
                 .Subscribe(h => CurrentTimeOffset = h);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -47,6 +47,7 @@ namespace TogglDesktop
                     .DisposeWith(_disposable);
                 ViewModel?.WhenValueChanged(x => x.IsTodaySelected)
                     .Where(x => x)
+                    .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(_ => MainViewScroll.ScrollToVerticalOffset(ViewModel.CurrentTimeOffset - MainViewScroll.ActualHeight / 2))
                     .DisposeWith(_disposable);
                 ViewModel?.WhenAnyValue(x => x.FirstTimeEntryOffset)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -18,13 +18,7 @@ namespace TogglDesktop
         private CompositeDisposable _disposable;
         public TimelineViewModel ViewModel
         {
-            get
-            {
-                if (Dispatcher.CheckAccess())
-                    return DataContext as TimelineViewModel;
-
-                return Dispatcher.Invoke(() => ViewModel);
-            }
+            get => DataContext as TimelineViewModel;
             set => DataContext = value;
         }
 
@@ -42,6 +36,7 @@ namespace TogglDesktop
                 _disposable = new CompositeDisposable();
 
                 ViewModel?.WhenAnyValue(x => x.SelectedScaleMode).Buffer(2, 1)
+                    .ObserveOn(RxApp.MainThreadScheduler)
                     .Select(b => (double)TimelineViewModel.ScaleModes[b[1]] / TimelineViewModel.ScaleModes[b[0]])
                     .Subscribe(ratio => SetMainViewScrollOffset(MainViewScroll.VerticalOffset * ratio))
                     .DisposeWith(_disposable);
@@ -51,6 +46,7 @@ namespace TogglDesktop
                     .Subscribe(_ => MainViewScroll.ScrollToVerticalOffset(ViewModel.CurrentTimeOffset - MainViewScroll.ActualHeight / 2))
                     .DisposeWith(_disposable);
                 ViewModel?.WhenAnyValue(x => x.FirstTimeEntryOffset)
+                    .ObserveOn(RxApp.MainThreadScheduler)
                     .Where(_ => !ViewModel.IsTodaySelected)
                     .Subscribe(SetMainViewScrollOffset)
                     .DisposeWith(_disposable);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using DynamicData.Binding;
 using ReactiveUI;
 using TogglDesktop.ViewModels;
 
@@ -44,8 +45,8 @@ namespace TogglDesktop
                     .Select(b => (double)TimelineViewModel.ScaleModes[b[1]] / TimelineViewModel.ScaleModes[b[0]])
                     .Subscribe(ratio => SetMainViewScrollOffset(MainViewScroll.VerticalOffset * ratio))
                     .DisposeWith(_disposable);
-                ViewModel?.WhenAnyValue(x => x.SelectedDate)
-                    .Where(_ => ViewModel.IsTodaySelected)
+                ViewModel?.WhenValueChanged(x => x.IsTodaySelected)
+                    .Where(x => x)
                     .Subscribe(_ => MainViewScroll.ScrollToVerticalOffset(ViewModel.CurrentTimeOffset - MainViewScroll.ActualHeight / 2))
                     .DisposeWith(_disposable);
                 ViewModel?.WhenAnyValue(x => x.FirstTimeEntryOffset)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -41,7 +41,7 @@ namespace TogglDesktop
                 _disposable = new CompositeDisposable();
 
                 ViewModel?.WhenAnyValue(x => x.SelectedScaleMode).Buffer(2, 1)
-                    .Select(b => (double)ViewModel.ScaleModes[b[1]] / ViewModel.ScaleModes[b[0]])
+                    .Select(b => (double)TimelineViewModel.ScaleModes[b[1]] / TimelineViewModel.ScaleModes[b[0]])
                     .Subscribe(ratio => SetMainViewScrollOffset(MainViewScroll.VerticalOffset * ratio))
                     .DisposeWith(_disposable);
                 ViewModel?.WhenAnyValue(x => x.SelectedDate)


### PR DESCRIPTION
### 📒 Description
Scroll in Timeline is automatically scrolled down to the first time entry of the day.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
 - **Breaking change** (fix or feature that would cause existing functionality to change) 

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Partly implements issue #4529

### 🔎 Review hints
What to test:
- Scroll is set to cur time if the date is today (centered)
- Scroll is set to the first TE of the day for all other dates
- Scroll doesn't change if there are no TEs for selected date
- Scaling works like it did before

