### PR TITLE
Display TEs that start on previous dated and end on selected date

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -872,6 +872,16 @@ void Context::updateUI(const UIElements &what) {
             std::sort(time_entries.begin(), time_entries.end(),
                       CompareByStart);
 
+            Poco::LocalDateTime datetime(
+                UI()->TimelineDateAt().year(),
+                UI()->TimelineDateAt().month(),
+                UI()->TimelineDateAt().day());
+            int tzd = datetime.tzd();
+
+            // Get all entires in this day (no chunk, no overlap)
+            time_t start_day = datetime.timestamp().epochTime() - tzd;
+            time_t end_day = start_day + 86400; // one day
+
             // Collect the time entries into a list
             for (unsigned int i = 0; i < time_entries.size(); i++) {
                 TimeEntry *te = time_entries[i];
@@ -880,11 +890,7 @@ void Context::updateUI(const UIElements &what) {
                     continue;
                 }
 
-                Poco::LocalDateTime te_date(Poco::Timestamp::fromEpochTime(te->StartTime()));
-                if (te_date.year() == UI()->TimelineDateAt().year()
-                        && te_date.month() == UI()->TimelineDateAt().month()
-                        && te_date.day() == UI()->TimelineDateAt().day()) {
-
+                if (te->StartTime() <= end_day && te->StopTime() >= start_day) {
                     view::TimeEntry view;
                     view.Fill(te);
                     view.GenerateRoundedTimes();

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -471,8 +471,9 @@ void GUI::DisplayTimeline(const bool open,
         view::TimeEntry te = entries_list.at(i);
         TogglTimeEntryView *item = time_entry_view_item_init(te);
         time_t start_time_entry = Poco::Timestamp::fromEpochTime(item->Started).epochTime();
+        time_t end_time_entry = Poco::Timestamp::fromEpochTime(item->Ended).epochTime();
 
-        if (start_time_entry >= start_day && start_time_entry <= end_day) {
+        if (end_time_entry >= start_day && start_time_entry <= end_day) {
             item->Next = first_entry;
             first_entry = item;
         } else {

--- a/src/ui/osx/TogglDesktop/Features/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/TimelineFlowLayout.swift
@@ -248,7 +248,7 @@ extension TimelineFlowLayout {
             print("Missing timestamp for at \(indexPath)")
             return nil
         }
-        let beginDay = Date.startOfDay(from: timestamp.start)
+        let beginDay = Date.startOfDay(from: currentDate.timeIntervalSince1970)
 
         // Length of time entry
         let span = CGFloat(timestamp.end - timestamp.start)


### PR DESCRIPTION
### 📒 Description
Display TEs that start on previous dated and end on selected date

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
 - **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4587 

### 🔎 Review hints
Review notes:
TE which starts on previous date looks cut at midnight, which is not bad as it displays that it has a continuation. The drawback is that the description is also cut and not displayed on current date. This is a small thing, but requires redesigning of TimeEntryBlock view model to handle.

Testing notes:
It would be very nice to check how the changes in lib behave on MacOS.  

