### PR TITLE
Track usage analytics of duration dropdown (mac)

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -461,4 +461,20 @@ void Analytics::TrackTimerShortcut(const std::string &client_id, const TimerShor
     Track(client_id, category, action_str);
 }
 
+void Analytics::TrackDurationDropdown(const std::string &client_id, const DurationDropdownActionType action) {
+    std::string category = "timer-duration-dropdown";
+    std::string action_str = "";
+
+    switch (action) {
+        case DurationDropdownActionTypeStartTimeChange:
+            action_str = "start-time-change";
+            break;
+        case DurationDropdownActionTypeDateChange:
+            action_str = "date-change";
+            break;
+    }
+
+    Track(client_id, category, action_str);
+}
+
 }  // namespace toggl

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -97,6 +97,7 @@ class Analytics : public Poco::TaskManager {
     void TrackTimerStart(const std::string &client_id, const TimerEditActionType actions);
 
     void TrackTimerShortcut(const std::string &client_id, const TimerShortcutActionType action);
+    void TrackDurationDropdown(const std::string &client_id, const DurationDropdownActionType action);
 
     void TrackTimelineResizing(const std::string& client_id, const std::string& os);
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -6921,6 +6921,12 @@ void Context::TrackTimerShortcut(TimerShortcutActionType action) {
     }
 }
 
+void Context::TrackDurationDropdown(DurationDropdownActionType action) {
+    if ("production" == environment_) {
+        analytics_.TrackDurationDropdown(db_->AnalyticsClientID(), action);
+    }
+}
+
 error Context::UpdateTimeEntry(
     const std::string &GUID,
     const std::string &description,

--- a/src/context.h
+++ b/src/context.h
@@ -586,6 +586,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     void TrackTimerEdit(TimerEditActionType action);
     void TrackTimerStart(TimerEditActionType actions);
     void TrackTimerShortcut(TimerShortcutActionType action);
+    void TrackDurationDropdown(DurationDropdownActionType action);
 
     // Onboarding action
     void UserDidClickOnTimelineTab();

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1696,6 +1696,16 @@ void track_timer_shortcut(
     app(context)->TrackTimerShortcut(action);
 }
 
+void track_duration_dropdown(
+     void *context,
+     DurationDropdownActionType action) {
+
+     if (!context) {
+         return;
+     }
+     app(context)->TrackDurationDropdown(action);
+ }
+
 bool_t toggl_update_time_entry(
     void *context,
     const char_t *guid,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -262,7 +262,12 @@ extern "C" {
         TimerShortcutActionTypeTagCreated
     } TimerShortcutActionType;
 
-typedef enum {
+    typedef enum {
+        DurationDropdownActionTypeStartTimeChange,
+        DurationDropdownActionTypeDateChange
+    } DurationDropdownActionType;
+
+    typedef enum {
         TogglServerStaging = 0,
         TogglServerProduction
     } TogglServerType;
@@ -1316,6 +1321,10 @@ typedef enum {
     TOGGL_EXPORT void track_timer_shortcut(
         void *context,
         TimerShortcutActionType action);
+
+    TOGGL_EXPORT void track_duration_dropdown(
+        void *context,
+        DurationDropdownActionType action);
 
     TOGGL_EXPORT bool_t toggl_update_time_entry(
         void *context,

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
@@ -39,6 +39,7 @@ class TimeEditView: NSView {
             }
             update(with: dateValue)
             onStartDateChange?(dateValue)
+            DesktopLibraryBridge.shared().trackDurationDropdown(DurationDropdownActionTypeDateChange)
         }
     }
 
@@ -156,6 +157,7 @@ extension TimeEditView: NSTextFieldDelegate {
     func controlTextDidEndEditing(_ obj: Notification) {
         if obj.object as? NSTextField == startTextField, isStartFieldChanged {
             onStartTextChange?(startStringValue)
+            DesktopLibraryBridge.shared().trackDurationDropdown(DurationDropdownActionTypeStartTimeChange)
             isStartFieldChanged = false
         }
     }

--- a/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.h
@@ -143,6 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)trackTimerEditUsingAction:(TimerEditActionType)action;
 - (void)trackTimerStartUsingActions:(TimerEditActionType)actions;
 - (void)trackTimerShortcut:(TimerShortcutActionType)action;
+- (void)trackDurationDropdown:(DurationDropdownActionType)action;
 
 #pragma mark - General
 

--- a/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/TogglDesktopLibrary/DesktopLibraryBridge.m
@@ -517,6 +517,11 @@ void *ctx;
     track_timer_shortcut(ctx, action);
 }
 
+- (void)trackDurationDropdown:(DurationDropdownActionType)action
+{
+    track_duration_dropdown(ctx, action);
+}
+
 #pragma mark - General
 
 - (uint64_t)defaultWorkspaceID


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Adds the analytics to track if users use the start time field and date controls.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4612 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
To test enable duration dropdown. It's hidden under the local feature flag. To enable it go to `TimerDurationControl.swift` line 28 and set `isDurationDropdownEnabled` to `true`.
Also, enable analytics in debug mode.
