### PR TITLE
Fix bug with project creation popup closing when creating client (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -512,7 +512,8 @@ class TimerViewController: NSViewController {
             object: projectAutoCompleteWindow,
             queue: .main
         ) { [unowned self] _ in
-            if self.projectAutoCompleteWindow.isVisible {
+            let hasChildWindows = self.projectAutoCompleteWindow.childWindows?.isEmpty == false
+            if self.projectAutoCompleteWindow.isVisible && !hasChildWindows {
                 self.projectAutocompleteResignTime = Date().timeIntervalSince1970
                 self.closeProjectAutoComplete()
             }


### PR DESCRIPTION
### 📒 Description
Currently, when creating a client after using the project timer shortcut (or dropdown) the project creation popup
is closing automatically but should not.
This happens because we're closing the project window when it loses focus. And because Client creation is a different window, moving focus to the "Create" button results in a closed project window.
This PR adds an additional check - we don't close the window if it has child windows.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4546

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
