### PR TITLE
Fix DatePicker date format in the Timeline view

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePickerTimelineStyle.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/DesignUpdate/DatePickerTimelineStyle.xaml
@@ -59,7 +59,7 @@
                                                            FontSize = "{TemplateBinding FontSize}"
                                                            Foreground = "{DynamicResource Toggl.PrimaryTextBrush}"
                                                            SelectionBrush = "{DynamicResource MahApps.Brushes.Highlight}"
-                                                           Text = "{Binding Path=SelectedDate, StringFormat='ddd, dd/MM/yyyy', RelativeSource={RelativeSource AncestorType={x:Type DatePicker}}}" >
+                                                           Text = "{Binding Text, RelativeSource={RelativeSource AncestorType={x:Type DatePicker}}}" >
                                                 <b:Interaction.Behaviors >
                                                     <behaviors:DatePickerTextBoxBehavior />
                                                 </b:Interaction.Behaviors >


### PR DESCRIPTION
### 📒 Description
Use the Windows' "Long" date format which is not confusing for users with various locales.
This is the same date format that the Edit view's DatePicker is using.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Use the "Long" date format for Timeline view's DatePicker

### 👫 Relationships
Closes #4588

### 🔎 Review hints
Test Timeline view's DatePicker with different Windows locale settings.
Settings -> Time & Language -> Regional Formats OR Change data formats