### PR TITLE
Update keyboard navigation inside duration dropdown (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Features/AutoComplete/GenericAutoComplete/AutoCompleteView.swift
@@ -197,7 +197,7 @@ extension AutoCompleteView {
             self?.dataSource?.selectRow(at: clickedRow)
         }
 
-        createNewItemBtn.didPressKey = { key in
+        createNewItemBtn.didPressKey = { key, _ in
             if key == .tab {
                 self.delegate?.shouldClose()
             }

--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/Views/CursorButton.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/Views/CursorButton.swift
@@ -11,7 +11,7 @@ import Foundation
 class CursorButton: NSButton {
 
     // MARK: - Variable
-    var didPressKey: ((Key) -> Void)?
+    var didPressKey: ((Key, NSEvent.ModifierFlags) -> Void)?
     var cursor: NSCursor? {
         didSet {
             resetCursorRects()
@@ -29,7 +29,7 @@ class CursorButton: NSButton {
     override func keyDown(with event: NSEvent) {
         super.keyDown(with: event)
         if let key = Key(rawValue: Int(event.keyCode)) {
-            didPressKey?(key)
+            didPressKey?(key, event.modifierFlags)
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
@@ -64,6 +64,8 @@ class TimeEditView: NSView {
     @IBOutlet private weak var startTextField: NSTextField!
     @IBOutlet private weak var todayButton: CursorButton!
     @IBOutlet private weak var datePicker: KeyboardDatePicker!
+    @IBOutlet private weak var prevDayButton: CursorButton!
+    @IBOutlet private weak var nextDayButton: CursorButton!
     @IBOutlet private weak var dateBox: NSBox!
 
     @IBOutlet private weak var dateBoxBottomConstraint: NSLayoutConstraint!
@@ -82,10 +84,25 @@ class TimeEditView: NSView {
     override func awakeFromNib() {
         super.awakeFromNib()
         dateValue = Date()
+
+        // nextDayButton is the last control in key view loop
+        nextDayButton.didPressKey = { [weak self] key, modifiers in
+            if key == .tab && !modifiers.contains(.shift) {
+                self?.hideWindow()
+            }
+        }
     }
 
     override func becomeFirstResponder() -> Bool {
         startTextField.becomeFirstResponder()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if let key = Key(rawValue: Int(event.keyCode)), key == .escape {
+            hideWindow()
+            return
+        }
+        super.keyDown(with: event)
     }
 
     // MARK: - Actions
@@ -116,6 +133,10 @@ class TimeEditView: NSView {
         calendarViewControler.prepareLayout(with: date)
         datePicker.dateValue = date
         datePicker.maxDate = Date()
+    }
+
+    private func hideWindow() {
+        window?.orderOut(nil)
     }
 
     private func showCalendar() {
@@ -167,12 +188,19 @@ extension TimeEditView: NSTextFieldDelegate {
     }
 
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-        if commandSelector == #selector(insertTab(_:))
-            || commandSelector == #selector(insertBacktab(_:))
-            || commandSelector == #selector(cancelOperation(_:))
-            || commandSelector == #selector(insertNewline(_:)) {
-                window?.orderOut(nil)
+        if commandSelector == #selector(cancelOperation(_:))
+            || commandSelector == #selector(insertNewline(_:))
+            || commandSelector == #selector(insertBacktab(_:)) {
+
+            hideWindow()
         }
+
+        if NSApplication.shared.isFullKeyboardAccessEnabled == false {
+            if commandSelector == #selector(insertTab(_:)) {
+                hideWindow()
+            }
+        }
+
         return false
     }
 }

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.xib
@@ -154,7 +154,7 @@
                                                         <subviews>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lIP-dg-XbA" customClass="CursorButton" customModule="Toggl_Track" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="4" width="61" height="17"/>
-                                                                <buttonCell key="cell" type="bevel" title="Tuesday," bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="0ZN-i2-ud9">
+                                                                <buttonCell key="cell" type="bevel" title="Tuesday," bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="0ZN-i2-ud9">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="menu" size="14"/>
                                                                 </buttonCell>
@@ -168,10 +168,10 @@
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="AFn-jk-hjv"/>
                                                                 </constraints>
-                                                                <datePickerCell key="cell" alignment="left" drawsBackground="NO" datePickerStyle="textField" id="ofN-Zc-xLU">
+                                                                <datePickerCell key="cell" refusesFirstResponder="YES" alignment="left" drawsBackground="NO" datePickerStyle="textField" useCurrentDate="YES" id="ofN-Zc-xLU">
                                                                     <font key="font" metaFont="system" size="14"/>
-                                                                    <date key="date" timeIntervalSinceReferenceDate="-569750400">
-                                                                        <!--1982-12-12 16:00:00 +0000-->
+                                                                    <date key="date" timeIntervalSinceReferenceDate="626269538.47442997">
+                                                                        <!--2020-11-05 11:45:38 +0000-->
                                                                     </date>
                                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="textColor" name="black-text-color"/>
@@ -199,7 +199,7 @@
                                             <color key="borderColor" name="upload-border-color"/>
                                             <color key="fillColor" name="editor-background-color"/>
                                         </box>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fu1-wD-m4F" userLabel="Next Day Button">
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fu1-wD-m4F" userLabel="Next Day Button" customClass="CursorButton" customModule="Toggl_Track" customModuleProvider="target">
                                             <rect key="frame" x="198" y="0.0" width="30" height="28"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="next_date_arrow" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="qXM-vH-7PF">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -209,7 +209,7 @@
                                                 <action selector="nextDayButtonClicked:" target="c22-O7-iKe" id="kik-i1-cxT"/>
                                             </connections>
                                         </button>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dgD-Nq-pU2" userLabel="Prev Day Button">
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dgD-Nq-pU2" userLabel="Prev Day Button" customClass="CursorButton" customModule="Toggl_Track" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="30" height="28"/>
                                             <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="previous_date_arrow" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="xem-qX-mAF">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -281,7 +281,9 @@
                 <outlet property="dateBox" destination="0wY-G9-sKx" id="8CJ-gg-ITS"/>
                 <outlet property="dateBoxBottomConstraint" destination="CHj-hN-VfY" id="Bnn-Po-yQs"/>
                 <outlet property="datePicker" destination="IcL-re-HKO" id="RaD-mg-rBd"/>
+                <outlet property="nextDayButton" destination="fu1-wD-m4F" id="eMk-aU-q1g"/>
                 <outlet property="nextKeyView" destination="GzC-fm-PNM" id="SB2-Ha-1tt"/>
+                <outlet property="prevDayButton" destination="dgD-Nq-pU2" id="jXO-Sc-ZX7"/>
                 <outlet property="startTextField" destination="GzC-fm-PNM" id="btD-Qh-cLd"/>
                 <outlet property="todayButton" destination="lIP-dg-XbA" id="F8g-bO-cTw"/>
             </connections>


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
This PR aims to improve keyboard navigation on duration dropdown.
We need to discuss what is the best way to do that.

Note that this PR works differently from what is described in Issue #4610.

On macOS there is an option in system Preferences:
<img width="780" alt="Screenshot 2020-11-05 at 17 38 24" src="https://user-images.githubusercontent.com/3470113/98535053-25371780-228e-11eb-91f0-6444e2c4c886.png">

In the app we check if option is enabled:
- Yes (keyboard navigation is extended) - 
-> Opens dropdown
-> Tab -> move to Start
-> Tab -> Day control left arrow
-> Tab -> Date picker
-> Tab -> Right arrow
-> Tab -> Close dropdown
- No - 
-> Opens dropdown 
-> Tab -> move to Start 
-> Tab -> Close dropdown

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4610

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Duration dropdown is hidden under the local feature flag. To enable it go to TimerDurationControl.swift line 28 and set isDurationDropdownEnabled to true.

Tell me what do you think.
