### PR TITLE
Fix ambiguous layout on Timeline for small time entries

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryPlaceholderCell.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Views/TimelineTimeEntryPlaceholderCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -37,7 +37,7 @@
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="k5r-l6-xWv" userLabel="Placeholder text">
                                     <rect key="frame" x="-2" y="0.0" width="89" height="15"/>
                                     <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" title="No Description" id="UTS-5M-sr1">
-                                        <font key="font" metaFont="label" size="12"/>
+                                        <font key="font" metaFont="cellTitle"/>
                                         <color key="textColor" name="black-text-color"/>
                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -52,7 +52,7 @@
                         </stackView>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="sgG-mk-OCF" secondAttribute="trailing" id="1eU-b1-bRH"/>
+                        <constraint firstAttribute="trailing" secondItem="sgG-mk-OCF" secondAttribute="trailing" priority="750" id="1eU-b1-bRH"/>
                         <constraint firstItem="sgG-mk-OCF" firstAttribute="top" secondItem="U1Q-Ej-cVI" secondAttribute="top" constant="4" id="Loe-wm-cVI"/>
                         <constraint firstItem="sgG-mk-OCF" firstAttribute="leading" secondItem="U1Q-Ej-cVI" secondAttribute="leading" constant="30" id="w9I-VI-Rps"/>
                     </constraints>


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Fixes ambiguous layout when creating small time entry that overlaps with another TE. See detailed STR in related issue.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4520

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Test if Timeline layout is not broken.
