### PR TITLE
Fix crash when onboarding is shown before window is loaded (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingViewController.swift
@@ -87,7 +87,6 @@ final class OnboardingViewController: NSViewController {
         preparePopoverContentView(with: payload)
 
         popover.show(relativeTo: presentView.bounds, of: presentView, preferredEdge: payload.preferEdges)
-        popover.positioningRect = payload.positioningRect(payload.hint, popover.positioningRect)
     }
 
     /// Dismiss all onboard view
@@ -160,6 +159,11 @@ extension OnboardingViewController: NSPopoverDelegate {
 
     func popoverWillClose(_ notification: Notification) {
         delegate?.onboardingViewControllerDidClose()
+    }
+
+    func popoverWillShow(_ notification: Notification) {
+        guard let payload = payload else { return }
+        popover.positioningRect = payload.positioningRect(payload.hint, popover.positioningRect)
     }
 }
 


### PR DESCRIPTION
### 📒 Description
Setting `positioningRect` when the main `NSWindow` is not yet visible may crash the app with `NSInternalInconsistencyException` "window must exist".

To fix this I moved this line to the delegate method, so it'll be called only after the popover show method executes successfully. This means that onboarding won't show in such edge cases but also won't crash the app.

I think the actual root cause of this issue is that onboarding is shown after a constant delay (1 sec) after the app start. See `onboarding_service.cpp` line65:
```
// If it's the call from the launch
// Check condition for onboarding after 1 seconds, after the app is loading successfully
  if (isAtLaunchTime) {
      timer.add(seconds(1), [&](CppTime::timer_id id) {
        ...
```
But fixing this isn't trivial, so propose to merge this quick fix first.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4617 

### 🔎 Review hints
The crash is very hard to reproduce but I was able to simulate it.
In `onboarding_service.cpp` comment lines 427 and 432 to force shortcuts onboarding to start every time on app launch.

In `OnboardingViewController` replace:
```
popover.show(relativeTo: presentView.bounds, of: presentView, preferredEdge: payload.preferEdges)
```
with:
```
let window = NSWindow()
let tmpView = NSView()
window.contentView = tmpView
popover.show(relativeTo: tmpView.bounds, of: tmpView, preferredEdge: payload.preferEdges)
```
