### PR TITLE
Handle beginning of week in the preferences dialog (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -38,8 +38,23 @@ PreferencesDialog::~PreferencesDialog() {
     delete ui;
 }
 
+void PreferencesDialog::setBeginningOfWeek(uint8_t day) {
+    if (day == beginningOfWeek)
+        return;
+    QVector<bool> stored;
+    for (int i = 0; i < 7; i++)
+        stored.append(checkBoxForDay(i)->isChecked());
+    beginningOfWeek = day;
+    for (int i = 0; i < 7; i++)
+        checkBoxForDay(i)->setChecked(stored[i]);
+    updateCheckboxLabels();
+}
+
 void PreferencesDialog::displaySettings(const bool open,
                                         SettingsView *settings) {
+
+    setBeginningOfWeek(TogglApi::instance->getUserBeginningOfWeek());
+
     if (open) {
         bool wasVisible = isVisible();
         show();
@@ -88,13 +103,13 @@ void PreferencesDialog::displaySettings(const bool open,
 
     ui->focusAppOnShortcut->setChecked((settings->FocusOnShortcut));
 
-    ui->dayCheckbox_1->setChecked(settings->RemindOnMonday);
-    ui->dayCheckbox_2->setChecked(settings->RemindOnTuesday);
-    ui->dayCheckbox_3->setChecked(settings->RemindOnWednesday);
-    ui->dayCheckbox_4->setChecked(settings->RemindOnThursday);
-    ui->dayCheckbox_5->setChecked(settings->RemindOnFriday);
-    ui->dayCheckbox_6->setChecked(settings->RemindOnSaturday);
-    ui->dayCheckbox_7->setChecked(settings->RemindOnSunday);
+    checkBoxForDay(1)->setChecked(settings->RemindOnMonday);
+    checkBoxForDay(2)->setChecked(settings->RemindOnTuesday);
+    checkBoxForDay(3)->setChecked(settings->RemindOnWednesday);
+    checkBoxForDay(4)->setChecked(settings->RemindOnThursday);
+    checkBoxForDay(5)->setChecked(settings->RemindOnFriday);
+    checkBoxForDay(6)->setChecked(settings->RemindOnSaturday);
+    checkBoxForDay(0)->setChecked(settings->RemindOnSunday);
 
     ui->reminderStartTimeEdit->setTime(settings->RemindStartTime);
     ui->reminderEndTimeEdit->setTime(settings->RemindEndTime);
@@ -124,13 +139,13 @@ void PreferencesDialog::displayLogin(const bool open,
 void PreferencesDialog::onDayCheckboxClicked(bool checked) {
     Q_UNUSED(checked);
     TogglApi::instance->setSettingsRemindDays(
-        ui->dayCheckbox_1->isChecked(),
-        ui->dayCheckbox_2->isChecked(),
-        ui->dayCheckbox_3->isChecked(),
-        ui->dayCheckbox_4->isChecked(),
-        ui->dayCheckbox_5->isChecked(),
-        ui->dayCheckbox_6->isChecked(),
-        ui->dayCheckbox_7->isChecked()
+        checkBoxForDay(1)->isChecked(),
+        checkBoxForDay(2)->isChecked(),
+        checkBoxForDay(3)->isChecked(),
+        checkBoxForDay(4)->isChecked(),
+        checkBoxForDay(5)->isChecked(),
+        checkBoxForDay(6)->isChecked(),
+        checkBoxForDay(0)->isChecked()
     );
 }
 
@@ -184,6 +199,13 @@ void PreferencesDialog::updateContinueStopShortcut() {
         text = "Record shortcut";
     }
     ui->continueStopButton->setText(text);
+}
+
+void PreferencesDialog::updateCheckboxLabels() {
+    static const QVector<QString> days { "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
+    for (int i = 0; i < 7; i++) {
+        checkBoxForDay(i)->setText(days[i]);
+    }
 }
 
 void PreferencesDialog::on_showHideClear_clicked() {
@@ -301,7 +323,22 @@ bool PreferencesDialog::setProxySettings() {
             ui->proxyHost->text(),
             ui->proxyPort->text().toULongLong(),
             ui->proxyUsername->text(),
-            ui->proxyPassword->text());
+                                                ui->proxyPassword->text());
+}
+
+QCheckBox *PreferencesDialog::checkBoxForDay(uint8_t day) {
+    int actualDay = day - beginningOfWeek;
+    actualDay = actualDay < 0 ? 7 + actualDay : actualDay;
+    switch (actualDay) {
+    case 0: return ui->dayCheckbox_1;
+    case 1: return ui->dayCheckbox_2;
+    case 2: return ui->dayCheckbox_3;
+    case 3: return ui->dayCheckbox_4;
+    case 4: return ui->dayCheckbox_5;
+    case 5: return ui->dayCheckbox_6;
+    case 6: return ui->dayCheckbox_7;
+    default: return nullptr;
+    }
 }
 
 void PreferencesDialog::on_useProxy_clicked(bool checked) {

--- a/src/ui/linux/TogglDesktop/preferencesdialog.h
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.h
@@ -5,6 +5,7 @@
 
 #include <QDialog>
 #include <QKeyEvent>
+#include <QCheckBox>
 #include "./settingsview.h"
 
 namespace Ui {
@@ -22,6 +23,10 @@ class PreferencesDialog : public QDialog {
     Ui::PreferencesDialog *ui;
     int keyId;
     QString keySequence;
+    uint8_t beginningOfWeek { 0 };
+
+    QCheckBox *checkBoxForDay(uint8_t day);
+    void setBeginningOfWeek(uint8_t day);
 
     bool setSettings();
     bool setProxySettings();
@@ -65,6 +70,7 @@ class PreferencesDialog : public QDialog {
 
     void updateShowHideShortcut();
     void updateContinueStopShortcut();
+    void updateCheckboxLabels();
 };
 
 #endif  // SRC_UI_LINUX_TOGGLDESKTOP_PREFERENCESDIALOG_H_

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -812,3 +812,7 @@ void TogglApi::setWindowsFrameSetting(const QRect frame) {
                               frame.height(),
                               frame.width());
 }
+
+uint8_t TogglApi::getUserBeginningOfWeek() {
+    return toggl_get_user_beginning_of_week(ctx);
+}

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -254,6 +254,8 @@ class TogglApi : public QObject {
     QRect const getWindowsFrameSetting();
     void setWindowsFrameSetting(const QRect frame);
 
+    uint8_t getUserBeginningOfWeek();
+
  signals:
     void displayApp(
         const bool open);


### PR DESCRIPTION
### 📒 Description
A PR adding the beginning of week functionality to the Linux app

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- User-set first day of week (from the web app) is now respected

### 👫 Relationships
Closes #3993

### 🔎 Review hints
The first day of week from the web app should be respected and the DB-stored reminder days should actually be the same as what's seen in the UI. Of course, reminders should also happen on the days that have been set in the UI.

