### PR TITLE
Small UI issues fixes

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
@@ -350,7 +350,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid>
+                    <Grid UseLayoutRounding="False">
                         <Rectangle Stroke="{DynamicResource Toggl.LightGrayBrush}"
                                    StrokeDashArray="1 1"
                                    StrokeThickness="2"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
@@ -397,4 +397,29 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style TargetType="ButtonBase" x:Key="Toggl.Timeline.InfoButton">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid x:Name="InfoIcon" Background="Transparent" VerticalAlignment="Center">
+                        <Path Data="{StaticResource Toggl.InfoIconGeometry}">
+                            <Path.Style>
+                                <Style TargetType="Path">
+                                    <Setter Property="Fill" Value="#B1B1B5"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ElementName=InfoButton, Path=IsMouseOver}" Value="True">
+                                            <Setter Property="Fill" Value="{DynamicResource Toggl.DarkGrayBrush}"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding ElementName=InfoButton, Path=IsChecked}" Value="True">
+                                            <Setter Property="Fill" Value="{DynamicResource Toggl.DarkGrayBrush}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Path.Style>
+                        </Path>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/Buttons.xaml
@@ -359,7 +359,7 @@
                                    RadiusY="7">
                         </Rectangle>
                         <Viewbox Stretch="None">
-                            <Path Opacity="0.348" Fill="{DynamicResource Toggl.DarkGrayBrush}" Data="M9.437 4.844v1.312h-3.28v3.281H4.843V6.156H1.562V4.844h3.282V1.561h1.312v3.281h3.281z"/>
+                            <Path Opacity="0.348" Fill="{DynamicResource Toggl.DarkGrayBrush}" Data="M 0 5h4.25v4.25h1.5v-4.25h4.25v-1.5h-4.25v-4.25h-1.5v4.25h-4.25Z"/>
                         </Viewbox>
                     </Grid>
                 </ControlTemplate>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -138,7 +138,7 @@ namespace TogglDesktop.ViewModels
                     {
                         var activity = new ActivityDescription()
                         {
-                            ActivityTitle = eventDesc.Header ? Path.GetFileName(eventDesc.Filename) : eventDesc.Title
+                            ActivityTitle = eventDesc.DurationString + " " + (eventDesc.Header ? Path.GetFileName(eventDesc.Filename) : eventDesc.Title)
                         };
                         activity.SubActivities = eventDesc.Header
                             ? eventDesc.SubEvents.Select(e => e.DurationString + " " + e.Title).ToList()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryBlock.xaml
@@ -16,7 +16,7 @@
             <sys:Double x:Key="DescriptionOpacity">0.2</sys:Double>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Button FontWeight="Normal" Command="{Binding OpenEditView}" MinHeight="2" Margin="0 0 4 0">
+    <Button FontWeight="Normal" Command="{Binding OpenEditView}" MinHeight="2" Margin="0 0 4 0" Height="{Binding Height}">
         <Button.Template>
             <ControlTemplate>
                 <Grid>
@@ -26,7 +26,7 @@
                     </Grid.ColumnDefinitions>
                     <Border Grid.Column="1" CornerRadius="8,8,8,8" Background="{DynamicResource Toggl.Background}" Margin="-10 0 0 0"/>
                     <Rectangle Grid.Column="0" Name ="TimeEntrySpan"
-                               Width="20" Height="{Binding Height}"
+                               Width="20"
                                Fill="{Binding Color, Converter={StaticResource AdaptProjectColorConverter}}"
                                RadiusX="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusX'}"
                                RadiusY="{Binding Height, Converter={StaticResource HeightToRadiusConverter}, ConverterParameter='RadiusY'}">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -101,7 +101,7 @@
             <ScrollViewer Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
                           VerticalScrollBarVisibility="Auto"
                           HorizontalAlignment="Stretch"
-                          Margin="0 0"
+                          Margin="0 0 6 0"
                           Focusable="False"
                           IsTabStop="False"
                           UseLayoutRounding="True"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -42,7 +42,8 @@
                       Margin="5 0 0 2">
                     <ToggleButton Name="InfoButton"
                                   Style="{StaticResource Toggl.Timeline.InfoButton}"/>
-                    <Popup IsOpen="{Binding ElementName=InfoButton, Path=IsChecked}" Name="RecordActivityInfoPopup" StaysOpen="True" UseLayoutRounding="True"
+                    <Popup IsOpen="{Binding ElementName=InfoButton, Path=IsChecked}" Name="RecordActivityInfoPopup" UseLayoutRounding="True"
+                           StaysOpen="{Binding ElementName=InfoButton, Path=IsMouseOver}"
                            PlacementTarget="{Binding ElementName=InfoButton}" AllowsTransparency="True">
                         <Border BorderThickness="1" Background="{DynamicResource Toggl.CardBackground}"
                                 BorderBrush="{DynamicResource Toggl.Background}">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -360,18 +360,18 @@
                     </Popup>
                 </Grid>
             </ScrollViewer>
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="No entries here... Go ahead and track some time!" Width="125" HorizontalAlignment="Center"
+                       VerticalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"
+                       Visibility="{Binding TimeEntryBlocks, Converter={StaticResource EmptyListToVisibleConverter}}"
+                       MouseWheel="HandleScrollViewerMouseWheel"/>
+            <TextBlock Grid.Row="3" Grid.Column="2" Text="No activity was recorded yet..." HorizontalAlignment="Center"
+                       VerticalAlignment="Center" TextAlignment="Center" 
+                       Visibility="{Binding ActivityBlocks, Converter={StaticResource EmptyListToVisibleConverter}}"
+                       MouseWheel="HandleScrollViewerMouseWheel">
+                <TextBlock.LayoutTransform>
+                    <RotateTransform Angle="90"/>
+                </TextBlock.LayoutTransform>
+            </TextBlock>
         </Grid>
-        <TextBlock Text="No entries here... Go ahead and track some time!" Width="125" HorizontalAlignment="Center"
-                   VerticalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center" Margin="0 100 0 0"
-                   Visibility="{Binding TimeEntryBlocks, Converter={StaticResource EmptyListToVisibleConverter}}"
-                   MouseWheel="HandleScrollViewerMouseWheel"/>
-        <TextBlock Text="No activity was recorded yet..." HorizontalAlignment="Right"
-                   VerticalAlignment="Center" TextAlignment="Center" Margin="0 100 10 0"
-                   Visibility="{Binding ActivityBlocks, Converter={StaticResource EmptyListToVisibleConverter}}"
-                   MouseWheel="HandleScrollViewerMouseWheel">
-            <TextBlock.LayoutTransform>
-                <RotateTransform Angle="90"/>
-            </TextBlock.LayoutTransform>
-        </TextBlock>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -37,15 +37,13 @@
                       IsChecked="{Binding RecordActivity}">
                     Record activity
                 </mah:ToggleSwitch>
-                <Grid Width="16" Height="16"
-                      VerticalAlignment="Center"
+                <Grid VerticalAlignment="Bottom"
                       HorizontalAlignment="Left"
-                      Margin="5 12 0 0">
-                    <Canvas MouseEnter="RecordActivityInfoBoxOnMouseEnter" x:Name="InfoIcon">
-                        <Path Fill="#B1B1B5" Data="{StaticResource Toggl.InfoIconGeometry}"/>
-                    </Canvas>
-                    <Popup IsOpen="False" Name="RecordActivityInfoPopup" StaysOpen="False" UseLayoutRounding="True"
-                           PlacementTarget="{Binding ElementName=InfoIcon}" AllowsTransparency="True">
+                      Margin="5 0 0 2">
+                    <ToggleButton Name="InfoButton"
+                                  Style="{StaticResource Toggl.Timeline.InfoButton}"/>
+                    <Popup IsOpen="{Binding ElementName=InfoButton, Path=IsChecked}" Name="RecordActivityInfoPopup" StaysOpen="True" UseLayoutRounding="True"
+                           PlacementTarget="{Binding ElementName=InfoButton}" AllowsTransparency="True">
                         <Border BorderThickness="1" Background="{DynamicResource Toggl.CardBackground}"
                                 BorderBrush="{DynamicResource Toggl.Background}">
                             <StackPanel MaxWidth="250" Margin="10 10 10 10">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -61,11 +61,6 @@ namespace TogglDesktop
             MainViewScroll.ScrollToVerticalOffset(offset);
         }
 
-        private void RecordActivityInfoBoxOnMouseEnter(object sender, MouseEventArgs e)
-        {
-            RecordActivityInfoPopup.IsOpen = true;
-        }
-
         private void HandleScrollViewerMouseWheel(object sender, MouseWheelEventArgs e)
         {
             MainViewScroll.ScrollToVerticalOffset(MainViewScroll.VerticalOffset - e.Delta);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -105,5 +105,6 @@ namespace TogglDesktop
                 TimeEntryPopup.IsOpen = false;
             }
         }
+
     }
 }


### PR DESCRIPTION
### 📒 Description

- Activity block tooltip - add total time near each app name.
- Make TEs which don't overlap, but start of the later is just the same as end of the earlier look non-overlapped.
- Move scroll bar to the left a bit like in List view.
- Center `+` sign in gap buttons.
- Center captions for empty TEs and Activity blocks.
- Open/close Info popup on button click.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
- **Breaking change** (fix or feature that would cause existing functionality to change) 

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4529 

### 🔎 Review hints
Popup is no loner closed when clicking somewhere outside (it closes only on Info button second click). Do we still need this functionality?
