### PR TITLE
Fix RunningTimeEntry is not set to null when stopped in other sources

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryFixture.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/LibraryFixture.cs
@@ -14,21 +14,17 @@ namespace TogglDesktop.Tests
 
         public string MeJson = File.ReadAllText("me.json");
 
+        private readonly IDisposable _runningTimerState;
+
         public LibraryFixture()
         {
             Toggl.Env = "test";
             Toggl.OnTimeEntryList += (open, list, button) => TimeEntries = list;
-            Toggl.RunningTimeEntry.Subscribe( te =>
+            _runningTimerState = Toggl.RunningTimeEntry.Subscribe( te =>
             {
-                if (te != null)
-                    RunningEntry = te.Value;
-                IsRunning = true;
+                RunningEntry = te ?? default;
+                IsRunning = te.HasValue;
             });
-            Toggl.OnStoppedTimerState += () =>
-            {
-                RunningEntry = default;
-                IsRunning = false;
-            };
             Assert.True(Toggl.StartUI("0.0.0"));
             Toggl.ClearCache();
             Toggl.SetManualMode(false);
@@ -36,6 +32,7 @@ namespace TogglDesktop.Tests
 
         public void Dispose()
         {
+            _runningTimerState.Dispose();
             Toggl.Clear();
         }
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
+using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -905,7 +906,6 @@ public static partial class Toggl
     public static event DisplayViewItems OnClientSelect = delegate { };
     public static event DisplayViewItems OnTags = delegate { };
     public static event DisplaySettings OnSettings = delegate { };
-    public static event DisplayStoppedTimerState OnStoppedTimerState = delegate { };
     public static event DisplayURL OnURL = delegate { };
     public static event DisplayIdleNotification OnIdleNotification = delegate { };
     public static event DisplayAutotrackerRules OnAutotrackerRules = delegate { };
@@ -930,6 +930,7 @@ public static partial class Toggl
     public static readonly BehaviorSubject<DateTime> TimelineSelectedDate = new BehaviorSubject<DateTime>(DateTime.Today);
 
     public static readonly BehaviorSubject<TogglTimeEntryView?> RunningTimeEntry = new BehaviorSubject<TogglTimeEntryView?>(null);
+    public static IObservable<Unit> StoppedTimerState = RunningTimeEntry.Where(te => te == null).Select(_ => new Unit());
     public static event DisplayTimelineUI OnDisplayTimelineUI = delegate { };
     private static void listenToLibEvents()
     {
@@ -1080,9 +1081,9 @@ public static partial class Toggl
         {
             if (te == IntPtr.Zero)
             {
-                using (Performance.Measure("Calling OnStoppedTimerState"))
+                using (Performance.Measure("Calling StoppedTimerState"))
                 {
-                    OnStoppedTimerState();
+                    RunningTimeEntry.OnNext(null);
                     return;
                 }
             }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -929,7 +929,7 @@ public static partial class Toggl
     public static readonly BehaviorSubject<DateTime> TimelineSelectedDate = new BehaviorSubject<DateTime>(DateTime.Today);
 
     public static readonly BehaviorSubject<TogglTimeEntryView?> RunningTimeEntry = new BehaviorSubject<TogglTimeEntryView?>(null);
-    public static IObservable<Unit> StoppedTimerState = RunningTimeEntry.Where(te => te == null).Select(_ => new Unit());
+    public static IObservable<Unit> StoppedTimerState = RunningTimeEntry.Where(te => te == null).Select(_ => Unit.Default);
     public static event DisplayTimelineUI OnDisplayTimelineUI = delegate { };
     private static void listenToLibEvents()
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -472,7 +472,6 @@ public static partial class Toggl
 
     public static bool Stop(bool preventOnApp = false)
     {
-        RunningTimeEntry.OnNext(null);
         return toggl_stop(ctx, preventOnApp);
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen4.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen4.xaml.cs
@@ -1,8 +1,12 @@
 ﻿
+using System;
+
 namespace TogglDesktop.Tutorial
 {
     public partial class BasicTutorialScreen4
     {
+        private IDisposable _timerStateObservable;
+
         public BasicTutorialScreen4()
         {
             this.InitializeComponent();
@@ -11,13 +15,13 @@ namespace TogglDesktop.Tutorial
         protected override void initialise()
         {
             Toggl.OnTimeEntryEditor += this.onTimeEntryEditor;
-            Toggl.OnStoppedTimerState += this.onStoppedTimerState;
+            _timerStateObservable = Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
         }
 
         protected override void cleanup()
         {
             Toggl.OnTimeEntryEditor -= this.onTimeEntryEditor;
-            Toggl.OnStoppedTimerState -= this.onStoppedTimerState;
+            _timerStateObservable.Dispose();
         }
 
         private void onTimeEntryEditor(bool open, Toggl.TogglTimeEntryView te, string focusedFieldName)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen5.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen5.xaml.cs
@@ -1,10 +1,13 @@
 ﻿
+using System;
 using System.Collections.Generic;
 
 namespace TogglDesktop.Tutorial
 {
     public partial class BasicTutorialScreen5
     {
+        private IDisposable _timerStateObservable;
+
         public BasicTutorialScreen5()
         {
             this.InitializeComponent();
@@ -13,13 +16,13 @@ namespace TogglDesktop.Tutorial
         protected override void initialise()
         {
             Toggl.OnTimeEntryList += this.onTimeEntryList;
-            Toggl.OnStoppedTimerState += this.onStoppedTimerState;
+            _timerStateObservable = Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
         }
 
         protected override void cleanup()
         {
             Toggl.OnTimeEntryList -= this.onTimeEntryList;
-            Toggl.OnStoppedTimerState -= this.onStoppedTimerState;
+            _timerStateObservable.Dispose();
         }
 
         private void onTimeEntryList(bool open, List<Toggl.TogglTimeEntryView> list, bool showLoadMoreButton)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen6.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen6.xaml.cs
@@ -1,8 +1,12 @@
 ﻿
+using System;
+
 namespace TogglDesktop.Tutorial
 {
     public partial class BasicTutorialScreen6
     {
+        private IDisposable _timerStateObservable;
+
         public BasicTutorialScreen6()
         {
             this.InitializeComponent();
@@ -10,12 +14,12 @@ namespace TogglDesktop.Tutorial
 
         protected override void initialise()
         {
-            Toggl.OnStoppedTimerState += this.onStoppedTimerState;
+            _timerStateObservable = Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
         }
 
         protected override void cleanup()
         {
-            Toggl.OnStoppedTimerState -= this.onStoppedTimerState;
+            _timerStateObservable.Dispose();
         }
 
         private void onStoppedTimerState()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
@@ -28,7 +28,7 @@ namespace TogglDesktop.ui.ViewModels
             setupSecondsTimer();
 
             Toggl.RunningTimeEntry.Subscribe(onRunningTimerState);
-            Toggl.OnStoppedTimerState += onStoppedTimerState;
+            Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
 
             ResetRunningTimeEntry(false, true);
         }
@@ -107,7 +107,7 @@ namespace TogglDesktop.ui.ViewModels
 
         private void onStoppedTimerState()
         {
-            using (Performance.Measure("timer responding to OnStoppedTimerState"))
+            using (Performance.Measure("timer responding to StoppedTimerState"))
             {
                 secondsTimer.IsEnabled = false;
                 ResetRunningTimeEntry(false);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
@@ -16,7 +16,7 @@ namespace TogglDesktop
         {
             this.InitializeComponent();
             Toggl.OnIdleNotification += this.onIdleNotification;
-            Toggl.OnStoppedTimerState += this.onStoppedTimerState;
+            Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
         }
 
         private void onIdleNotification(string guid, string since, string duration, long started, string description)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -241,7 +241,7 @@ namespace TogglDesktop
             Toggl.OnURL += this.onURL;
             Toggl.OnUserTimeEntryStart += this.onUserTimeEntryStart;
             Toggl.RunningTimeEntry.Subscribe(this.onRunningTimerState);
-            Toggl.OnStoppedTimerState += this.onStoppedTimerState;
+            Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
             Toggl.OnSettings += this.onSettings;
             Toggl.OnDisplayInAppNotification += this.onDisplayInAppNotification;
         }


### PR DESCRIPTION
### 📒 Description
Fix RunningTimeEntry is not set to null when stopped in other sources

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4652 

### 🔎 Review hints
Testing:
1. Start TE and check it's started in timeline UI.
2. Stop TE in browser (or other clients) and check it's stopped in timeline UI.

