### PR TITLE
Use home/end keys in both dropdown and editfield for autocomplete

### DIFF
--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -77,6 +77,13 @@ bool AutocompleteComboBox::eventFilter(QObject *o, QEvent *e) {
             else
                 listView->keyPressEvent(ke);
             return true;
+        case Qt::Key_Home:
+        case Qt::Key_End:
+            if (!listView->isVisible())
+                lineEdit()->event(e);
+            else
+                listView->event(e);
+            return true;
         default:
             QComboBox::keyPressEvent(ke);
             //lineEdit()->keyPressEvent(ke);


### PR DESCRIPTION
### 📒 Description
Changes the behavior of home and end keys in the autocomplete dropdowns to modify the dropdown (when it's visible) and the edit field (when the dropdown is hidden).

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- The Home and End keys now work with autocomplete dropdown as well.

### 👫 Relationships
Closes #4512

