### PR TITLE
Don't allow edit view to fall out of screen bounds (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -192,6 +192,7 @@ namespace TogglDesktop
             this.timerEntryListView.Entries.CloseEditPopup += (sender, args) => this.closeEditPopup(true);
 
             this.editPopup.IsVisibleChanged += this.editPopupVisibleChanged;
+            editPopup.Activated += (s, e) => updateEditPopupLocation();
             this.editPopup.SizeChanged += (sender, args) => this.updateEntriesListWidth();
 
             this.idleNotificationWindow.AddedIdleTimeAsNewEntry += (o, e) => this.ShowOnTop();
@@ -543,7 +544,6 @@ namespace TogglDesktop
 
         private void editPopupVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            this.updateEditPopupLocation();
             this.updateEntriesListWidth();
             if (editPopup.IsVisible == false && ReferenceEquals(this.activeView, this.timerEntryListView))
             {
@@ -855,7 +855,7 @@ namespace TogglDesktop
                 bool left = s.Right - (this.Left + this.ActualWidth) < this.editPopup.Width;
 
                 var x = this.Left;
-                var y = this.Top;
+                var y = Top + editPopup.Height > s.Bottom ? s.Bottom - editPopup.Height : Top;
 
                 if (!left)
                 {


### PR DESCRIPTION
### 📒 Description
Don't allow edit view to fall out of screen bounds

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4555 

### 🔎 Review hints
Try to make main windows small and place in the bottom. Then open edit view. See if it fits into screen. Try to move main windows around the screen and see if edit view still fits into screen.

