### PR TITLE
Click-drag to create time entry

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -331,6 +331,7 @@
     <Compile Include="ui\ViewModels\TimeEntryCellViewModel.cs" />
     <Compile Include="ui\ViewModels\TimeEntryLabelViewModel.cs" />
     <Compile Include="ui\ViewModels\TimeEntryListViewModel.cs" />
+    <Compile Include="ui\ViewModels\TimelineBlockViewModel.cs" />
     <Compile Include="ui\ViewModels\TimelineViewModel.cs" />
     <Compile Include="ui\ViewModels\TimerEntryListViewViewModel.cs" />
     <Compile Include="ui\ViewModels\TimerViewModel.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/EmptyListToCollapsedConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/EmptyListToCollapsedConverter.cs
@@ -13,7 +13,7 @@ namespace TogglDesktop.Converters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var visibility = Visibility.Collapsed;
-            if (value is IList list && list.Count > 0)
+            if (value is ICollection list && list.Count > 0)
                 visibility = Visibility.Visible;
             if (Inverse) visibility = visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
             return visibility;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
@@ -20,13 +20,5 @@ namespace TogglDesktop.Resources
             {2, 50},
             {3, 25}
         };
-
-        public static ulong ConvertOffsetToTime(double offset, DateTime date, double hourHeight)
-        {
-            var hours = 1.0 * offset / hourHeight;
-            var dateTime = date.AddHours(hours);
-            var unixTime = Toggl.UnixFromDateTime(dateTime);
-            return unixTime >= 0 ? (ulong)unixTime : 0;
-        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
@@ -20,5 +20,13 @@ namespace TogglDesktop.Resources
             {2, 50},
             {3, 25}
         };
+
+        public static ulong ConvertOffsetToTime(double offset, DateTime date, double hourHeight)
+        {
+            var hours = 1.0 * offset / hourHeight;
+            var dateTime = date.AddHours(hours);
+            var unixTime = Toggl.UnixFromDateTime(dateTime);
+            return unixTime >= 0 ? (ulong)unixTime : 0;
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -67,10 +67,10 @@ namespace TogglDesktop.ViewModels
             TimeEntryId = timeEntryId;
             OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(TimeEntryId, false, Toggl.Description));
             this.WhenAnyValue(x => x.VerticalOffset)
-                .Select(h => TimelineConstants.ConvertOffsetToTime(h, Toggl.DateTimeFromUnix(Started).Date, _hourHeight))
+                .Select(h => TimelineUtils.ConvertOffsetToTime(h, Toggl.DateTimeFromUnix(Started).Date, _hourHeight))
                 .Subscribe(next => Started = next);
             this.WhenAnyValue(x => x.Height, x => x.VerticalOffset)
-                .Select(h => TimelineConstants.ConvertOffsetToTime(h.Item1 + h.Item2, Toggl.DateTimeFromUnix(Ended).Date, _hourHeight))
+                .Select(h => TimelineUtils.ConvertOffsetToTime(h.Item1 + h.Item2, Toggl.DateTimeFromUnix(Ended).Date, _hourHeight))
                 .Subscribe(next => Ended = next);
             this.WhenAnyValue(x => x.Started, x => x.Ended)
                 .Select(pair => $"{Toggl.DateTimeFromUnix(pair.Item1):HH:mm tt} - {Toggl.DateTimeFromUnix(pair.Item2):HH:mm tt}")
@@ -91,13 +91,13 @@ namespace TogglDesktop.ViewModels
         public void ChangeStartTime()
         {
             Toggl.SetTimeEntryStartTimeStamp(TimeEntryId,
-                (long)TimelineConstants.ConvertOffsetToTime(VerticalOffset, Toggl.DateTimeFromUnix(Started).Date, _hourHeight));
+                (long)TimelineUtils.ConvertOffsetToTime(VerticalOffset, Toggl.DateTimeFromUnix(Started).Date, _hourHeight));
         }
 
         public void ChangeEndTime()
         {
             Toggl.SetTimeEntryEndTimeStamp(TimeEntryId,
-                (long)TimelineConstants.ConvertOffsetToTime(VerticalOffset + Height, Toggl.DateTimeFromUnix(Ended).Date, _hourHeight));
+                (long)TimelineUtils.ConvertOffsetToTime(VerticalOffset + Height, Toggl.DateTimeFromUnix(Ended).Date, _hourHeight));
         }
 
         public void ChangeStartEndTime()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using TogglDesktop.Resources;
+
+namespace TogglDesktop.ViewModels
+{
+    public class TimelineBlockViewModel : ReactiveObject
+    {
+        [Reactive]
+        public double HorizontalOffset { get; set; }
+        [Reactive]
+        public double Height { get; set; }
+        [Reactive]
+        public double VerticalOffset { get; set; }
+    }
+
+    public class GapTimeEntryBlock : TimelineBlockViewModel
+    {
+        public ReactiveCommand<Unit, string> CreateTimeEntryFromBlock { get; }
+
+        public GapTimeEntryBlock(Func<double, double, string> addNewTimeEntry)
+        {
+            CreateTimeEntryFromBlock = ReactiveCommand.Create(() => addNewTimeEntry(VerticalOffset, Height));
+        }
+    }
+
+    public class TimeEntryBlock : TimelineBlockViewModel
+    {
+        [Reactive]
+        public string Color { get; set; }
+        [Reactive]
+        public bool ShowDescription { get; set; }
+        [Reactive]
+        public string Description { get; set; }
+        [Reactive]
+        public string ProjectName { get; set; }
+        [Reactive]
+        public string ClientName { get; set; }
+        public string TaskName { get; set; }
+        [Reactive]
+        public ulong Started { get; set; } = 0;
+
+        [Reactive]
+        public ulong Ended { get; set; } = 0;
+        [Reactive]
+        public bool HasTag { get; set; }
+        [Reactive]
+        public bool IsBillable { get; set; }
+        public string Duration { [ObservableAsProperty]get; }
+        public string StartEndCaption { [ObservableAsProperty]get; }
+        public ReactiveCommand<Unit, Unit> OpenEditView { get; }
+        public string TimeEntryId { get; private set; }
+
+        [Reactive]
+        public bool IsEditViewOpened { get; set; }
+
+        public bool IsResizable { [ObservableAsProperty] get; }
+
+        private readonly double _hourHeight;
+
+        public TimeEntryBlock(string timeEntryId, int hourHeight)
+        {
+            _hourHeight = hourHeight;
+            TimeEntryId = timeEntryId;
+            OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(TimeEntryId, false, Toggl.Description));
+            this.WhenAnyValue(x => x.VerticalOffset)
+                .Select(h => TimelineConstants.ConvertOffsetToTime(h, Toggl.DateTimeFromUnix(Started).Date, _hourHeight))
+                .Subscribe(next => Started = next);
+            this.WhenAnyValue(x => x.Height, x => x.VerticalOffset)
+                .Select(h => TimelineConstants.ConvertOffsetToTime(h.Item1 + h.Item2, Toggl.DateTimeFromUnix(Ended).Date, _hourHeight))
+                .Subscribe(next => Ended = next);
+            this.WhenAnyValue(x => x.Started, x => x.Ended)
+                .Select(pair => $"{Toggl.DateTimeFromUnix(pair.Item1):HH:mm tt} - {Toggl.DateTimeFromUnix(pair.Item2):HH:mm tt}")
+                .ToPropertyEx(this, x => x.StartEndCaption);
+            this.WhenAnyValue(x => x.Started, x => x.Ended)
+                .Select(pair =>
+                {
+                    var (start, end) = pair;
+                    var duration = Toggl.DateTimeFromUnix(end).Subtract(Toggl.DateTimeFromUnix(start));
+                    return duration.Hours + " h " + duration.Minutes + " min";
+                })
+                .ToPropertyEx(this, x => x.Duration);
+            this.WhenAnyValue(x => x.Height)
+                .Select(h => h >= TimelineConstants.MinResizableTimeEntryBlockHeight)
+                .ToPropertyEx(this, x => x.IsResizable);
+        }
+
+        public void ChangeStartTime()
+        {
+            Toggl.SetTimeEntryStartTimeStamp(TimeEntryId,
+                (long)TimelineConstants.ConvertOffsetToTime(VerticalOffset, Toggl.DateTimeFromUnix(Started).Date, _hourHeight));
+        }
+
+        public void ChangeEndTime()
+        {
+            Toggl.SetTimeEntryEndTimeStamp(TimeEntryId,
+                (long)TimelineConstants.ConvertOffsetToTime(VerticalOffset + Height, Toggl.DateTimeFromUnix(Ended).Date, _hourHeight));
+        }
+
+        public void ChangeStartEndTime()
+        {
+            ChangeStartTime();
+            ChangeEndTime();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -23,7 +23,12 @@ namespace TogglDesktop.ViewModels
 
         public GapTimeEntryBlock(Func<double, double, string> addNewTimeEntry)
         {
-            CreateTimeEntryFromBlock = ReactiveCommand.Create(() => addNewTimeEntry(VerticalOffset, Height));
+            CreateTimeEntryFromBlock = ReactiveCommand.Create(() =>
+            {
+                var id = addNewTimeEntry(VerticalOffset, Height);
+                Toggl.Edit(id, false, Toggl.Description);
+                return id;
+            });
         }
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -319,7 +319,6 @@ namespace TogglDesktop.ViewModels
             var ended = TimelineUtils.ConvertOffsetToTime(offset+height, date,
                 TimelineConstants.ScaleModes[scaleMode]);
             var timeEntryId = Toggl.CreateEmptyTimeEntry(started, ended);
-            Toggl.Edit(timeEntryId, false, Toggl.Description);
             return timeEntryId;
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -86,7 +86,7 @@ namespace TogglDesktop.ViewModels
                 .Subscribe(h => CurrentTimeOffset = h);
             this.WhenAnyValue(x => x.CurrentTimeOffset).Where(_ => RunningTimeEntryBlock != null)
                 .Select(off => Math.Max(TimelineConstants.MinTimeEntryBlockHeight,
-                    CurrentTimeOffset - RunningTimeEntryBlock.VerticalOffset))
+                    CurrentTimeOffset - RunningTimeEntryBlock.VerticalOffset - 1))
                 .Subscribe(h => RunningTimeEntryBlock.Height = h);
             this.WhenAnyValue(x => x.TimeEntryBlocks, x => x.RunningTimeEntryBlock, x => x.IsTodaySelected,
                 (blocks, running, isToday) => blocks?.Any() == true || (running != null && isToday))
@@ -198,7 +198,7 @@ namespace TogglDesktop.ViewModels
 
                 var startTime = Toggl.DateTimeFromUnix(entry.Started);
                 var ended = entry.GUID == runningEntry?.GUID 
-                    ? TimelineUtils.ConvertOffsetToTime(currentTimeOffset, selectedDate, TimelineConstants.ScaleModes[selectedScaleMode])
+                    ? TimelineUtils.ConvertOffsetToTime(currentTimeOffset - 1, selectedDate, TimelineConstants.ScaleModes[selectedScaleMode])
                     : entry.Ended;
                 var height = ConvertTimeIntervalToHeight(startTime, Toggl.DateTimeFromUnix(ended), selectedScaleMode);
                 var block = new TimeEntryBlock(entry.GUID, TimelineConstants.ScaleModes[selectedScaleMode])

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -194,6 +194,8 @@ namespace TogglDesktop.ViewModels
                 allEntries = allEntries.Union(new List<Toggl.TogglTimeEntryView>(){runningEntry.Value});
             foreach (var entry in allEntries)
             {
+                if (blocks.ContainsKey(entry.GUID)) continue;
+
                 var startTime = Toggl.DateTimeFromUnix(entry.Started);
                 var ended = entry.GUID == runningEntry?.GUID 
                     ? TimelineUtils.ConvertOffsetToTime(currentTimeOffset, selectedDate, TimelineConstants.ScaleModes[selectedScaleMode])

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -189,7 +189,7 @@
                                 <Canvas Name="TimeEntryCanvas" Background="Transparent" 
                                         MouseDown="OnTimeEntryCanvasMouseDown"
                                         MouseMove="OnTimeEntryCanvasMouseMove"
-                                        DragLeave="OnTimeEntryCanvasDragEnded"/>
+                                        MouseUp="OnTimeEntryCanvasMouseUp"/>
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -146,23 +146,6 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                     <GridSplitter Grid.Column="1" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Left" Width="1" Background="{DynamicResource Toggl.TimelineSeparatorBrush}"/>
-                    <Canvas Name="RunningTimeEntryCanvas" Grid.Row="1" Grid.Column="2" Margin="10 0 0 0" Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <togglDesktop:TimelineRunningTimeEntryBlock DataContext="{Binding RunningTimeEntryBlock}"
-                                                                Canvas.Top="{Binding VerticalOffset}"
-                                                                Canvas.Left="{Binding HorizontalOffset}"
-                                                                MouseEnter="OnTimeEntryBlockMouseEnter"
-                                                                MouseLeave="OnTimeEntyrBlockMouseLeave">
-                            <togglDesktop:TimelineRunningTimeEntryBlock.Style>
-                                <Style TargetType="FrameworkElement">
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding ShowDescription}" Value="True">
-                                            <Setter Property="Width" Value="{Binding ElementName=RunningTimeEntryCanvas, Path=ActualWidth}"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </togglDesktop:TimelineRunningTimeEntryBlock.Style>
-                        </togglDesktop:TimelineRunningTimeEntryBlock>
-                    </Canvas>
                     <Canvas Grid.Row="1" Grid.ColumnSpan="5" Grid.Column="0"
                             Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}"
                             x:Name="CurrentTimeCanvas">
@@ -216,6 +199,23 @@
                             </Style>
                         </ItemsControl.ItemContainerStyle>
                     </ItemsControl>
+                    <Canvas Name="RunningTimeEntryCanvas" Grid.Row="1" Grid.Column="2" Margin="10 0 0 0" Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <togglDesktop:TimelineRunningTimeEntryBlock DataContext="{Binding RunningTimeEntryBlock}"
+                                                                    Canvas.Top="{Binding VerticalOffset}"
+                                                                    Canvas.Left="{Binding HorizontalOffset}"
+                                                                    MouseEnter="OnTimeEntryBlockMouseEnter"
+                                                                    MouseLeave="OnTimeEntyrBlockMouseLeave">
+                            <togglDesktop:TimelineRunningTimeEntryBlock.Style>
+                                <Style TargetType="FrameworkElement">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ShowDescription}" Value="True">
+                                            <Setter Property="Width" Value="{Binding ElementName=RunningTimeEntryCanvas, Path=ActualWidth}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </togglDesktop:TimelineRunningTimeEntryBlock.Style>
+                        </togglDesktop:TimelineRunningTimeEntryBlock>
+                    </Canvas>
                     <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=GapTimeEntryBlocks}" Margin="10 0 0 0">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -186,12 +186,15 @@
                     <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=TimeEntryBlocks}" Margin="10 0 0 0" Name="TimeEntryBlocks">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <Canvas Name="TimeEntryCanvas" />
+                                <Canvas Name="TimeEntryCanvas" Background="Transparent" 
+                                        MouseDown="OnTimeEntryCanvasMouseDown"
+                                        MouseMove="OnTimeEntryCanvasMouseMove"
+                                        DragLeave="OnTimeEntryCanvasDragEnded"/>
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <togglDesktop:TimelineTimeEntryBlock Panel.ZIndex="1" DataContext="{Binding Path=.}"
+                                <togglDesktop:TimelineTimeEntryBlock Panel.ZIndex="1" DataContext="{Binding Path=Value}"
                                                                      MouseEnter="OnTimeEntryBlockMouseEnter"
                                                                      MouseLeave="OnTimeEntyrBlockMouseLeave">
                                     <togglDesktop:TimelineTimeEntryBlock.Style>
@@ -208,8 +211,8 @@
                         </ItemsControl.ItemTemplate>
                         <ItemsControl.ItemContainerStyle>
                             <Style TargetType="ContentPresenter">
-                                <Setter Property="Canvas.Left" Value="{Binding HorizontalOffset}" />
-                                <Setter Property="Canvas.Top" Value="{Binding VerticalOffset}" />
+                                <Setter Property="Canvas.Left" Value="{Binding Value.HorizontalOffset}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Value.VerticalOffset}" />
                             </Style>
                         </ItemsControl.ItemContainerStyle>
                     </ItemsControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -107,5 +107,34 @@ namespace TogglDesktop
             }
         }
 
+        private double? _dragStartedPoint;
+        private string _timeEntryId;
+        private void OnTimeEntryCanvasMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            _dragStartedPoint = e.GetPosition(TimeEntryBlocks).Y;
+            _timeEntryId = ViewModel.AddNewTimeEntry(_dragStartedPoint.Value);
+        }
+
+        private void OnTimeEntryCanvasMouseMove(object sender, MouseEventArgs e)
+        {
+            if (_dragStartedPoint != null && _timeEntryId != null && e.LeftButton == MouseButtonState.Pressed)
+            {
+                var verticalChange = Math.Abs(e.GetPosition(TimeEntryBlocks).Y - _dragStartedPoint.Value);
+                ViewModel.TimeEntryBlocks[_timeEntryId].VerticalOffset =
+                    Math.Min(_dragStartedPoint.Value, e.GetPosition(TimeEntryBlocks).Y);
+                ViewModel.TimeEntryBlocks[_timeEntryId].Height = verticalChange;
+            }
+        }
+
+        private void OnTimeEntryCanvasDragEnded(object sender, DragEventArgs e)
+        {
+            if (_timeEntryId != null)
+            {
+                ViewModel.TimeEntryBlocks[_timeEntryId].ChangeStartTime();
+                ViewModel.TimeEntryBlocks[_timeEntryId].ChangeEndTime();
+            }
+            _dragStartedPoint = null;
+            _timeEntryId = null;
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -111,6 +111,7 @@ namespace TogglDesktop
         private string _timeEntryId;
         private void OnTimeEntryCanvasMouseDown(object sender, MouseButtonEventArgs e)
         {
+            Mouse.Capture(sender as UIElement);
             _dragStartedPoint = e.GetPosition(TimeEntryBlocks).Y;
             _timeEntryId = ViewModel.AddNewTimeEntry(_dragStartedPoint.Value);
         }
@@ -126,7 +127,7 @@ namespace TogglDesktop
             }
         }
 
-        private void OnTimeEntryCanvasDragEnded(object sender, DragEventArgs e)
+        private void OnTimeEntryCanvasMouseUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             if (_timeEntryId != null)
             {
@@ -135,6 +136,7 @@ namespace TogglDesktop
             }
             _dragStartedPoint = null;
             _timeEntryId = null;
+            Mouse.Capture(null);
         }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -129,8 +129,12 @@ namespace TogglDesktop
 
         private void OnTimeEntryCanvasMouseUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            if (_timeEntryId != null)
+            if (_timeEntryId != null && _dragStartedPoint != null)
             {
+                if (Math.Abs(mouseButtonEventArgs.GetPosition(TimeEntryBlocks).Y - _dragStartedPoint.Value) <= 2)
+                {
+                    ViewModel.TimeEntryBlocks[_timeEntryId].Height = TimelineConstants.ScaleModes[ViewModel.SelectedScaleMode];
+                }
                 ViewModel.TimeEntryBlocks[_timeEntryId].ChangeStartTime();
                 ViewModel.TimeEntryBlocks[_timeEntryId].ChangeEndTime();
             }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -139,6 +139,7 @@ namespace TogglDesktop
                     ViewModel.TimeEntryBlocks[_timeEntryId].Height = TimelineConstants.ScaleModes[ViewModel.SelectedScaleMode];
                 }
                 ViewModel.TimeEntryBlocks[_timeEntryId].ChangeStartEndTime();
+                Toggl.Edit(_timeEntryId, false, Toggl.Description);
             }
             _dragStartedPoint = null;
             _timeEntryId = null;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -111,9 +111,12 @@ namespace TogglDesktop
         private string _timeEntryId;
         private void OnTimeEntryCanvasMouseDown(object sender, MouseButtonEventArgs e)
         {
-            Mouse.Capture(sender as UIElement);
-            _dragStartedPoint = e.GetPosition(TimeEntryBlocks).Y;
-            _timeEntryId = ViewModel.AddNewTimeEntry(_dragStartedPoint.Value, 0);
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                Mouse.Capture(sender as UIElement);
+                _dragStartedPoint = e.GetPosition(TimeEntryBlocks).Y;
+                _timeEntryId = TimelineViewModel.AddNewTimeEntry(_dragStartedPoint.Value, 0, ViewModel.SelectedScaleMode, ViewModel.SelectedDate);
+            }
         }
 
         private void OnTimeEntryCanvasMouseMove(object sender, MouseEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -113,7 +113,7 @@ namespace TogglDesktop
         {
             Mouse.Capture(sender as UIElement);
             _dragStartedPoint = e.GetPosition(TimeEntryBlocks).Y;
-            _timeEntryId = ViewModel.AddNewTimeEntry(_dragStartedPoint.Value);
+            _timeEntryId = ViewModel.AddNewTimeEntry(_dragStartedPoint.Value, 0);
         }
 
         private void OnTimeEntryCanvasMouseMove(object sender, MouseEventArgs e)
@@ -135,8 +135,7 @@ namespace TogglDesktop
                 {
                     ViewModel.TimeEntryBlocks[_timeEntryId].Height = TimelineConstants.ScaleModes[ViewModel.SelectedScaleMode];
                 }
-                ViewModel.TimeEntryBlocks[_timeEntryId].ChangeStartTime();
-                ViewModel.TimeEntryBlocks[_timeEntryId].ChangeEndTime();
+                ViewModel.TimeEntryBlocks[_timeEntryId].ChangeStartEndTime();
             }
             _dragStartedPoint = null;
             _timeEntryId = null;


### PR DESCRIPTION
### 📒 Description
- Clicking the Timeline view (or dragging for less than 2 px) creates a time entry with a duration of 1hr.
- Clicking and dragging on Timeline view creates a TE, whose start and end corresponds to dragged distance and offset.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
 - **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4621 
Closes #4622 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

