### PR TITLE
Automatically fill in info from the project that was created from Timer

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Input/ProjectAutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Input/ProjectAutoCompleteTextField.swift
@@ -100,11 +100,11 @@ final class ProjectAutoCompleteTextField: AutoCompleteTextField {
 
 extension ProjectAutoCompleteTextField: ProjectCreationViewDelegate {
 
-    func projectCreationDidAdd(with name: String, color: String, projectGUID: String) {
-        lastProjectGUID = projectGUID
-        stringValue = name
-        layoutProject(with: name)
-        applyColor(with: color)
+    func projectCreationDidAdd(newProject: Project) {
+        lastProjectGUID = newProject.guid
+        stringValue = newProject.name
+        layoutProject(with: newProject.name)
+        applyColor(with: newProject.colorHex)
         closeSuggestion()
     }
 

--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/ProjectCreation/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/ProjectCreation/ProjectCreationView.swift
@@ -12,7 +12,7 @@ import Carbon.HIToolbox
 protocol ProjectCreationViewDelegate: class {
 
     func projectCreationDidCancel()
-    func projectCreationDidAdd(with name: String, color: String, projectGUID: String)
+    func projectCreationDidAdd(newProject: Project)
     func projectCreationDidUpdateSize()
 }
 
@@ -142,11 +142,11 @@ final class ProjectCreationView: NSView {
         delegate?.projectCreationDidCancel()
     }
 
-    private func getSelectedClientData() -> (UInt64, String?) {
+    private func getSelectedClientData() -> (id: UInt64, guid: String?, name: String?) {
         if let selectedClient = ClientStorage.shared.client(with: clientAutoComplete.stringValue) {
-            return (selectedClient.ID, selectedClient.guid)
+            return (selectedClient.ID, selectedClient.guid, selectedClient.name)
         }
-        return (0, nil)
+        return (0, nil, nil)
     }
 
     @IBAction func addBtnOnTap(_ sender: Any) {
@@ -159,8 +159,8 @@ final class ProjectCreationView: NSView {
         // Safe for unwrapped
         let isBillable = timeEntryIsBillable
         let workspaceID = selectedWorkspace.ID
-        let clientID = clientData.0
-        let clientGUID = clientData.1
+        let clientID = clientData.id
+        let clientGUID = clientData.guid
         let projectName = projectTextField.stringValue
         let colorHex = selectedColor.hex
 
@@ -177,7 +177,14 @@ final class ProjectCreationView: NSView {
                                                                                    isBillable: isBillable)
         }
 
-        delegate?.projectCreationDidAdd(with: projectName, color: colorHex, projectGUID: projectGUID)
+        delegate?.projectCreationDidAdd(
+            newProject: Project(
+                guid: projectGUID,
+                name: projectName,
+                colorHex: colorHex,
+                clientName: clientData.name
+            )
+        )
     }
 
     @IBAction func publicProjectOnChange(_ sender: Any) {

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -652,18 +652,16 @@ extension TimerViewController: ProjectCreationViewDelegate {
         closeProjectAutoComplete()
     }
 
-    func projectCreationDidAdd(with name: String, color: String, projectGUID: String) {
+    func projectCreationDidAdd(newProject: Project) {
         switch descriptionFieldHandler.state {
         case .projectFilter:
             descriptionFieldHandler.didSelectProject()
             analyticsTrackShortcutCreated(.project)
-
         default:
             closeProjectAutoComplete()
         }
 
-        // TODO: set project on UI
-        // problem is we don't have library method to get project by GUID and pass it to view model
+        viewModel.didCreateNewProject(newProject)
     }
 
     func projectCreationDidUpdateSize() {

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -231,6 +231,21 @@ final class TimerViewModel: NSObject {
         actionsUsedBeforeStart.insert(TimerEditActionTypeProject)
     }
 
+    func didCreateNewProject(_ project: Project) {
+        if !isRunning {
+            // when TE is running, the project is set on Library level
+            clearProject()
+        }
+
+        timeEntry.projectGUID = project.guid
+        timeEntry.projectColor = project.colorHex
+        timeEntry.projectLabel = project.name
+        timeEntry.taskLabel = project.taskName
+        timeEntry.clientLabel = project.clientName
+
+        onProjectUpdated?(project)
+    }
+
     // MARK: - Private
 
     private func startTimeEntry() {
@@ -569,24 +584,6 @@ extension TimerViewModel: NSTableViewDelegate {
             return inputField.worksapceItemHeight
         default:
             return inputField.itemHeight
-        }
-    }
-}
-
-// MARK: - Project struct
-
-extension TimerViewModel {
-
-    struct Project {
-        let color: NSColor
-        let attributedTitle: NSAttributedString
-
-        init?(timeEntry: TimeEntryViewItem) {
-            guard timeEntry.projectLabel != nil, timeEntry.projectLabel.isEmpty == false else {
-                return nil
-            }
-            self.color = ConvertHexColor.hexCode(toNSColor: timeEntry.projectColor)
-            self.attributedTitle = ProjectTitleFactory().title(for: timeEntry)
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Models/Project.swift
+++ b/src/ui/osx/TogglDesktop/Models/Project.swift
@@ -1,0 +1,44 @@
+//
+//  Project.swift
+//  TogglDesktop
+//
+//  Created by Andrew Nester on 15.10.2020.
+//  Copyright © 2020 Toggl. All rights reserved.
+//
+
+import Foundation
+
+struct Project {
+    let guid: String?
+    let name: String
+    let colorHex: String
+    let taskName: String?
+    let clientName: String?
+
+    var color: NSColor {
+        ConvertHexColor.hexCode(toNSColor: colorHex)
+    }
+
+    var attributedTitle: NSAttributedString {
+        ProjectTitleFactory().title(withProject: name, task: taskName, client: clientName, projectColor: color)
+    }
+
+    init(guid: String? = nil, name: String, colorHex: String, taskName: String? = nil, clientName: String? = nil) {
+        self.guid = guid
+        self.name = name
+        self.colorHex = colorHex
+        self.taskName = taskName
+        self.clientName = clientName
+    }
+
+    init?(timeEntry: TimeEntryViewItem) {
+        guard timeEntry.projectLabel != nil, timeEntry.projectLabel.isEmpty == false else {
+            return nil
+        }
+        self.guid = timeEntry.guid
+        self.colorHex = timeEntry.projectColor
+        self.name = timeEntry.projectLabel
+        self.taskName = timeEntry.taskLabel
+        self.clientName = timeEntry.clientLabel
+    }
+}

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -618,6 +618,8 @@
 		C2A84AEA2524668900DAA468 /* Comparable+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A84AE82524668900DAA468 /* Comparable+Utils.swift */; };
 		C2A84B022524D0ED00DAA468 /* AutocompleteSourceViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A84B012524D0ED00DAA468 /* AutocompleteSourceViewType.swift */; };
 		C2A84B032524D0ED00DAA468 /* AutocompleteSourceViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A84B012524D0ED00DAA468 /* AutocompleteSourceViewType.swift */; };
+		C2C076D62538728E00C20527 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C076D52538728E00C20527 /* Project.swift */; };
+		C2C076D72538728E00C20527 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C076D52538728E00C20527 /* Project.swift */; };
 		C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */; };
 		C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DA1FBD17F1B08A001C4565 /* MainWindowController.m */; };
 		C5DA1FC017F1B08A001C4565 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5DA1FBE17F1B08A001C4565 /* MainWindowController.xib */; };
@@ -1099,6 +1101,7 @@
 		C238D7DE251B7215004EC739 /* TimerDescriptionFieldHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerDescriptionFieldHandler.swift; sourceTree = "<group>"; };
 		C2A84AE82524668900DAA468 /* Comparable+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+Utils.swift"; sourceTree = "<group>"; };
 		C2A84B012524D0ED00DAA468 /* AutocompleteSourceViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteSourceViewType.swift; sourceTree = "<group>"; };
+		C2C076D52538728E00C20527 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		C5CB7F0217F43EE100A2AEB1 /* TimeEntryCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeEntryCell.h; sourceTree = "<group>"; };
 		C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TimeEntryCell.m; sourceTree = "<group>"; usesTabs = 1; };
 		C5DA1FB817F19647001C4565 /* Kopsik.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = Kopsik.dylib; path = ../../../lib/osx/build/Kopsik.dylib; sourceTree = "<group>"; };
@@ -2138,6 +2141,7 @@
 			isa = PBXGroup;
 			children = (
 				BA01404922570893000E5B91 /* Tag.swift */,
+				C2C076D52538728E00C20527 /* Project.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3045,6 +3049,7 @@
 				BAF50DF821A2A18D0090BA95 /* AppIconFactory.m in Sources */,
 				74A7346A18297DD100525BBC /* ConvertHexColor.m in Sources */,
 				4988E66024CEC8460072C1B5 /* TimerViewController.swift in Sources */,
+				C2C076D62538728E00C20527 /* Project.swift in Sources */,
 				BA65A24D22B79FEC00F895FD /* OGSwitch.swift in Sources */,
 				BA4791F822F0478A00E24F79 /* NSView+Shadow+Border.swift in Sources */,
 				BA47DEB823969EAC005216AD /* InAppMessage.swift in Sources */,
@@ -3273,6 +3278,7 @@
 				BAE64DC82368334000244D2B /* ConvertHexColor.m in Sources */,
 				BAE64DC92368334000244D2B /* TimeEntryViewItem.m in Sources */,
 				4988E66124CEC8460072C1B5 /* TimerViewController.swift in Sources */,
+				C2C076D72538728E00C20527 /* Project.swift in Sources */,
 				BAE64DCA2368334000244D2B /* NoClientCellView.swift in Sources */,
 				BAE64DCB2368334000244D2B /* IdleNotificationWindowController.m in Sources */,
 				BAE64DCC2368334000244D2B /* Tag.swift in Sources */,


### PR DESCRIPTION
### 📒 Description
Currently, when no TE is running, after creating a new Project from Timer dropdown (or shortcut) project was created but not assigned to the Timer. So after clicking on Start the TE started without the project. 
This is not the case with the running TE - a new project is automatically set for the running TE.

This PR fixes this. Now it automatically fills in info from the project that was created from the Timer.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
Turns out this can be done without changing the library 😄 

### 👫 Relationships
Closes #4334

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Just test if project selection and creation is not broken.
