### PR TITLE
Make it possible to close the preferences with Escape

### DIFF
--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -300,6 +300,11 @@ void PreferencesDialog::keyPressEvent(QKeyEvent *event) {
             ui->continueStopButton->setText(keySequence);
         }
     }
+    else {
+        if (event->key() == Qt::Key_Escape) {
+            close();
+        }
+    }
 }
 
 void PreferencesDialog::keyReleaseEvent(QKeyEvent *event) {


### PR DESCRIPTION
### 📒 Description
Now using escape actually closes the preferences dialog. As a side note: wth is the code above what I changed.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Closing preferences with the Escape key is now possible

### 👫 Relationships
Closes #4140

