### PR TITLE
Force displaying the stopped timer state when the app starts

### DIFF
--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -69,6 +69,8 @@ selectedProjectId(0) {
 
     descriptionPlaceholder = "What are you doing?";
     tagsHolder = "";
+
+    displayStoppedTimerState();
 }
 
 TimerWidget::~TimerWidget() {


### PR DESCRIPTION
### 📒 Description
This basically just renders the stopped state immediately when the Timer is constructed. Then, when the callbacks from the library start coming, the actual timer state gets synced to the UI. This usually takes a few seconds for new accounts because the initial sync has to run.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Timer behaves as expected after first login

### 👫 Relationships
Closes #4498 

### 🔎 Review hints
It's easiest to test this by deleting `~/.local/share/Toggl/Toggl Desktop/toggldesktop-staging.db` and then logging in.

