### PR TITLE
Change the definitions of user-facing errors

### DIFF
--- a/src/error.cc
+++ b/src/error.cc
@@ -118,22 +118,10 @@ bool IsUserError(const error &err) {
     if (err.find(kPaymentRequiredError) != std::string::npos) {
         return true;
     }
-    if (err.find("File not found") != std::string::npos) {
-        return true;
-    }
-    if (err.find("SSL context exception") != std::string::npos) {
-        return true;
-    }
-    if (err.find("Access to file denied") != std::string::npos) {
-        return true;
-    }
     if (err.find(kBadRequestError) != std::string::npos) {
         return true;
     }
     if (err.find(kUnauthorizedError) != std::string::npos) {
-        return true;
-    }
-    if (err.find(kCannotWriteFile) != std::string::npos) {
         return true;
     }
     if (err.find(kIsSuspended) != std::string::npos) {
@@ -157,6 +145,22 @@ bool IsUserError(const error &err) {
         return true;
     }
     if (err.find("Start time year must be between 2010 and 2100")
+            != std::string::npos) {
+        return true;
+    }
+    if (err.find("Stop time year must be between 2010 and 2100")
+            != std::string::npos) {
+        return true;
+    }
+    if (err.find("Start time year must be between 2006 and 2030")
+            != std::string::npos) {
+        return true;
+    }
+    if (err.find("Stop time year must be between 2006 and 2030")
+            != std::string::npos) {
+        return true;
+    }
+    if (err.find("Max allowed duration per 1 time entry is 999 hours")
             != std::string::npos) {
         return true;
     }
@@ -204,6 +208,18 @@ bool IsUserError(const error &err) {
         return true;
     }
     if (err.find(kThisEntryCantBeSavedPleaseAdd) != std::string::npos) {
+        return true;
+    }
+    if (err.find("Currently running time entry has unmet constraints") != std::string::npos) {
+        return true;
+    }
+    if (err.find("User cannot access the selected project") != std::string::npos) {
+        return true;
+    }
+    if (err.find("Entries can't be added or edited in this period. Contact your admin for details.") != std::string::npos) {
+        return true;
+    }
+    if (err.find("workspace does not have the tasks feature") != std::string::npos) {
         return true;
     }
     return false;


### PR DESCRIPTION
### 📒 Description
This PR changes the behavior on some errors that get handled in the app:
These will now be treated as user errors (that is, not reported to bugsnag):
 - "Stop time year must be between 2010 and 2100"
 - "Start time year must be between 2006 and 2030"
 - "Stop time year must be between 2006 and 2030"
 - "Max allowed duration per 1 time entry is 999 hours"
 - "User cannot access the selected project"
 - "Entries can't be added or edited in this period. Contact your admin for details."
 - "workspace does not have the tasks feature"
 - and finally: "Currently running time entry has unmet constraints"
   - this one was responsible for the most of reports in bugsnag (literally hundreds of thousands)

And these ones now will get reported to bugsnag because they come from errors that could be handled in a better way in the code (or they're not used anymore):
 - "File not found"
 - "SSL context exception" (seems important but it may spam a lot, you'll need to keep track of this one after merging the PR)
 - "Access to file denied"
 - "cannot write file"

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Read the code, compare to bugsnag ( https://app.bugsnag.com/toggldesktop/toggldesktop/timeline?filters[event.since][0]=30d&filters[error.status][0]=open&sort=events&pivot_tab=error ) and decide if the choices are made are right.

