### PR TITLE
Fix Tab focus change from description field on Edit popup (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/AutoCompleteView.swift
@@ -79,7 +79,12 @@ final class AutoCompleteView: NSView {
 
     // MARK: OUTLET
 
-    @IBOutlet weak var tableView: KeyboardTableView!
+    @IBOutlet weak var tableView: KeyboardTableView! {
+        didSet {
+            tableView.refusesFirstResponder = true
+        }
+    }
+
     @IBOutlet weak var tableViewHeight: NSLayoutConstraint!
     @IBOutlet weak var tableScrollView: NSScrollView!
     @IBOutlet weak var createNewItemBtn: CursorButton!
@@ -228,7 +233,7 @@ extension AutoCompleteView {
                 // Don't focus to create button if it's hidden
                 if strongSelf.createNewItemContainerView.isHidden {
                     strongSelf.delegate?.shouldClose()
-                    return true
+                    return false
                 }
 
                 // Only focus to create button if the view is expaned


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Returning true from keyboard handler to prevent switching focus was a bad idea because it disabled Tab key for description autocomplete on Edit popup. "Create" button is always hidden there.
This PR fixes this by allowing focus to flow but closing autocomplete when needed. Additionally, table view now cannot become first responder (the reason why previously focus was lost).

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4601 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Test if Tab works as expected in different places where autocomplete is used.