### PR TITLE
Fix Tab not working on description field (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerDescriptionFieldHandler.swift
@@ -197,13 +197,12 @@ extension TimerDescriptionFieldHandler: NSTextFieldDelegate {
     }
 
     private func autocompleteControl(doCommandBy commandSelector: Selector) -> Bool {
+        if textField.isListHidden {
+            return descriptionSimpleControl(doCommandBy: commandSelector)
+        }
+
         if commandSelector == #selector(moveDown(_:)) {
-            if textField.isListHidden {
-                textField.toggleList(true)
-                return true
-            } else {
-                return onPerformAction(.autoCompleteTableSelectNext)
-            }
+            return onPerformAction(.autoCompleteTableSelectNext)
 
         } else if commandSelector == #selector(moveUp(_:)) {
             return onPerformAction(.autoCompleteTableSelectPrevious)


### PR DESCRIPTION
### 📒 Description
Now description field in `autocompleteFilter` state will process keyboard events the same as in `descriptionUpdate` state if dropdown is not visible.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4574

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

