### PR TITLE
Implement start time update via duration dropdown (mac)

### DIFF
--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -642,6 +642,35 @@ char_t *toggl_format_tracked_time_duration(
     return copy_string(formatted);
 }
 
+char_t *toggl_format_time(
+    const int64_t time) {
+
+    std::string formatted = toggl::Formatter::FormatTimeForTimeEntryEditor(time);
+    return copy_string(formatted);
+}
+
+int64_t toggl_timestamp_from_time_string(const char_t *time) {
+    int hours(0), minutes(0);
+    if (!toggl::Formatter::ParseTimeInput(to_string(time), &hours, &minutes)) {
+        return 0;
+    }
+
+    Poco::LocalDateTime now;
+
+    Poco::LocalDateTime dt(
+        now.year(), now.month(), now.day(),
+        hours, minutes, 0);
+
+    // check if time is in future and subtrack 1 day if needed
+    if (dt.utcTime() > now.utcTime()) {
+        Poco::LocalDateTime new_date =
+            dt - Poco::Timespan(1 * Poco::Timespan::DAYS);
+        dt = new_date;
+    }
+
+    return dt.utc().timestamp().epochTime();
+}
+
 char_t *toggl_start_with_current_running(
     void *context,
     const char_t *description,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1165,6 +1165,13 @@ typedef enum {
     TOGGL_EXPORT char_t *toggl_format_tracked_time_duration(
         const int64_t duration_in_seconds);
 
+    // You must free() the result
+    TOGGL_EXPORT char_t *toggl_format_time(
+        const int64_t time);
+
+    TOGGL_EXPORT int64_t toggl_timestamp_from_time_string(
+        const char_t *time);
+
     TOGGL_EXPORT int64_t toggl_parse_duration_string_into_seconds(
         const char_t *duration_string);
 

--- a/src/ui/osx/TogglDesktop/Features/Calendar/Date+Utils.swift
+++ b/src/ui/osx/TogglDesktop/Features/Calendar/Date+Utils.swift
@@ -15,6 +15,10 @@ extension Calendar {
 
 extension Date {
 
+    var seconds: Int {
+        Calendar.current.dateComponents([.second], from: self).second ?? 0
+    }
+
     func dayOfWeekString() -> String? {
         guard let weekday = Calendar.current.dateComponents([.weekday], from: self).weekday else {
             return nil

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -138,8 +138,14 @@ class TimerViewController: NSViewController {
         }
 
         viewModel.onDurationChanged = { [unowned self] duration in
-            if self.durationControl.stringValue != duration {
-                self.durationControl.stringValue = duration
+            if self.durationControl.durationStringValue != duration {
+                self.durationControl.durationStringValue = duration
+            }
+        }
+
+        viewModel.onStartTimeChanged = { [unowned self] startTime in
+            if self.durationControl.startTimeStringValue != startTime {
+                self.durationControl.startTimeStringValue = startTime
             }
         }
 
@@ -414,6 +420,10 @@ class TimerViewController: NSViewController {
 
         durationControl.onDurationTextChange = { [unowned self] text in
             self.viewModel.setDuration(text)
+        }
+
+        durationControl.onStartTextChange = { [unowned self] text in
+            self.viewModel.setStartTime(text)
         }
 
         durationControl.onPerformAction = { [unowned self] action in

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
@@ -10,6 +10,20 @@ import Cocoa
 
 class TimeEditView: NSView {
 
+    var onStartTextChange: ((String) -> Void)?
+
+    var startStringValue: String {
+        get {
+            startTextField.stringValue
+        }
+        set {
+            startTextField.stringValue = newValue
+            isStartFieldChanged = false
+        }
+    }
+
+    private var isStartFieldChanged = false
+
     @IBOutlet private weak var startTextField: NSTextField!
 
     override func becomeFirstResponder() -> Bool {
@@ -18,12 +32,22 @@ class TimeEditView: NSView {
 }
 
 extension TimeEditView: NSTextFieldDelegate {
+    func controlTextDidEndEditing(_ obj: Notification) {
+        if obj.object as? NSTextField == startTextField, isStartFieldChanged {
+            onStartTextChange?(startStringValue)
+        }
+    }
+
+    func controlTextDidChange(_ obj: Notification) {
+        isStartFieldChanged = true
+    }
+
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
         if commandSelector == #selector(insertTab(_:))
             || commandSelector == #selector(insertBacktab(_:))
-            || commandSelector == #selector(cancelOperation(_:)) {
+            || commandSelector == #selector(cancelOperation(_:))
+            || commandSelector == #selector(insertNewline(_:)) {
                 window?.orderOut(nil)
-                return true
         }
         return false
     }

--- a/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.h
@@ -115,6 +115,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString * _Nullable)formatDurationTimestampt:(NSTimeInterval)duration;
 - (int64_t)secondsFromDurationString:(NSString *)durationString;
+- (NSString * _Nullable)formatTime:(NSTimeInterval)time;
+- (NSTimeInterval)timestampFromString:(NSString *)timeString;
 
 #pragma mark - Colors
 

--- a/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.m
@@ -388,6 +388,8 @@ void *ctx;
     return nil;
 }
 
+#pragma mark - Formatter
+
 - (NSString *)formatDurationTimestampt:(NSTimeInterval)duration
 {
     char *durationStr = toggl_format_duration_time(ctx, duration);
@@ -402,6 +404,22 @@ void *ctx;
 - (int64_t)secondsFromDurationString:(NSString *)durationString {
     return toggl_parse_duration_string_into_seconds([durationString UTF8String]);
 }
+
+- (NSString *)formatTime:(NSTimeInterval)time {
+    char *timeStr = toggl_format_time(time);
+    if (timeStr) {
+        NSString *time = [NSString stringWithUTF8String:timeStr];
+        free(timeStr);
+        return time;
+    }
+    return nil;
+}
+
+- (NSTimeInterval)timestampFromString:(NSString *)timeString {
+    return toggl_timestamp_from_time_string([timeString UTF8String]);
+}
+
+#pragma mark - Colors
 
 - (NSColor *) getAdaptiveColorForShapeFromColor:(NSColor *) color {
     TogglAdaptiveColor type = [self isDarkTheme] ? AdaptiveColorShapeOnDarkBackground : AdaptiveColorShapeOnLightBackground;


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
PR adds the ability to edit TE start time via duration dropdown

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4591 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Duration dropdown is hidden under local feature flag. To enable it go to `TimerDurationControl.swift` line 16 and set `isDurationDropdownEnabled` to `true`.

Test if interactions make sense and if using the start time and duration text fields work as expected.