### PR TITLE
Fix tab order in the Preferences

### DIFF
--- a/src/ui/linux/TogglDesktop/preferencesdialog.ui
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <attribute name="title">
@@ -513,6 +513,40 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>continueStopButton</tabstop>
+  <tabstop>continueStopClear</tabstop>
+  <tabstop>showHideButton</tabstop>
+  <tabstop>showHideClear</tabstop>
+  <tabstop>focusAppOnShortcut</tabstop>
+  <tabstop>pomodoroTimer</tabstop>
+  <tabstop>pomodoroMinutes</tabstop>
+  <tabstop>pomodoroBreakTimer</tabstop>
+  <tabstop>pomodoroBreakMinutes</tabstop>
+  <tabstop>idleDetection</tabstop>
+  <tabstop>idleMinutes</tabstop>
+  <tabstop>recordTimeline</tabstop>
+  <tabstop>stopEntry</tabstop>
+  <tabstop>useSystemProxySettings</tabstop>
+  <tabstop>useProxy</tabstop>
+  <tabstop>proxyHost</tabstop>
+  <tabstop>proxyPort</tabstop>
+  <tabstop>proxyUsername</tabstop>
+  <tabstop>proxyPassword</tabstop>
+  <tabstop>sslCheckbox</tabstop>
+  <tabstop>remindToTrackTime</tabstop>
+  <tabstop>reminderMinutes</tabstop>
+  <tabstop>reminderStartTimeEdit</tabstop>
+  <tabstop>reminderEndTimeEdit</tabstop>
+  <tabstop>dayCheckbox_1</tabstop>
+  <tabstop>dayCheckbox_2</tabstop>
+  <tabstop>dayCheckbox_3</tabstop>
+  <tabstop>dayCheckbox_4</tabstop>
+  <tabstop>dayCheckbox_5</tabstop>
+  <tabstop>dayCheckbox_6</tabstop>
+  <tabstop>dayCheckbox_7</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
### 📒 Description
The tab order (that is the order in which using the Tab key will select UI elements) was messed up. This PR fixes it to be as you expect (left to right, top to bottom)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Tab order in Preferences is now as expected

### 👫 Relationships
Closes #4139 

### 🔎 Review hints
Try tabbing through the preferences dialog, it should be as expected.

