### PR TITLE
Prevent possible crash when emptyActivityLbl is not yet loaded (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/TimelineDashboardViewController.swift
@@ -21,7 +21,11 @@ final class TimelineDashboardViewController: NSViewController {
     @IBOutlet weak var recordSwitcher: OGSwitch!
     @IBOutlet weak var collectionView: TimelineCollectionView!
     @IBOutlet weak var emptyLbl: NSTextField!
-    @IBOutlet weak var emptyActivityLbl: NSTextField!
+    @IBOutlet weak var emptyActivityLbl: NSTextField! {
+        didSet {
+            emptyActivityLbl.frameCenterRotation = -90
+        }
+    }
     @IBOutlet weak var emptyActivityLblPadding: NSLayoutConstraint!
     @IBOutlet weak var zoomContainerView: NSView!
     @IBOutlet weak var collectionViewContainerView: NSView!
@@ -269,7 +273,6 @@ extension TimelineDashboardViewController {
         datePickerView.edgesToSuperView()
         datePickerView.delegate = self
         datePickerView.setBackgroundForTimeline()
-        emptyActivityLbl.frameCenterRotation = -90
 
         // Forect Render the view
         _ = activityHoverController.view


### PR DESCRIPTION
### 📒 Description
This PR possibly 🤞 fixes the `EXC_BAD_INSTRUCTION` crash reported on [Bugsnug](https://app.bugsnag.com/toggldesktop/toggldesktop/errors/5f991d32e4ba5b0017e967d8?i=em&m=ws&filters[event.since][0]=2020-09-03T16%3A43%3A38.658Z).
This crash seems rare and almost impossible to reproduce. So this PR is like a prevention of the possible issue:
We assume that the crash happened because `emptyActivityLbl` view was not yet loaded. The change that was done here is totally unharmful, so after the release, we can check Bugsnag again to see if the bug was really fixed or we need to investigate again.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4636

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

