### PR TITLE
Enable constrains visualization only in debug mode (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/App/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/App/AppDelegate.m
@@ -132,13 +132,6 @@ void *ctx;
 {
 	NSLog(@"applicationDidFinishLaunching");
 
-	if (![self.environment isEqualToString:@"production"] && ![self.version isEqualToString:@"7.0.0"])
-	{
-		// Turn on UI constraint debugging, if not in production
-		[[NSUserDefaults standardUserDefaults] setBool:YES
-												forKey:@"NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints"];
-	}
-
 	self.mainWindowController = [[MainWindowController alloc] initWithWindowNibName:@"MainWindowController"];
 	[self.mainWindowController.window setReleasedWhenClosed:NO];
 

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/xcshareddata/xcschemes/TogglDesktop.xcscheme
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/xcshareddata/xcschemes/TogglDesktop.xcscheme
@@ -80,6 +80,12 @@
             ReferencedContainer = "container:TogglDesktop.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
### 📒 Description
Previously `NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints` settings was persisted in NSUserDefaults. So when you run the app in `Debug` mode, at least once, it will set visualization on this mac to YES and it will always stay this way, even for production apps.

In this PR I move `NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints` to scheme settings, meaning it'll be enabled only during debug sessions.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #4540

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
To see if visual debugging will show in debug mode you can revert commit related to Issue #4520 and try to reproduce it.

To see if visual debugging settings are not persisted in user defaults run `defaults read com.toggl.toggldesktop.TogglDesktop` and look for `NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints` value.
