### PR TITLE
Speed up loading time entry list

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/ViewModelExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/ViewModelExtensions.cs
@@ -55,5 +55,30 @@ namespace TogglDesktop.ViewModels
                 item.Billable,
                 false);
         }
+
+        public static bool IsEqualTo(
+            this TimeEntryLabelViewModel timeEntryLabelViewModel,
+            Toggl.TogglTimeEntryView item)
+        {
+            if (timeEntryLabelViewModel == null) return false;
+            return timeEntryLabelViewModel.Description == item.Description
+                   && timeEntryLabelViewModel.Tags == item.Tags
+                   && timeEntryLabelViewModel.IsBillable == item.Billable
+                   && timeEntryLabelViewModel.ProjectLabel.IsEqualTo(item);
+        }
+
+        public static bool IsEqualTo(
+            this ProjectLabelViewModel projectLabelViewModel,
+            Toggl.TogglTimeEntryView item)
+        {
+            if (projectLabelViewModel == null) return false;
+            return projectLabelViewModel.ProjectName == item.ProjectLabel
+                   && projectLabelViewModel.TaskName == item.TaskLabel
+                   && projectLabelViewModel.ClientName == item.ClientLabel
+                   && projectLabelViewModel.ColorString == item.Color
+                   && projectLabelViewModel.WorkspaceName == item.WorkspaceName
+                   && projectLabelViewModel.ProjectInfo.ProjectId == item.PID
+                   && projectLabelViewModel.ProjectInfo.TaskId == item.TID;
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
@@ -50,13 +50,21 @@ namespace TogglDesktop
 
             ViewModel.IsSubItem = !item.Group && item.GroupOpen;
             ViewModel.DurationInSeconds = item.DurationInSeconds;
-            ViewModel.TimeEntryLabel = item.ToTimeEntryLabelViewModel();
+            ResetTimeEntryLabelIfChanged(item);
 
             this.durationLabel.Text = item.Duration;
             this.durationPanel.ToolTip = $"{item.StartTimeString} - {item.EndTimeString}";
 
             this.unsyncedIcon.ShowOnlyIf(item.Unsynced);
             this.lockedIcon.ShowOnlyIf(item.Locked);
+        }
+
+        private void ResetTimeEntryLabelIfChanged(Toggl.TogglTimeEntryView item)
+        {
+            if (!ViewModel.TimeEntryLabel.IsEqualTo(item))
+            {
+                ViewModel.TimeEntryLabel = item.ToTimeEntryLabelViewModel();
+            }
         }
 
         #region open edit window event handlers


### PR DESCRIPTION
### 📒 Description
Speed up loading time entry list by avoiding recreating and reassigning a time entry label view model if the time entry hasn't changed.

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] compare an already loaded time entry label view model with the incoming time entry model
- [x] do not recreate a time entry label view model if it's already the same as the time entry model

### 👫 Relationships
Closes #4550.

### 🔎 Review hints
- Log in to an account with or create 200+ TEs
- Try opening/closing Edit view and expanding/collapsing TEs on `master` and on the current branch.
- Check if the performance improvements are tangible
- In Performance.cs line 12 set `debug` to `true`
- Try opening/closing Edit view and expanding/collapsing TEs on `master` and on the current branch.
- Look at the performance measurements in the logs


### Performance Measurements
Method: `OnTimeEntryList`
Input Data: 259 TEs, about 10% of which are grouped into 2-3 TEs.
Actions: Opening/Closing Edit view, Expanding/Collapsing grouped TEs
Before: 324ms - 545ms
After: 59ms - 110ms
