### PR TITLE
In the tarball, contain everyting in a root folder

### DIFF
--- a/dist/linux/package.sh
+++ b/dist/linux/package.sh
@@ -160,7 +160,9 @@ function package() {
 
     echo "=========== Packaging" >&2
     mv "$BINDIR/TogglDesktop.sh" "$BINDIR"/..
-    tar cvfz $reporoot/toggldesktop_$(uname -m).tar.gz * >/dev/null
+    cd ..
+    mv "$PREFIX" toggldesktop
+    tar cvfz $reporoot/toggldesktop_$(uname -m).tar.gz toggldesktop >/dev/null
 
     popd >/dev/null
     echo "=========== Result is: $reporoot/toggldesktop_$(uname -m).tar.gz ==========="


### PR DESCRIPTION
### 📒 Description
With our tarball, some users were complaining they contain everything right in the root directory, that means, if you ran `tar xvf toggldesktop.tar.gz` in your `$HOME` directory, you would end up with having the `bin`, `lib` and `share` folders right in your `$HOME` which is a bit annoying. This PR adds a directory called `toggldesktop` to the root of the tarball so if you unpack it, it will be neatly contained in one folder.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- The tarball now contains everyting in a `toggldesktop` folder in its root

### 👫 Relationships
Closes #4490 

### 🔎 Review hints
Unpack an old archive, you'll end up with 3 folders and 1 file.
Unpack the new archive (hopefully it'll be in the artifacts) and you'll end up with just 1 folder (which will contain 3 folders and 1 file).

