### PR TITLE
Remove BatchUpdate* methods (lib)

### DIFF
--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -88,45 +88,6 @@ bool BaseModel::userCannotAccessWorkspace(const error &err) const {
         kCannotAccessWorkspaceError));
 }
 
-std::string BaseModel::batchUpdateRelativeURL() const {
-    if (NeedsPOST()) {
-        return ModelURL();
-    }
-
-    std::stringstream url;
-    url << ModelURL() << "/" << ID();
-    return url.str();
-}
-
-std::string BaseModel::batchUpdateMethod() const {
-    if (NeedsDELETE()) {
-        return "DELETE";
-    }
-
-    if (NeedsPOST()) {
-        return "POST";
-    }
-
-    return "PUT";
-}
-
-// Convert model JSON into batch update format.
-error BaseModel::BatchUpdateJSON(Json::Value *result) const {
-    if (GUID().empty()) {
-        return error("Cannot export model to batch update without a GUID");
-    }
-
-    Json::Value body;
-    body[ModelName()] = SaveToJSON();
-
-    (*result)["method"] = batchUpdateMethod();
-    (*result)["relative_url"] = batchUpdateRelativeURL();
-    (*result)["guid"] = GUID();
-    (*result)["body"] = body;
-
-    return noError;
-}
-
 Logger BaseModel::logger() const {
     return { ModelName() };
 }

--- a/src/model/base_model.h
+++ b/src/model/base_model.h
@@ -115,17 +115,11 @@ class TOGGL_INTERNAL_EXPORT BaseModel {
 
     void Delete();
 
-    // Convert model JSON into batch update format.
-    error BatchUpdateJSON(Json::Value *result) const;
-
  protected:
     Logger logger() const;
 
     bool userCannotAccessWorkspace(const toggl::error &err) const;
 
- private:
-    std::string batchUpdateRelativeURL() const;
-    std::string batchUpdateMethod() const;
 };
 
 }  // namespace toggl

--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -1219,32 +1219,6 @@ error User::LoginToken(
     return noError;
 }
 
-error User::UpdateJSON(
-    std::vector<TimeEntry *> * const time_entries,
-    std::string *result) const {
-
-    poco_check_ptr(time_entries);
-
-    Json::Value c;
-
-    // Time entries go last
-    for (std::vector<TimeEntry *>::const_iterator it =
-        time_entries->begin();
-            it != time_entries->end(); ++it) {
-        Json::Value update;
-        error err = (*it)->BatchUpdateJSON(&update);
-        if (err != noError) {
-            return err;
-        }
-        c.append(update);
-    }
-
-    Json::StyledWriter writer;
-    *result = writer.write(c);
-
-    return noError;
-}
-
 std::string User::generateKey(const std::string &password) {
     Poco::SHA1Engine sha1;
     Poco::DigestOutputStream outstr(sha1);

--- a/src/model/user.h
+++ b/src/model/user.h
@@ -163,10 +163,6 @@ class TOGGL_INTERNAL_EXPORT User : public BaseModel {
     std::vector<const TimelineEvent *> CompressedTimelineForUI(const Poco::LocalDateTime *date) const;
     std::vector<const TimelineEvent *> CompressedTimelineForUpload(const Poco::LocalDateTime *date = nullptr) const;
 
-    error UpdateJSON(
-        std::vector<TimeEntry *> * const,
-        std::string *result) const;
-
     // excludeCollapseTimeEntries should be removed when getting rid of Context::pullUserPreferences
     bool LoadUserPreferencesFromJSON(
         const Json::Value &data,

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1684,41 +1684,6 @@ TEST(User, DurationFormat) {
     ASSERT_EQ("decimal", Formatter::DurationFormat);
 }
 
-TEST(BaseModel, BatchUpdateJSONWithoutGUID) {
-    TimeEntry t;
-    Json::Value v;
-    error err = t.BatchUpdateJSON(&v);
-    ASSERT_NE(noError, err);
-}
-
-TEST(BaseModel, BatchUpdateJSON) {
-    TimeEntry t;
-    t.EnsureGUID();
-    Json::Value v;
-    error err = t.BatchUpdateJSON(&v);
-    ASSERT_EQ(noError, err);
-}
-
-TEST(BaseModel, BatchUpdateJSONForDelete) {
-    TimeEntry t;
-    t.EnsureGUID();
-    t.SetID(123);
-    t.SetDeletedAt(time(0));
-    Json::Value v;
-    error err = t.BatchUpdateJSON(&v);
-    ASSERT_EQ(noError, err);
-}
-
-TEST(BaseModel, BatchUpdateJSONForPut) {
-    TimeEntry t;
-    t.EnsureGUID();
-    t.SetID(123);
-    t.SetDescription("test", false);
-    Json::Value v;
-    error err = t.BatchUpdateJSON(&v);
-    ASSERT_EQ(noError, err);
-}
-
 TEST(Proxy, IsConfigured) {
     Proxy p;
     ASSERT_FALSE(p.IsConfigured());


### PR DESCRIPTION
### 📒 Description
As mentioned in this PR and the original issue, there's not much else to it. The methods were not used anywhere except in tests so I'm just removing them.

### 🕶️ Types of changes
- ** Cleanup **

### 👫 Relationships
Closes #4543 

### 🔎 Review hints
Well, since the code was not used anywhere except in tests, there should be nothing to test. Maybe if we hit a compiler bug or somethiing.

