### PR TITLE
Implement date control on duration dropdown (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Calendar/Date+Utils.swift
+++ b/src/ui/osx/TogglDesktop/Features/Calendar/Date+Utils.swift
@@ -53,4 +53,15 @@ extension Date {
         let between = Calendar.current.dateComponents([.month], from: self, to: endDate)
         return between.month ?? 0
     }
+
+    static func combine(dayFrom dayDate: Date, withTimeFrom timeDate: Date) -> Date? {
+        let dayComponents = Calendar.current.dateComponents([.year, .month, .day], from: dayDate)
+        let timeComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: timeDate)
+
+        guard let day = Calendar.current.date(from: dayComponents) else {
+            return nil
+        }
+
+        return Calendar.current.date(byAdding: timeComponents, to: day)
+    }
 }

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -143,10 +143,11 @@ class TimerViewController: NSViewController {
             }
         }
 
-        viewModel.onStartTimeChanged = { [unowned self] startTime in
-            if self.durationControl.startTimeStringValue != startTime {
-                self.durationControl.startTimeStringValue = startTime
+        viewModel.onStartTimeChanged = { [unowned self] startTimeString, startDate in
+            if self.durationControl.startTimeStringValue != startTimeString {
+                self.durationControl.startTimeStringValue = startTimeString
             }
+            self.durationControl.startDateValue = startDate
         }
 
         viewModel.onTagSelected = { [unowned self] isSelected in
@@ -424,6 +425,10 @@ class TimerViewController: NSViewController {
 
         durationControl.onStartTextChange = { [unowned self] text in
             self.viewModel.setStartTime(text)
+        }
+
+        durationControl.onStartDateChange = { [unowned self] startDate in
+            self.viewModel.setStartDate(startDate)
         }
 
         durationControl.onPerformAction = { [unowned self] action in

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
@@ -11,6 +11,7 @@ import Cocoa
 class TimeEditView: NSView {
 
     var onStartTextChange: ((String) -> Void)?
+    var onStartDateChange: ((Date) -> Void)?
 
     var startStringValue: String {
         get {
@@ -22,19 +23,140 @@ class TimeEditView: NSView {
         }
     }
 
+    var startDateValue: Date {
+        get {
+            dateValue
+        }
+        set {
+            update(with: newValue)
+        }
+    }
+
+    private var dateValue: Date = Date() {
+        didSet {
+            if dateValue > Date() {
+                dateValue = Date()
+            }
+            update(with: dateValue)
+            onStartDateChange?(dateValue)
+        }
+    }
+
     private var isStartFieldChanged = false
 
+    private var isCalendarVisible: Bool {
+        calendarView.superview != nil && !calendarView.isHidden
+    }
+
+    private enum Constants {
+        static let dayNameAttribute: [NSAttributedString.Key: Any] = {
+            return [NSAttributedString.Key.font: NSFont.systemFont(ofSize: 14),
+                    NSAttributedString.Key.foregroundColor: NSColor.togglBlackText]
+        }()
+
+        static let calendarTopPadding: CGFloat = 8
+    }
+
+    // MARK: - Views
+
+    @IBOutlet private weak var contentView: NSView!
     @IBOutlet private weak var startTextField: NSTextField!
+    @IBOutlet private weak var todayButton: CursorButton!
+    @IBOutlet private weak var datePicker: KeyboardDatePicker!
+    @IBOutlet private weak var dateBox: NSBox!
+
+    @IBOutlet private weak var dateBoxBottomConstraint: NSLayoutConstraint!
+    private var bottomCalendarConstraint: NSLayoutConstraint!
+
+    private var calendarView: NSView { calendarViewControler.view }
+
+    private lazy var calendarViewControler: CalendarViewController = {
+        let controller = CalendarViewController(nibName: NSNib.Name("CalendarViewController"), bundle: nil)
+        controller.delegate = self
+        return controller
+    }()
+
+    // MARK: - Overrides
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        dateValue = Date()
+    }
 
     override func becomeFirstResponder() -> Bool {
         startTextField.becomeFirstResponder()
     }
+
+    // MARK: - Actions
+
+    @IBAction func previousDayButtonClicked(_ sender: Any) {
+        dateValue = dateValue.previousDate() ?? dateValue
+    }
+
+    @IBAction func nextDayButtonClicked(_ sender: Any) {
+        dateValue = dateValue.nextDate() ?? dateValue
+    }
+
+    @IBAction func datePickerChanged(_ sender: Any) {
+        dateValue = datePicker.dateValue
+    }
+
+    @IBAction func todayButtonClicked(_ sender: Any) {
+        isCalendarVisible ? hideCalendar() : showCalendar()
+    }
+
+    // MARK: - Private
+
+    private func update(with date: Date) {
+        todayButton.attributedTitle = NSAttributedString(
+            string: date.dayOfWeekString() ?? "Unknown",
+            attributes: Constants.dayNameAttribute
+        )
+        calendarViewControler.prepareLayout(with: date)
+        datePicker.dateValue = date
+        datePicker.maxDate = Date()
+    }
+
+    private func showCalendar() {
+        if calendarView.superview == nil {
+            addCalendarSubview()
+        }
+
+        dateBoxBottomConstraint.priority = .defaultHigh
+        bottomCalendarConstraint.priority = .required
+        calendarView.isHidden = false
+        window?.setContentSize(frame.size)
+    }
+
+    private func hideCalendar() {
+        bottomCalendarConstraint.priority = .defaultHigh
+        dateBoxBottomConstraint.priority = .required
+        calendarView.isHidden = true
+        window?.setContentSize(frame.size)
+    }
+
+    private func addCalendarSubview() {
+        calendarView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(calendarView)
+
+        bottomCalendarConstraint = calendarView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+
+        NSLayoutConstraint.activate([
+            calendarView.topAnchor.constraint(equalTo: dateBox.bottomAnchor, constant: Constants.calendarTopPadding),
+            bottomCalendarConstraint,
+            calendarView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            calendarView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+    }
 }
+
+// MARK: - NSTextFieldDelegate
 
 extension TimeEditView: NSTextFieldDelegate {
     func controlTextDidEndEditing(_ obj: Notification) {
         if obj.object as? NSTextField == startTextField, isStartFieldChanged {
             onStartTextChange?(startStringValue)
+            isStartFieldChanged = false
         }
     }
 
@@ -50,5 +172,18 @@ extension TimeEditView: NSTextFieldDelegate {
                 window?.orderOut(nil)
         }
         return false
+    }
+}
+
+// MARK: - CalendarViewControllerDelegate
+
+extension TimeEditView: CalendarViewControllerDelegate {
+
+    func calendarViewControllerDidSelect(date: Date) {
+        dateValue = date
+    }
+
+    func calendarViewControllerDoneBtnOnTap() {
+        hideCalendar()
     }
 }

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.xib
@@ -21,7 +21,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="sVF-vD-5lX" userLabel="Time Field Container">
-                                <rect key="frame" x="16" y="84" width="96" height="50"/>
+                                <rect key="frame" x="12" y="84" width="96" height="50"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4Mk-Mx-TIX">
                                         <rect key="frame" x="-2" y="34" width="46" height="16"/>
@@ -79,7 +79,7 @@
                                 </constraints>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="A6g-th-xyB" userLabel="Time Field Container">
-                                <rect key="frame" x="142" y="84" width="96" height="50"/>
+                                <rect key="frame" x="146" y="84" width="96" height="50"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WgJ-O7-ngF">
                                         <rect key="frame" x="-2" y="34" width="31" height="16"/>
@@ -134,23 +134,23 @@
                                 </constraints>
                             </customView>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2oP-p3-wSn">
-                                <rect key="frame" x="112" y="96" width="30" height="7"/>
+                                <rect key="frame" x="108" y="96" width="38" height="7"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" image="duration-arrow" id="Qf1-j8-mKi"/>
                             </imageView>
                             <box boxType="custom" cornerRadius="8" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="0wY-G9-sKx">
-                                <rect key="frame" x="16" y="16" width="222" height="30"/>
+                                <rect key="frame" x="12" y="16" width="230" height="30"/>
                                 <view key="contentView" id="JHb-Vf-cnk">
-                                    <rect key="frame" x="1" y="1" width="220" height="28"/>
+                                    <rect key="frame" x="1" y="1" width="228" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box boxType="custom" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="YSn-xx-d8B">
-                                            <rect key="frame" x="30" y="-1" width="160" height="30"/>
+                                            <rect key="frame" x="30" y="-1" width="168" height="30"/>
                                             <view key="contentView" id="t9F-eI-yHh">
-                                                <rect key="frame" x="1" y="1" width="158" height="28"/>
+                                                <rect key="frame" x="1" y="1" width="166" height="28"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <stackView distribution="equalSpacing" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vJ4-Ci-Cmv">
-                                                        <rect key="frame" x="6" y="3" width="146" height="25"/>
+                                                        <rect key="frame" x="10" y="3" width="146" height="25"/>
                                                         <subviews>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lIP-dg-XbA" customClass="CursorButton" customModule="Toggl_Track" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="4" width="61" height="17"/>
@@ -159,6 +159,9 @@
                                                                     <font key="font" metaFont="menu" size="14"/>
                                                                 </buttonCell>
                                                                 <color key="contentTintColor" name="black-text-color"/>
+                                                                <connections>
+                                                                    <action selector="todayButtonClicked:" target="c22-O7-iKe" id="0C7-0W-PM0"/>
+                                                                </connections>
                                                             </button>
                                                             <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IcL-re-HKO" customClass="KeyboardDatePicker" customModule="Toggl_Track" customModuleProvider="target">
                                                                 <rect key="frame" x="61" y="0.0" width="85" height="25"/>
@@ -173,6 +176,9 @@
                                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="textColor" name="black-text-color"/>
                                                                 </datePickerCell>
+                                                                <connections>
+                                                                    <action selector="datePickerChanged:" target="c22-O7-iKe" id="4Jy-yg-wNT"/>
+                                                                </connections>
                                                             </datePicker>
                                                         </subviews>
                                                         <visibilityPriorities>
@@ -193,19 +199,25 @@
                                             <color key="borderColor" name="upload-border-color"/>
                                             <color key="fillColor" name="editor-background-color"/>
                                         </box>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fu1-wD-m4F">
-                                            <rect key="frame" x="190" y="0.0" width="30" height="28"/>
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fu1-wD-m4F" userLabel="Next Day Button">
+                                            <rect key="frame" x="198" y="0.0" width="30" height="28"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="next_date_arrow" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="qXM-vH-7PF">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
+                                            <connections>
+                                                <action selector="nextDayButtonClicked:" target="c22-O7-iKe" id="kik-i1-cxT"/>
+                                            </connections>
                                         </button>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dgD-Nq-pU2">
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dgD-Nq-pU2" userLabel="Prev Day Button">
                                             <rect key="frame" x="0.0" y="0.0" width="30" height="28"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="previous_date_arrow" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="xem-qX-mAF">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
+                                            <connections>
+                                                <action selector="previousDayButtonClicked:" target="c22-O7-iKe" id="A5y-UE-HuB"/>
+                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
@@ -230,7 +242,7 @@
                                 <color key="fillColor" name="editor-background-color"/>
                             </box>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fVo-LF-7n2">
-                                <rect key="frame" x="18" y="50" width="82" height="16"/>
+                                <rect key="frame" x="10" y="50" width="82" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="START DATE" id="Mor-IR-d0G">
                                     <font key="font" metaFont="systemMedium" size="13"/>
                                     <color key="textColor" name="grey-text-color"/>
@@ -242,15 +254,16 @@
                             <constraint firstItem="2oP-p3-wSn" firstAttribute="leading" secondItem="sVF-vD-5lX" secondAttribute="trailing" id="1Fo-ha-7pj"/>
                             <constraint firstItem="sVF-vD-5lX" firstAttribute="top" secondItem="SIL-am-mKQ" secondAttribute="top" constant="12" id="3y7-d3-e0A"/>
                             <constraint firstItem="2oP-p3-wSn" firstAttribute="centerY" secondItem="7f9-Da-ISN" secondAttribute="centerY" id="B1R-h3-Xap"/>
-                            <constraint firstAttribute="bottom" secondItem="0wY-G9-sKx" secondAttribute="bottom" constant="16" id="CHj-hN-VfY"/>
-                            <constraint firstItem="sVF-vD-5lX" firstAttribute="leading" secondItem="SIL-am-mKQ" secondAttribute="leading" constant="16" id="DKb-63-DoX"/>
+                            <constraint firstAttribute="bottom" secondItem="0wY-G9-sKx" secondAttribute="bottom" priority="750" constant="16" id="CHj-hN-VfY"/>
+                            <constraint firstItem="sVF-vD-5lX" firstAttribute="leading" secondItem="SIL-am-mKQ" secondAttribute="leading" constant="12" id="DKb-63-DoX"/>
                             <constraint firstItem="A6g-th-xyB" firstAttribute="top" secondItem="SIL-am-mKQ" secondAttribute="top" constant="12" id="ESQ-gk-2TR"/>
-                            <constraint firstItem="0wY-G9-sKx" firstAttribute="leading" secondItem="SIL-am-mKQ" secondAttribute="leading" constant="16" id="HaX-A8-yWI"/>
-                            <constraint firstAttribute="trailing" secondItem="A6g-th-xyB" secondAttribute="trailing" constant="16" id="M1m-V0-5xr"/>
+                            <constraint firstItem="0wY-G9-sKx" firstAttribute="leading" secondItem="SIL-am-mKQ" secondAttribute="leading" constant="12" id="HaX-A8-yWI"/>
+                            <constraint firstAttribute="trailing" secondItem="A6g-th-xyB" secondAttribute="trailing" constant="12" id="M1m-V0-5xr"/>
                             <constraint firstItem="0wY-G9-sKx" firstAttribute="top" secondItem="fVo-LF-7n2" secondAttribute="bottom" constant="4" id="X1k-HC-b28"/>
-                            <constraint firstAttribute="trailing" secondItem="0wY-G9-sKx" secondAttribute="trailing" constant="16" id="XlI-JU-mMb"/>
+                            <constraint firstAttribute="trailing" secondItem="0wY-G9-sKx" secondAttribute="trailing" constant="12" id="XlI-JU-mMb"/>
                             <constraint firstItem="A6g-th-xyB" firstAttribute="leading" secondItem="2oP-p3-wSn" secondAttribute="trailing" id="c4h-lh-QRI"/>
-                            <constraint firstItem="fVo-LF-7n2" firstAttribute="leading" secondItem="SIL-am-mKQ" secondAttribute="leading" constant="20" symbolic="YES" id="fXR-2z-j2S"/>
+                            <constraint firstItem="fVo-LF-7n2" firstAttribute="top" secondItem="sVF-vD-5lX" secondAttribute="bottom" constant="18" id="d7O-aZ-MKT"/>
+                            <constraint firstItem="fVo-LF-7n2" firstAttribute="leading" secondItem="SIL-am-mKQ" secondAttribute="leading" constant="12" id="fXR-2z-j2S"/>
                         </constraints>
                     </view>
                     <color key="borderColor" name="color-project-btn-border-color"/>
@@ -264,8 +277,13 @@
                 <constraint firstAttribute="bottom" secondItem="GfM-qi-LYd" secondAttribute="bottom" id="ttE-uW-vxv"/>
             </constraints>
             <connections>
+                <outlet property="contentView" destination="SIL-am-mKQ" id="eCI-aQ-GsB"/>
+                <outlet property="dateBox" destination="0wY-G9-sKx" id="8CJ-gg-ITS"/>
+                <outlet property="dateBoxBottomConstraint" destination="CHj-hN-VfY" id="Bnn-Po-yQs"/>
+                <outlet property="datePicker" destination="IcL-re-HKO" id="RaD-mg-rBd"/>
                 <outlet property="nextKeyView" destination="GzC-fm-PNM" id="SB2-Ha-1tt"/>
                 <outlet property="startTextField" destination="GzC-fm-PNM" id="btD-Qh-cLd"/>
+                <outlet property="todayButton" destination="lIP-dg-XbA" id="F8g-bO-cTw"/>
             </connections>
             <point key="canvasLocation" x="-172" y="154"/>
         </customView>

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimerDurationControl.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimerDurationControl.swift
@@ -11,9 +11,16 @@ import Foundation
 class TimerDurationControl: NSView {
 
     var onDurationTextChange: ((String) -> Void)?
+
     var onStartTextChange: ((String) -> Void)? {
         didSet {
             timeEditView.onStartTextChange = onStartTextChange
+        }
+    }
+
+    var onStartDateChange: ((Date) -> Void)? {
+        didSet {
+            timeEditView.onStartDateChange = onStartDateChange
         }
     }
 
@@ -28,6 +35,11 @@ class TimerDurationControl: NSView {
     var startTimeStringValue: String {
         get { timeEditView.startStringValue }
         set { timeEditView.startStringValue = newValue }
+    }
+
+    var startDateValue: Date {
+        get { timeEditView.startDateValue }
+        set { timeEditView.startDateValue = newValue }
     }
 
     var isEditing: Bool {
@@ -96,6 +108,7 @@ class TimerDurationControl: NSView {
         }
 
         timeEditView.onStartTextChange = onStartTextChange
+        timeEditView.onStartDateChange = onStartDateChange
 
         notificationObserverToken = NotificationCenter.default.addObserver(
             forName: NSWindow.didResignKeyNotification,


### PR DESCRIPTION
### 📒 Description
Adds working date control to duration dropdown along with an embedded calendar.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4611

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Duration dropdown is hidden under local feature flag. To enable it go to `TimerDurationControl.swift` line 28 and set `isDurationDropdownEnabled` to `true`
