### PR TITLE
Fix incorrect summary of reminder weekdays

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/UIUnitTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/UIUnitTests.cs
@@ -20,6 +20,7 @@ namespace TogglDesktop.Tests
         [InlineData(new[] { true,  true,  true,  true,  true,  true,  true},  DayOfWeek.Monday, "every day")]
         [InlineData(new[] { true,  true,  false, false, false, false, false}, DayOfWeek.Monday, "on Monday, Sunday")]
         [InlineData(new[] { true,  true,  false, false, false, false, false}, DayOfWeek.Sunday, "on Sunday, Monday")]
+        [InlineData(new[] { false, true,  true,  true,  true,  true,  false}, DayOfWeek.Sunday, "on weekdays")]
         public void TestSelectedDaysOfWeekText(bool[] daysChecked, DayOfWeek beginningOfWeek, string expectedText)
         {
             var isDayChecked = daysChecked.WithIndex()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/DaysOfWeekSelector.xaml.cs
@@ -49,6 +49,7 @@ namespace TogglDesktop
             }
 
             _lastBeginningOfWeek = beginningOfWeek;
+            RefreshText();
         }
 
         public void Reset(bool mon, bool tue, bool wed, bool thu, bool fri, bool sat, bool sun)


### PR DESCRIPTION
### 📒 Description
Fix incorrect summary of reminder weekdays

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4609

### 🔎 Review hints
STR
1. In the web app profile settings set the "first day of the week" setting to Sunday.
2. Run the desktop app.
3. Open Preferences->Reminder, leave only Monday-Friday checked.
4. Press Save, Close the Preferences window.
5. Open Preferences->Reminder again, observe the reminder weekdays summary text.

Note: make sure you set web app settings on Staging if you run the desktop app in Debug mode 😄 
Note 2: test doesn't actually check the bug is fixed (i.e. it doesn't fail if the bug is not fixed), it's just to verify that the method for creating text summaries produces the correct result in the following user scenario.