### PR TITLE
When showing the app, focus the timer description (if available) (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -521,6 +521,9 @@ void MainWindowController::showEvent(QShowEvent *event) {
 
     // Avoid 'user already logged in' error from double UI start
     if (ui_started) {
+        if (qobject_cast<TimeEntryListWidget*>(ui->stackedWidget->currentWidget())) {
+            qobject_cast<TimeEntryListWidget*>(ui->stackedWidget->currentWidget())->focusDescription();
+        }
         return;
     }
     ui_started = true;

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -45,6 +45,10 @@ TimerWidget *TimeEntryListWidget::timer() {
     return ui->timer;
 }
 
+void TimeEntryListWidget::focusDescription() {
+    ui->timer->focusDescription();
+}
+
 void TimeEntryListWidget::focusTimeEntryList() {
     if (!highlightedCell()) {
         ui->list->setFocus();

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.h
@@ -32,6 +32,7 @@ class TimeEntryListWidget : public QWidget {
     TimerWidget *timer();
 
  public slots:
+    void focusDescription();
     void focusTimeEntryList();
 
  protected:

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -81,6 +81,10 @@ QString TimerWidget::currentEntryGuid() {
     return guid;
 }
 
+void TimerWidget::focusDescription() {
+    ui->description->setFocus(Qt::FocusReason::ActiveWindowFocusReason);
+}
+
 void TimerWidget::deleteTimeEntry() {
     if (guid.isEmpty())
         return;

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -27,6 +27,7 @@ class TimerWidget : public QFrame {
     QString currentEntryGuid();
 
  public slots:
+    void focusDescription();
     void deleteTimeEntry();
 
  signals:


### PR DESCRIPTION
### 📒 Description
This PR makes the app focus the Description in the Timer when re-showing the app - if time entry list was visible before hiding it and the timer is not running.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #2261

### 🔎 Review hints
Other hide/show workflows should not break.

