### PR TITLE
Start autotracker only if a window has been in focus for over 5 seconds

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -20,7 +20,7 @@
 #define kTimerStartInterval 10
 #define kTimelineSecondsToKeep 604800
 #define kWindowFocusThresholdSeconds 10
-#define kAutotrackerThresholdSeconds 10
+#define kAutotrackerThresholdSeconds 5
 #define kBetaChannelPercentage 25
 #define kTimelineChunkSeconds 900
 #define kEnterpriseInstall false

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -65,13 +65,19 @@ void WindowChangeRecorder::inspectFocusedWindow() {
         }
     }
 
+    idle = idle || getIsLocked() || getIsSleeping();
+
     time_t now;
     time(&now);
 
     time_t time_delta = now - last_event_started_at_;
 
+    if (last_filename_ != filename) {
+        current_app_started_at_ = now;
+    }
+
     if (last_event_started_at_ > 0) {
-        if (!last_idle_ && last_autotracker_title_ != title) {
+        if (!idle && last_autotracker_title_ != title && now - current_app_started_at_ >= kAutotrackerThresholdSeconds) {
             // Notify that the timeline event has started
             // we'll use this in auto tracking
             last_autotracker_title_ = title;
@@ -84,7 +90,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
             timeline_datasource_->StartAutotrackerEvent(event);
         }
     }
-    idle = idle || getIsLocked() || getIsSleeping();
+    
     bool idleChanged = hasIdlenessChanged(idle);
 
     if (idleChanged) {

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -97,14 +97,15 @@ void WindowChangeRecorder::inspectFocusedWindow() {
         last_autotracker_title_ = "";
     }
 
-    if (!idleChanged && !hasWindowChanged(title, filename)) {
+    bool windowHasChanged = hasWindowChanged(title, filename);
+    if (!idleChanged && !windowHasChanged) {
         return;
     }
 
     // Lite version of timeline recorder
     // Since we don't have Screen Recording permission yet => title will be empty
     // So we only track the primary timeline (treat title is filename)
-    if (is_catalina_OSX && last_title_ == title && last_filename_ == filename) {
+    if (is_catalina_OSX && !windowHasChanged) {
         return;
     }
 

--- a/src/window_change_recorder.h
+++ b/src/window_change_recorder.h
@@ -85,6 +85,7 @@ class TOGGL_INTERNAL_EXPORT WindowChangeRecorder {
     std::string last_title_;
     std::string last_filename_;
     time_t last_event_started_at_;
+    time_t current_app_started_at_;
     bool last_idle_;
 
     TimelineDatasource *timeline_datasource_;


### PR DESCRIPTION
### 📒 Description
Start autotracker only if a window has been in focus for over 5 seconds.

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Start autotracker only if a window has been in focus for over 5 seconds
- [x] Fix idleness condition for autotracker - current value should be checked instead of the previous value

### 👫 Relationships
Closes #4605

### 🔎 Review hints
Set up a few keywords+projects, and try to use the autotracker.

The autotracker should pop up within 5 seconds of a window becoming active.
The autotracker should also work even if the window title changes.

- Test on Windows (as it has #3917 enabled, it covers more use cases).
- Test on one other platform