### PR TITLE
Fix global keyboard shortcut issues

### DIFF
--- a/third_party/qxtglobalshortcut5/gui/qxtglobalshortcut_x11.cpp
+++ b/third_party/qxtglobalshortcut5/gui/qxtglobalshortcut_x11.cpp
@@ -29,7 +29,6 @@
 ** <http://libqxt.org>  <foundation@libqxt.org>
 *****************************************************************************/
 
-#include <QVector>
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
 #   include <QX11Info>
 #else
@@ -37,22 +36,52 @@
 #   include <qpa/qplatformnativeinterface.h>
 #   include <xcb/xcb.h>
 #endif
+#include <QVector>
+#include <QWidget>
+#include <X11/keysym.h>
 #include <X11/Xlib.h>
 
 #include "xcbkeyboard.h"
 
 namespace {
 
-const QVector<quint32> maskModifiers = QVector<quint32>()
-    << 0 << Mod2Mask << LockMask << (Mod2Mask | LockMask);
+/**
+ * Creates first invisible application window
+ * so X11 key press events can be received.
+ *
+ * This is used for Cinnamon and KDE.
+ */
+void createFirstWindow()
+{
+    static QWidget *w = nullptr;
+    if (!w) {
+        // Try hard so the window is not visible.
 
-typedef int (*X11ErrorHandler)(Display *display, XErrorEvent *event);
+        // Tool tips won't show in taskbar.
+        w = new QWidget(nullptr, Qt::ToolTip);
+
+        // Move out of screen (if it's not possible to show the window minimized).
+        w->resize(1, 1);
+        w->move(-100000, -100000);
+
+        // Show and hide quickly.
+        w->showMinimized();
+        w->hide();
+    }
+}
+
+QVector<quint32> maskModifiers()
+{
+    return QVector<quint32>() << 0 << Mod2Mask << LockMask << (Mod2Mask | LockMask);
+}
+
+using X11ErrorHandler = int (*)(Display* display, XErrorEvent* event);
 
 class QxtX11ErrorHandler {
 public:
     static bool error;
 
-    static int qxtX11ErrorHandler(Display *display, XErrorEvent *event)
+    static int qxtX11ErrorHandler(Display* display, XErrorEvent *event)
     {
         Q_UNUSED(display);
         switch (event->error_code)
@@ -73,6 +102,7 @@ public:
     }
 
     QxtX11ErrorHandler()
+        : m_previousErrorHandler(nullptr)
     {
         error = false;
         m_previousErrorHandler = XSetErrorHandler(qxtX11ErrorHandler);
@@ -92,7 +122,10 @@ bool QxtX11ErrorHandler::error = false;
 class QxtX11Data {
 public:
     QxtX11Data()
+        : m_display(nullptr)
     {
+        createFirstWindow();
+
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
         m_display = QX11Info::display();
 #else
@@ -103,9 +136,9 @@ public:
 #endif
     }
 
-    bool isValid()
+    bool isValid() const
     {
-        return m_display != 0;
+        return m_display != nullptr;
     }
 
     Display *display()
@@ -123,9 +156,11 @@ public:
     {
         QxtX11ErrorHandler errorHandler;
 
-        for (int i = 0; !errorHandler.error && i < maskModifiers.size(); ++i) {
-            XGrabKey(display(), keycode, modifiers | maskModifiers[i], window, True,
+        for (const auto maskMods : maskModifiers()) {
+            XGrabKey(display(), static_cast<int>(keycode), modifiers | maskMods, window, True,
                      GrabModeAsync, GrabModeAsync);
+            if (errorHandler.error)
+                break;
         }
 
         if (errorHandler.error) {
@@ -140,8 +175,8 @@ public:
     {
         QxtX11ErrorHandler errorHandler;
 
-        foreach (quint32 maskMods, maskModifiers) {
-            XUngrabKey(display(), keycode, modifiers | maskMods, window);
+        for (const auto maskMods : maskModifiers()) {
+            XUngrabKey(display(), static_cast<int>(keycode), modifiers | maskMods, window);
         }
 
         return !errorHandler.error;
@@ -151,31 +186,45 @@ private:
     Display *m_display;
 };
 
+KeySym qtKeyToXKeySym(Qt::Key key)
+{
+    for (int i = 0; KeyTbl[i] != 0; i += 2) {
+        if (KeyTbl[i + 1] == key)
+            return KeyTbl[i];
+    }
+
+    const auto keySym = XStringToKeysym(QKeySequence(key).toString().toLatin1().data());
+    if (keySym != NoSymbol)
+        return keySym;
+
+    return static_cast<ushort>(key);
+}
+
 } // namespace
 
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
-bool QxtGlobalShortcutPrivate::eventFilter(void *message)
+bool QxtGlobalShortcutPrivate::eventFilter(void* message)
 {
     XEvent *event = static_cast<XEvent *>(message);
     if (event->type == KeyPress)
     {
-        XKeyEvent *key = reinterpret_cast<XKeyEvent *>(event);
+        XKeyEvent* key = reinterpret_cast<XKeyEvent *>(event);
         unsigned int keycode = key->keycode;
         unsigned int keystate = key->state;
 #else
 bool QxtGlobalShortcutPrivate::nativeEventFilter(const QByteArray & eventType,
-    void *message, long *result)
+    void * message, long * result)
 {
     Q_UNUSED(result);
 
-    xcb_key_press_event_t *kev = 0;
+    xcb_key_press_event_t *kev = nullptr;
     if (eventType == "xcb_generic_event_t") {
-        xcb_generic_event_t *ev = static_cast<xcb_generic_event_t *>(message);
+        xcb_generic_event_t* ev = static_cast<xcb_generic_event_t *>(message);
         if ((ev->response_type & 127) == XCB_KEY_PRESS)
             kev = static_cast<xcb_key_press_event_t *>(message);
     }
 
-    if (kev != 0) {
+    if (kev != nullptr) {
         unsigned int keycode = kev->detail;
         unsigned int keystate = 0;
         if(kev->state & XCB_MOD_MASK_1)
@@ -191,11 +240,7 @@ bool QxtGlobalShortcutPrivate::nativeEventFilter(const QByteArray & eventType,
             // Mod1Mask == Alt, Mod4Mask == Meta
             keystate & (ShiftMask | ControlMask | Mod1Mask | Mod4Mask));
     }
-#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
-    return prevEventFilter ? prevEventFilter(message) : false;
-#else
-	return false;
-#endif
+    return false;
 }
 
 quint32 QxtGlobalShortcutPrivate::nativeModifiers(Qt::KeyboardModifiers modifiers)
@@ -224,15 +269,7 @@ quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key)
     if (!x11.isValid())
         return 0;
 
-    KeySym keysym = XStringToKeysym(QKeySequence(key).toString().toLatin1().data());
-    if (keysym == NoSymbol)
-        keysym = static_cast<ushort>(key);
-
-    for (int i = 0; KeyTbl[i] != 0; i += 2) {
-        if (KeyTbl[i + 1] == key)
-            keysym = KeyTbl[i];
-    }
-
+    const KeySym keysym = qtKeyToXKeySym(key);
     return XKeysymToKeycode(x11.display(), keysym);
 }
 

--- a/third_party/qxtglobalshortcut5/gui/xcbkeyboard.h
+++ b/third_party/qxtglobalshortcut5/gui/xcbkeyboard.h
@@ -103,7 +103,7 @@
 #define XF86XK_KbdBrightnessUp     0x1008FF05
 #define XF86XK_KbdBrightnessDown   0x1008FF06
 #define XF86XK_Standby             0x1008FF10
-#define XF86XK_AudioLowerVolume    0x1008FF11
+#define XF86XK_AudioLowerVolume	   0x1008FF11
 #define XF86XK_AudioMute           0x1008FF12
 #define XF86XK_AudioRaiseVolume    0x1008FF13
 #define XF86XK_AudioPlay           0x1008FF14
@@ -186,10 +186,8 @@
 #define XF86XK_MenuKB              0x1008FF65
 #define XF86XK_MenuPB              0x1008FF66
 #define XF86XK_MySites             0x1008FF67
-#define XF86XK_New                 0x1008FF68
 #define XF86XK_News                0x1008FF69
 #define XF86XK_OfficeHome          0x1008FF6A
-#define XF86XK_Open                0x1008FF6B
 #define XF86XK_Option              0x1008FF6C
 #define XF86XK_Paste               0x1008FF6D
 #define XF86XK_Phone               0x1008FF6E
@@ -244,6 +242,8 @@
 
 
 // end of XF86keysyms.h
+
+QT_BEGIN_NAMESPACE
 
 // keyboard mapping table
 static const unsigned int KeyTbl[] = {
@@ -330,66 +330,66 @@ static const unsigned int KeyTbl[] = {
 
     // International & multi-key character composition
     XK_ISO_Level3_Shift,        Qt::Key_AltGr,
-    XK_Multi_key,               Qt::Key_Multi_key,
-    XK_Codeinput,               Qt::Key_Codeinput,
-    XK_SingleCandidate,         Qt::Key_SingleCandidate,
-    XK_MultipleCandidate,       Qt::Key_MultipleCandidate,
-    XK_PreviousCandidate,       Qt::Key_PreviousCandidate,
+    XK_Multi_key,		Qt::Key_Multi_key,
+    XK_Codeinput,		Qt::Key_Codeinput,
+    XK_SingleCandidate,		Qt::Key_SingleCandidate,
+    XK_MultipleCandidate,	Qt::Key_MultipleCandidate,
+    XK_PreviousCandidate,	Qt::Key_PreviousCandidate,
 
     // Misc Functions
-    XK_Mode_switch,             Qt::Key_Mode_switch,
-    XK_script_switch,           Qt::Key_Mode_switch,
+    XK_Mode_switch,		Qt::Key_Mode_switch,
+    XK_script_switch,		Qt::Key_Mode_switch,
 
     // Japanese keyboard support
-    XK_Kanji,                   Qt::Key_Kanji,
-    XK_Muhenkan,                Qt::Key_Muhenkan,
-    //XK_Henkan_Mode,           Qt::Key_Henkan_Mode,
-    XK_Henkan_Mode,             Qt::Key_Henkan,
-    XK_Henkan,                  Qt::Key_Henkan,
-    XK_Romaji,                  Qt::Key_Romaji,
-    XK_Hiragana,                Qt::Key_Hiragana,
-    XK_Katakana,                Qt::Key_Katakana,
-    XK_Hiragana_Katakana,       Qt::Key_Hiragana_Katakana,
-    XK_Zenkaku,                 Qt::Key_Zenkaku,
-    XK_Hankaku,                 Qt::Key_Hankaku,
-    XK_Zenkaku_Hankaku,         Qt::Key_Zenkaku_Hankaku,
-    XK_Touroku,                 Qt::Key_Touroku,
-    XK_Massyo,                  Qt::Key_Massyo,
-    XK_Kana_Lock,               Qt::Key_Kana_Lock,
-    XK_Kana_Shift,              Qt::Key_Kana_Shift,
-    XK_Eisu_Shift,              Qt::Key_Eisu_Shift,
-    XK_Eisu_toggle,             Qt::Key_Eisu_toggle,
-    //XK_Kanji_Bangou,          Qt::Key_Kanji_Bangou,
-    //XK_Zen_Koho,              Qt::Key_Zen_Koho,
-    //XK_Mae_Koho,              Qt::Key_Mae_Koho,
-    XK_Kanji_Bangou,            Qt::Key_Codeinput,
-    XK_Zen_Koho,                Qt::Key_MultipleCandidate,
-    XK_Mae_Koho,                Qt::Key_PreviousCandidate,
+    XK_Kanji,			Qt::Key_Kanji,
+    XK_Muhenkan,		Qt::Key_Muhenkan,
+    //XK_Henkan_Mode,		Qt::Key_Henkan_Mode,
+    XK_Henkan_Mode,		Qt::Key_Henkan,
+    XK_Henkan,			Qt::Key_Henkan,
+    XK_Romaji,			Qt::Key_Romaji,
+    XK_Hiragana,		Qt::Key_Hiragana,
+    XK_Katakana,		Qt::Key_Katakana,
+    XK_Hiragana_Katakana,	Qt::Key_Hiragana_Katakana,
+    XK_Zenkaku,			Qt::Key_Zenkaku,
+    XK_Hankaku,			Qt::Key_Hankaku,
+    XK_Zenkaku_Hankaku,		Qt::Key_Zenkaku_Hankaku,
+    XK_Touroku,			Qt::Key_Touroku,
+    XK_Massyo,			Qt::Key_Massyo,
+    XK_Kana_Lock,		Qt::Key_Kana_Lock,
+    XK_Kana_Shift,		Qt::Key_Kana_Shift,
+    XK_Eisu_Shift,		Qt::Key_Eisu_Shift,
+    XK_Eisu_toggle,		Qt::Key_Eisu_toggle,
+    //XK_Kanji_Bangou,		Qt::Key_Kanji_Bangou,
+    //XK_Zen_Koho,		Qt::Key_Zen_Koho,
+    //XK_Mae_Koho,		Qt::Key_Mae_Koho,
+    XK_Kanji_Bangou,		Qt::Key_Codeinput,
+    XK_Zen_Koho,		Qt::Key_MultipleCandidate,
+    XK_Mae_Koho,		Qt::Key_PreviousCandidate,
 
-#ifdef XK_KOREAN
+    #ifdef XK_KOREAN
     // Korean keyboard support
-    XK_Hangul,                  Qt::Key_Hangul,
-    XK_Hangul_Start,            Qt::Key_Hangul_Start,
-    XK_Hangul_End,              Qt::Key_Hangul_End,
-    XK_Hangul_Hanja,            Qt::Key_Hangul_Hanja,
-    XK_Hangul_Jamo,             Qt::Key_Hangul_Jamo,
-    XK_Hangul_Romaja,           Qt::Key_Hangul_Romaja,
-    //XK_Hangul_Codeinput,      Qt::Key_Hangul_Codeinput,
-    XK_Hangul_Codeinput,        Qt::Key_Codeinput,
-    XK_Hangul_Jeonja,           Qt::Key_Hangul_Jeonja,
-    XK_Hangul_Banja,            Qt::Key_Hangul_Banja,
-    XK_Hangul_PreHanja,         Qt::Key_Hangul_PreHanja,
-    XK_Hangul_PostHanja,        Qt::Key_Hangul_PostHanja,
+    XK_Hangul,			Qt::Key_Hangul,
+    XK_Hangul_Start,		Qt::Key_Hangul_Start,
+    XK_Hangul_End,		Qt::Key_Hangul_End,
+    XK_Hangul_Hanja,		Qt::Key_Hangul_Hanja,
+    XK_Hangul_Jamo,		Qt::Key_Hangul_Jamo,
+    XK_Hangul_Romaja,		Qt::Key_Hangul_Romaja,
+    //XK_Hangul_Codeinput,	Qt::Key_Hangul_Codeinput,
+    XK_Hangul_Codeinput,	Qt::Key_Codeinput,
+    XK_Hangul_Jeonja,		Qt::Key_Hangul_Jeonja,
+    XK_Hangul_Banja,		Qt::Key_Hangul_Banja,
+    XK_Hangul_PreHanja,		Qt::Key_Hangul_PreHanja,
+    XK_Hangul_PostHanja,	Qt::Key_Hangul_PostHanja,
     //XK_Hangul_SingleCandidate,Qt::Key_Hangul_SingleCandidate,
     //XK_Hangul_MultipleCandidate,Qt::Key_Hangul_MultipleCandidate,
     //XK_Hangul_PreviousCandidate,Qt::Key_Hangul_PreviousCandidate,
-    XK_Hangul_SingleCandidate,  Qt::Key_SingleCandidate,
+    XK_Hangul_SingleCandidate,	Qt::Key_SingleCandidate,
     XK_Hangul_MultipleCandidate,Qt::Key_MultipleCandidate,
     XK_Hangul_PreviousCandidate,Qt::Key_PreviousCandidate,
-    XK_Hangul_Special,          Qt::Key_Hangul_Special,
-    //XK_Hangul_switch,         Qt::Key_Hangul_switch,
-    XK_Hangul_switch,           Qt::Key_Mode_switch,
-#endif  // XK_KOREAN
+    XK_Hangul_Special,		Qt::Key_Hangul_Special,
+    //XK_Hangul_switch,		Qt::Key_Hangul_switch,
+    XK_Hangul_switch,		Qt::Key_Mode_switch,
+    #endif  // XK_KOREAN
 
     // dead keys
     XK_dead_grave,              Qt::Key_Dead_Grave,
@@ -413,7 +413,7 @@ static const unsigned int KeyTbl[] = {
     XK_dead_horn,               Qt::Key_Dead_Horn,
 
     // Special keys from X.org - This include multimedia keys,
-        // wireless/bluetooth/uwb keys, special launcher keys, etc.
+    // wireless/bluetooth/uwb keys, special launcher keys, etc.
     XF86XK_Back,                Qt::Key_Back,
     XF86XK_Forward,             Qt::Key_Forward,
     XF86XK_Stop,                Qt::Key_Stop,
@@ -431,7 +431,6 @@ static const unsigned int KeyTbl[] = {
     XF86XK_AudioPrev,           Qt::Key_MediaPrevious,
     XF86XK_AudioNext,           Qt::Key_MediaNext,
     XF86XK_AudioRecord,         Qt::Key_MediaRecord,
-    XF86XK_AudioPause,          Qt::Key_MediaPause,
     XF86XK_Mail,                Qt::Key_LaunchMail,
     XF86XK_MyComputer,          Qt::Key_Launch0,  // ### Qt 6: remap properly
     XF86XK_Calculator,          Qt::Key_Launch1,
@@ -486,14 +485,8 @@ static const unsigned int KeyTbl[] = {
     XF86XK_MenuKB,              Qt::Key_MenuKB,
     XF86XK_MenuPB,              Qt::Key_MenuPB,
     XF86XK_MySites,             Qt::Key_MySites,
-#if QT_VERSION >= 0x050400
-    XF86XK_New,                 Qt::Key_New,
-#endif
     XF86XK_News,                Qt::Key_News,
     XF86XK_OfficeHome,          Qt::Key_OfficeHome,
-#if QT_VERSION >= 0x050400
-    XF86XK_Open,                Qt::Key_Open,
-#endif
     XF86XK_Option,              Qt::Key_Option,
     XF86XK_Paste,               Qt::Key_Paste,
     XF86XK_Phone,               Qt::Key_Phone,
@@ -535,21 +528,17 @@ static const unsigned int KeyTbl[] = {
     XF86XK_Select,              Qt::Key_Select,
     XF86XK_View,                Qt::Key_View,
     XF86XK_TopMenu,             Qt::Key_TopMenu,
-#if QT_VERSION >= 0x050400
     XF86XK_Red,                 Qt::Key_Red,
     XF86XK_Green,               Qt::Key_Green,
     XF86XK_Yellow,              Qt::Key_Yellow,
     XF86XK_Blue,                Qt::Key_Blue,
-#endif
     XF86XK_Bluetooth,           Qt::Key_Bluetooth,
     XF86XK_Suspend,             Qt::Key_Suspend,
     XF86XK_Hibernate,           Qt::Key_Hibernate,
-#if QT_VERSION >= 0x050400
     XF86XK_TouchpadToggle,      Qt::Key_TouchpadToggle,
     XF86XK_TouchpadOn,          Qt::Key_TouchpadOn,
     XF86XK_TouchpadOff,         Qt::Key_TouchpadOff,
     XF86XK_AudioMicMute,        Qt::Key_MicMute,
-#endif
     XF86XK_Launch0,             Qt::Key_Launch2, // ### Qt 6: remap properly
     XF86XK_Launch1,             Qt::Key_Launch3,
     XF86XK_Launch2,             Qt::Key_Launch4,


### PR DESCRIPTION
### 📒 Description
This PR is a combination of these sources of code:
 - https://github.com/qt/qtbase/tree/dev/src/plugins/platforms/xcb
 - https://github.com/hluk/qxtglobalshortcut/blob/master/src/qxtglobalshortcut_x11.cpp
 - Some experiments with the order of returning results based on our previous code

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Global keyboard shortcuts now should actually work as expected

### 👫 Relationships
#4580 

### 🔎 Review hints
Try setting some (especially "exotic") keyboard shortcuts and observe if they:
 * Work as expected
 * Don't break other global shortcuts
In case this PR breaks some more stuff, it may be worth reverting #4416
