### PR TITLE
Fix switching focus from empty tags selection search field (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/AutoCompleteView.swift
@@ -227,7 +227,8 @@ extension AutoCompleteView {
             case .tab:
                 // Don't focus to create button if it's hidden
                 if strongSelf.createNewItemContainerView.isHidden {
-                    return false
+                    strongSelf.delegate?.shouldClose()
+                    return true
                 }
 
                 // Only focus to create button if the view is expaned


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Fixes the bug by returning `true` - meaning we say to the OS that the keypress was handled by us. This way OS won't switch focus automatically.
Additionally, pressing on the Tab when the "Create" button is hidden will close the dropdown.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4506

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

