### PR TITLE
Fix recording activity twice for the same apps

### DIFF
--- a/src/model/user.cc
+++ b/src/model/user.cc
@@ -1449,6 +1449,8 @@ void User::CompressTimeline() {
             chunk = compressed[key];
             chunk->SetEndTime(chunk->EndTime() + duration);
             event->Delete();
+            //Needed to be deleted from database
+            event->MarkAsDeletedOnServer();
         }
         compressed[key] = chunk;
     }


### PR DESCRIPTION

### 📒 Description
Mark timeline events as deleted from served so they are removed from local database.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #3099 

### 🔎 Review hints
After this PR and #4603 all activity in timeline chunks must have correct duration. This PR does not fix timeline data that is already tracked, but all new data must have correct duration.

