### PR TITLE
Fix Timeline breaking after drag-creating TE with open Edit (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/TimelineDashboardViewController.swift
@@ -79,7 +79,7 @@ final class TimelineDashboardViewController: NSViewController {
     }()
     private lazy var editorPopover: EditorPopover = {
         let popover = EditorPopover()
-        popover.animates = true
+        popover.animates = false
         popover.prepareViewController()
         popover.delegate = self
         return popover


### PR DESCRIPTION
### 📒 Description
Fixes the issue when Timeline becomes empty after specific steps that are described in the related issue.

The bug became possible after we made Edit popover animated. So it basically closes after some delay, during the drag-to-create event. 

Narrowed down the fix to this small one line removal. Not sure why this line even was there. If you have any thoughts about this, please tell me. It calls `app(context)->OpenTimeEntryList();` that results in a chain of other calls. It seems like it reloads all time entries and because this happens during drag-to-create event the Timeline breaks. 

Another possible fix would be to make Edit popover not animated again. But this solution has two problems:
- When Edit popover is opened and the user clicks on Timeline, app will close popover but also will create TE with default duration.
- It seems like it'll just hides the real issue till it'll occur again next time.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4570

### 🔎 Review hints
Please test if Timeline functions well. Especially unique use cases (if you know any).
