### PR TITLE
Update start/end and duration on popup while resizing

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -268,6 +268,8 @@ namespace TogglDesktop.ViewModels
                     var start = Toggl.DateTimeFromUnix(prevEnd.Value+1);
                     var block = new TimeEntryBlock(TimelineConstants.ScaleModes[selectedScaleMode])
                     {
+                        Started = prevEnd.Value + 1,
+                        Ended = entry.Started - 1,
                         Height = ConvertTimeIntervalToHeight(start, Toggl.DateTimeFromUnix(entry.Started - 1), selectedScaleMode),
                         VerticalOffset =
                             ConvertTimeIntervalToHeight(new DateTime(start.Year, start.Month, start.Day), start, selectedScaleMode),
@@ -401,7 +403,7 @@ namespace TogglDesktop.ViewModels
 
         private void AddNewTimeEntry()
         {
-            TimeEntryId = Toggl.CreateEmptyTimeEntry((ulong)Started, (ulong)Ended);
+            TimeEntryId = Toggl.CreateEmptyTimeEntry(Started, Ended);
             OpenEditView.Execute().Subscribe();
         }
 


### PR DESCRIPTION
### 📒 Description
Update start/end and duration on popup while resizing

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4562 

### 🔎 Review hints
Check that start/end and duration are updated correctly on popup while resizing in different scale modes.

