### PR TITLE
Fix bug when autocomplete mouse selection wasn't working on macOS

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Storage/TagStorage.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/Storage/TagStorage.swift
@@ -19,7 +19,6 @@ extension Notification.Name {
     // MARK: Variables
 
     private(set) var tags: [Tag] = []
-    private var newTags: [Tag] = []
 
     // MARK: Public
 
@@ -42,7 +41,6 @@ extension Notification.Name {
     }
 
     func addNewTag(_ tag: Tag) {
-        newTags.append(tag)
         tags.append(tag)
     }
 }
@@ -50,21 +48,6 @@ extension Notification.Name {
 extension TagStorage {
 
     fileprivate func build(from viewItems: [ViewItem], complete: @escaping ([Tag]) -> Void) {
-        DispatchQueue.global(qos: .background).async {[weak self] in
-            guard let strongSelf = self else { return }
-            var tags = viewItems.map { Tag(viewItem: $0) }
-
-            // We have to add new tags manually
-            // It's a bug in Library
-            // There is no new tags, even if synced properly, until we open the TimeEntryEditor again
-            strongSelf.newTags.forEach { tag in
-                if !tags.contains(where: { $0.name == tag.name }) {
-                    tags.append(tag)
-                }
-            }
-            DispatchQueue.main.async {
-                complete(tags)
-            }
-        }
+        complete(viewItems.map { Tag(viewItem: $0) })
     }
 }

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/LiteAutoCompleteDataSource.m
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/LiteAutoCompleteDataSource.m
@@ -347,17 +347,13 @@ extern void *ctx;
 
 - (void)setFilter:(NSString *)filter
 {
-    if ([filter isEqualToString:self.currentFilter]) {
-        return;
-    }
-
-    self.textLength = 0;
-    bool lastFilterWasNonEmpty = ((filter == nil || filter.length == 0) && (self.currentFilter != nil && self.currentFilter.length > 0));
-
+    NSString *oldFilter = self.currentFilter;
     self.currentFilter = filter;
+
     if (filter == nil || filter.length == 0)
     {
         self.filteredOrderedKeys = [NSMutableArray arrayWithArray:self.orderedKeys];
+        bool lastFilterWasNonEmpty = self.currentFilter != nil && self.currentFilter.length > 0;
         if (lastFilterWasNonEmpty)
         {
             [self reload];
@@ -368,8 +364,15 @@ extern void *ctx;
             CGFloat totalHeight = [self.input calculateTotalHeightFromArray:self.filteredOrderedKeys];
             [self.input updateDropdownWithHeight:totalHeight];
         }
+
         return;
     }
+
+    if ([self.currentFilter isEqualToString:oldFilter]) {
+        return;
+    }
+
+    self.textLength = 0;
     NSString *trimmedFilter = [filter stringByTrimmingCharactersInSet:
                                [NSCharacterSet whitespaceAndNewlineCharacterSet]];
     [self findFilter:trimmedFilter];

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
@@ -122,8 +122,10 @@ class TimerDescriptionFieldHandler: NSResponder {
             self?.controlListVisibilityDidChange()
         }
 
-        kvoSelectedRangeToken = textField.observe(\.selectedRange) { [weak self] _, _ in
-            self?.controlTextCursorDidChange()
+        kvoSelectedRangeToken = textField.observe(\.selectedRange, options: [.new, .old]) { [weak self] _, change in
+            if change.newValue != change.oldValue {
+                self?.controlTextCursorDidChange()
+            }
         }
     }
 
@@ -196,7 +198,12 @@ extension TimerDescriptionFieldHandler: NSTextFieldDelegate {
 
     private func autocompleteControl(doCommandBy commandSelector: Selector) -> Bool {
         if commandSelector == #selector(moveDown(_:)) {
-            return onPerformAction(.autoCompleteTableSelectNext)
+            if textField.isListHidden {
+                textField.toggleList(true)
+                return true
+            } else {
+                return onPerformAction(.autoCompleteTableSelectNext)
+            }
 
         } else if commandSelector == #selector(moveUp(_:)) {
             return onPerformAction(.autoCompleteTableSelectPrevious)

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -97,13 +97,12 @@ class TimerViewController: NSViewController {
 
         viewModel.projectDataSource.setup(with: projectAutoCompleteView)
         viewModel.tagsDataSource.setup(with: tagsAutoCompleteView)
-
-        viewModel.prepareData()
     }
 
     override func viewDidAppear() {
         super.viewDidAppear()
 
+        viewModel.prepareData()
         configureHideAutoCompleteWhenLostFocus()
     }
 

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -342,7 +342,7 @@ class TimerViewController: NSViewController {
     private func resetFromDescriptionFieldState(_ state: TimerDescriptionFieldHandler.State) {
         switch state {
         case .autocompleteFilter:
-            descriptionTextField.resetTable()
+            descriptionTextField.toggleList(false)
         case .projectFilter:
             closeProjectAutoComplete()
         case .tagsFilter:

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -89,10 +89,6 @@ class TimerViewController: NSViewController {
         viewModel.isEditingDuration = { [weak self] in
             return self?.durationTextField.currentEditor() != nil
         }
-    }
-
-    override func viewDidAppear() {
-        super.viewDidAppear()
 
         // !!!: we're passing views into view model - refactor this someday
         // this is needed because current Autocomplete functionality
@@ -103,6 +99,10 @@ class TimerViewController: NSViewController {
         viewModel.tagsDataSource.setup(with: tagsAutoCompleteView)
 
         viewModel.prepareData()
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
 
         configureHideAutoCompleteWhenLostFocus()
     }

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -366,7 +366,7 @@ final class TimerViewModel: NSObject {
 
         } else if entry.isRunning() {
             let isDescriptionEditing = isEditingDescription?() ?? true
-            if entryDescription.isEmpty || !isDescriptionEditing {
+            if !isDescriptionEditing {
                 entryDescription = entry.entryDescription ?? ""
             }
 

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -362,6 +362,7 @@ final class TimerViewModel: NSObject {
         if isNewEntry {
             entryDescription = entry.entryDescription ?? ""
             durationString = entry.duration ?? ""
+            onDescriptionFocusChanged?(false)
 
         } else if entry.isRunning() {
             let isDescriptionEditing = isEditingDescription?() ?? true

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -414,6 +414,7 @@ final class TimerViewModel: NSObject {
         entryDescription = ""
         durationString = ""
         selectedTags = []
+        fetchTags()
         updateBillableStatus()
         focusTimer()
         actionsUsedBeforeStart = Set()

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -539,7 +539,7 @@ extension TimerViewModel: NSTableViewDelegate {
     }
 
     func tableViewSelectionDidChange(_ notification: Notification) {
-        guard let row = descriptionDataSource.input?.autocompleteTableView.selectedRow, row >= 0 else {
+        guard let row = descriptionDataSource.input?.autocompleteTableView.lastClicked, row >= 0 else {
             return
         }
 


### PR DESCRIPTION
### 📒 Description
Fixes the bug when user could not select item from the description autocomplete with a mouse.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4548 

### 🔎 Review hints
Test autocomplete in different use cases. This PR can break stuff
