### PR TITLE
Remove the ability to open Edit popover for running entry from Timer

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.h
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.h
@@ -12,7 +12,7 @@
 
 @interface TimerEditViewController : NSViewController
 @property (weak) IBOutlet NSBoxClickable *manualBox;
-@property (weak) IBOutlet NSBoxClickable *mainBox;
+@property (weak) IBOutlet NSBox *mainBox;
 
 - (void)startButtonClicked;
 - (void)focusTimer;

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerEditViewController/TimerEditViewController.xib
@@ -99,7 +99,7 @@
                     </view>
                     <color key="fillColor" name="white-background-color"/>
                 </box>
-                <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Fga-BR-x8G" userLabel="timerBox" customClass="NSBoxClickable">
+                <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Fga-BR-x8G" userLabel="timerBox">
                     <rect key="frame" x="0.0" y="0.0" width="411" height="150"/>
                     <view key="contentView" id="gK5-Lo-ktx">
                         <rect key="frame" x="0.0" y="0.0" width="411" height="150"/>

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimerDurationControl.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimerDurationControl.swift
@@ -24,9 +24,6 @@ class TimerDurationControl: NSView {
         }
     }
 
-    /// Feature flag for duration dropdown. Set to `true` to test the current implementation.
-    var isDurationDropdownEnabled = false
-
     var durationStringValue: String {
         get { durationTextField.stringValue }
         set { durationTextField.stringValue = newValue }
@@ -128,10 +125,6 @@ class TimerDurationControl: NSView {
     // MARK: - Private
 
     private func presentDropdown() {
-        guard isDurationDropdownEnabled else {
-            return
-        }
-
         let windowRect = dropdownWindowRect(fromView: durationTextField, offset: Constants.dropdownOffset)
         dropdownWindow.setFrame(windowRect, display: false)
         dropdownWindow.setFrameTopLeftPoint(windowRect.origin)


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
We replace "clickable" box behind Timer UI with a non-clickable.

Because this PR closes the last Issue for duration dropdown, it also enables the local feature flag so it's available for everyone.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4619

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

