### PR TITLE
Improve mouse selection on autocomplete list (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteInput.m
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteInput.m
@@ -88,6 +88,7 @@ static CGFloat dropdownHorizontalPadding = 11;
 							  forIdentifier :@"AutoCompleteTableCell"];
 
 	[self.autocompleteTableView setDelegate:self];
+	[self.autocompleteTableView setRefusesFirstResponder:YES];
 
 	[self.autocompleteTableContainer setDocumentView:self.autocompleteTableView];
 	[self.autocompleteTableContainer setAutohidesScrollers:YES];

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteTable.h
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteTable.h
@@ -12,7 +12,6 @@
 
 @interface AutoCompleteTable : NSTableView
 @property (nonatomic, assign, readonly) NSInteger lastSelected;
-@property (nonatomic, assign, readonly) NSInteger lastClicked;
 @property (nonatomic, assign) NSInteger lastSavedSelected;
 
 - (void)nextItem;

--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteTable.m
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/LegacyAutoComplete/AutoCompleteTable.m
@@ -11,7 +11,6 @@
 
 @interface AutoCompleteTable ()
 @property (nonatomic, assign) NSInteger lastSelected;
-@property (nonatomic, assign) NSInteger lastClicked;
 @end
 
 @implementation AutoCompleteTable
@@ -30,15 +29,6 @@
 		[self setIntercellSpacing:NSMakeSize(0, 0)];
 	}
 	return self;
-}
-
-- (void)mouseDown:(NSEvent *)theEvent
-{
-	NSPoint globalLocation = [theEvent locationInWindow];
-	NSPoint localLocation = [self convertPoint:globalLocation fromView:nil];
-
-	self.lastClicked = [self rowAtPoint:localLocation];
-	[super mouseDown:theEvent];
 }
 
 - (void)drawGridInClipRect:(NSRect)clipRect

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -541,7 +541,7 @@ extension TimerViewModel: NSTableViewDelegate {
     }
 
     func tableViewSelectionDidChange(_ notification: Notification) {
-        guard let row = descriptionDataSource.input?.autocompleteTableView.lastClicked, row >= 0 else {
+        guard let row = descriptionDataSource.input?.autocompleteTableView.lastSelected, row >= 0 else {
             return
         }
 


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
**Fixed issues:**
- sometimes item from the list was not selected after mouse click because of a race condition
- blue selection background was not visible to the user when selecting with a mouse - dropdown was closing too quickly

**Root cause:**
Before this change, `AutoCompleteTableView` could become a first responder. This resulted in a situation when `TimerDescriptionFieldHandler` was closing autocomplete because the text field was losing focus. Sometimes the list was closed quicker than it could process the selection event.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4559

### 🔎 Review hints
