### PR TITLE
Use SHA-256 for signing Windows binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -439,18 +439,18 @@ jobs:
     - name: Create x86 installer
       run: |
         cd dist/windows
-        makensis /DCERT_PASSWORD=${{ secrets.CERT_WINDOWS_PASSWORD }} TogglDesktopInstaller-x86.nsi
-    - name: Upload artifacts to GitHub
-      if: github.event_name != 'release'
-      uses: actions/upload-artifact@v2
-      with:
-        name: TogglDesktopInstaller-x86.exe
-        path: dist\windows\TogglDesktopInstaller.exe    
+        makensis /DCERT_PASSWORD=${{ secrets.CERT_WINDOWS_PASSWORD }} TogglDesktopInstaller-x86.nsi  
     - name: Sign the installer
       if: github.event_name == 'release'
       shell: cmd
       run: |
         "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller.exe
+    - name: Upload artifacts to GitHub
+      if: github.event_name != 'release'
+      uses: actions/upload-artifact@v2
+      with:
+        name: TogglDesktopInstaller-x86.exe
+        path: dist\windows\TogglDesktopInstaller.exe
     - name: Upload to GitHub
       if: github.event_name == 'release'
       run: |
@@ -507,17 +507,17 @@ jobs:
       run: |
         cd dist/windows
         makensis /DCERT_PASSWORD=${{ secrets.CERT_WINDOWS_PASSWORD }} TogglDesktopInstaller-x64.nsi
+    - name: Sign the installer
+      if: github.event_name == 'release'
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller-x64.exe
     - name: Upload artifacts to GitHub
       if: github.event_name != 'release'
       uses: actions/upload-artifact@v2
       with:
         name: TogglDesktopInstaller-x64.exe
         path: dist\windows\TogglDesktopInstaller-x64.exe
-    - name: Sign the installer
-      if: github.event_name == 'release'
-      shell: cmd
-      run: |
-        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller-x64.exe
     - name: Upload to GitHub
       if: github.event_name == 'release'
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -444,7 +444,7 @@ jobs:
       if: github.event_name == 'release'
       shell: cmd
       run: |
-        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller.exe
+        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller.exe
     - name: Upload artifacts to GitHub
       if: github.event_name != 'release'
       uses: actions/upload-artifact@v2
@@ -511,7 +511,7 @@ jobs:
       if: github.event_name == 'release'
       shell: cmd
       run: |
-        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller-x64.exe
+        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller-x64.exe
     - name: Upload artifacts to GitHub
       if: github.event_name != 'release'
       uses: actions/upload-artifact@v2

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -23,7 +23,7 @@
   ; That will have written an uninstaller binary for us.  Now we sign it with your
   ; favorite code signing tool.
  
-  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -a -t "http://timestamp.verisign.com/scripts/timestamp.dll" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
+  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t "http://timestamp.verisign.com/scripts/timestamp.dll" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
  
   ; Good.  Now we can carry on writing the real installer.
  

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -23,7 +23,7 @@
   ; That will have written an uninstaller binary for us.  Now we sign it with your
   ; favorite code signing tool.
  
-  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -a -t "http://timestamp.verisign.com/scripts/timestamp.dll" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
+  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t "http://timestamp.verisign.com/scripts/timestamp.dll" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
  
   ; Good.  Now we can carry on writing the real installer.
  

--- a/dist/windows/scripts/sign.sh
+++ b/dist/windows/scripts/sign.sh
@@ -23,6 +23,6 @@ arguments=$(sed 's/\</\*./g' <<< $EXTENSIONS | sed 's/\s/ -or -name /g' | sed 's
 
 for i in $(find $PATHS $arguments 2>/dev/null); do
     echo "Signing $i"
-    "$SIGNTOOL" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f "Certificate.pfx" -p $cert_password $i
+    "$SIGNTOOL" sign -fd SHA256 -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f "Certificate.pfx" -p $cert_password $i
 done
 


### PR DESCRIPTION
### 📒 Description
Use SHA-256 for signing Windows binaries and installers.

### 🕶️ Types of changes
- **Enhancement** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Change hash algorithm to SHA-256 for Windows binaries, installers, and uninstallers
- [x] Change the order in CI to sign installers before uploading artifacts. These are mutually exclusive (release/non-release) under normal circumstances, so it doesn't affect anything.

### 👫 Relationships
Closes #4571

### 🔎 Review hints

1. Take the installers from the artifacts of the commit https://github.com/toggl-open-source/toggldesktop/commit/34db28c9d8fba9dbd4461a10fbf95d2a5208100c which is simulating the release build.
2. Check that the installer is signed with SHA-256 (Properties->Digital Signatures).
3. Install the app.
4. Check that the binaries are signed with SHA-256.
5. Check that the app can be successfully run.
6. Test the same on Windows 7.