### PR TITLE
Add a setting for showing autotracker suggestion while timer is running

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -20,7 +20,7 @@
 #define kTimerStartInterval 10
 #define kTimelineSecondsToKeep 604800
 #define kWindowFocusThresholdSeconds 10
-#define kAutotrackerThresholdSeconds 5
+#define kAutotrackerThresholdSeconds 0
 #define kBetaChannelPercentage 25
 #define kTimelineChunkSeconds 900
 #define kEnterpriseInstall false

--- a/src/context.cc
+++ b/src/context.cc
@@ -4901,10 +4901,10 @@ error Context::StartAutotrackerEvent(const TimelineEvent &event) {
 
         TimeEntry* runningEntry = user_->RunningTimeEntry();
         if (runningEntry) {
-            // on Windows show suggestion also where there is a running entry (#3917)
-            if (POCO_OS_WINDOWS_NT != POCO_OS) {
-                return noError;
-            }
+            // TODO: on Windows show suggestion also where there is a running entry (#3917)
+            //if (POCO_OS_WINDOWS_NT != POCO_OS) {
+            return noError;
+            //}
         }
 
         AutotrackerRule *rule = user_->related.FindAutotrackerRule(event);

--- a/src/context.cc
+++ b/src/context.cc
@@ -2065,6 +2065,11 @@ error Context::SetSettingsStartAutotrackerWithoutSuggestions(const bool start_au
         db()->SetSettingsStartAutotrackerWithoutSuggestions(start_autotracker_without_suggestions));
 }
 
+error Context::SetSettingsStartAutotrackerWhileTimerIsRunning(const bool start_autotracker_while_timer_is_running) {
+    return applySettingsSaveResultToUI(
+        db()->SetSettingsStartAutotrackerWhileTimerIsRunning(start_autotracker_while_timer_is_running));
+}
+
 error Context::SetSettingsActiveTab(const uint8_t active_tab) {
     return applySettingsSaveResultToUI(
         db()->SetSettingsActiveTab(active_tab));

--- a/src/context.cc
+++ b/src/context.cc
@@ -4906,10 +4906,9 @@ error Context::StartAutotrackerEvent(const TimelineEvent &event) {
 
         TimeEntry* runningEntry = user_->RunningTimeEntry();
         if (runningEntry) {
-            // TODO: on Windows show suggestion also where there is a running entry (#3917)
-            //if (POCO_OS_WINDOWS_NT != POCO_OS) {
-            return noError;
-            //}
+            if (!settings_.start_autotracker_while_timer_is_running) {
+                return noError;
+            }
         }
 
         AutotrackerRule *rule = user_->related.FindAutotrackerRule(event);

--- a/src/context.h
+++ b/src/context.h
@@ -171,6 +171,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error SetSettingsStartAutotrackerWithoutSuggestions(const bool start_autotracker_without_suggestions);
 
+    error SetSettingsStartAutotrackerWhileTimerIsRunning(const bool start_autotracker_while_timer_is_running);
+
     error SetSettingsActiveTab(const uint8_t active_tab);
 
     error SetSettingsColorTheme(const uint8_t color_theme);

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -424,7 +424,7 @@ error Database::LoadSettings(Settings *settings) {
                   "open_editor_on_shortcut, has_seen_beta_offering, "
                   "pomodoro, pomodoro_minutes, "
                   "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep, show_touch_bar, active_tab, color_theme, "
-                  "force_ignore_cert, start_autotracker_without_suggestions "
+                  "force_ignore_cert, start_autotracker_without_suggestions, start_autotracker_while_timer_is_running "
                   "from settings "
                   "limit 1",
                   into(settings->use_idle_detection),
@@ -460,6 +460,7 @@ error Database::LoadSettings(Settings *settings) {
                   into(settings->color_theme),
                   into(settings->force_ignore_cert),
                   into(settings->start_autotracker_without_suggestions),
+                  into(settings->start_autotracker_while_timer_is_running),
                   limit(1),
                   now;
     } catch(const Poco::Exception& exc) {
@@ -857,6 +858,10 @@ error Database::SetSettingsShowTouchBar(const bool &show_touch_bar) {
 
 error Database::SetSettingsStartAutotrackerWithoutSuggestions(const bool &start_autotracker_without_suggestions) {
     return setSettingsValue("start_autotracker_without_suggestions", start_autotracker_without_suggestions);
+}
+
+error Database::SetSettingsStartAutotrackerWhileTimerIsRunning(const bool &start_autotracker_while_timer_is_running) {
+    return setSettingsValue("start_autotracker_while_timer_is_running", start_autotracker_while_timer_is_running);
 }
 
 error Database::SetSettingsActiveTab(const uint8_t &active_tab) {

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -129,6 +129,8 @@ class TOGGL_INTERNAL_EXPORT Database {
 
     error SetSettingsStartAutotrackerWithoutSuggestions(const bool &start_autotracker_without_suggestions);
 
+    error SetSettingsStartAutotrackerWhileTimerIsRunning(const bool &start_autotracker_while_timer_is_running);
+
     error SetSettingsActiveTab(const uint8_t &active_tab);
 
     error SetSettingsColorTheme(const uint8_t &color_theme);

--- a/src/database/migrations.cc
+++ b/src/database/migrations.cc
@@ -1420,6 +1420,14 @@ error Migrations::migrateSettings() {
         return err;
     }
 
+    err = db_->Migrate(
+        "settings.start_autotracker_while_timer_is_running",
+        "ALTER TABLE settings "
+        "ADD COLUMN start_autotracker_while_timer_is_running INTEGER NOT NULL DEFAULT 0;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/model/settings.cc
+++ b/src/model/settings.cc
@@ -38,6 +38,7 @@ Json::Value Settings::SaveToJSON(int) const {
     json["stop_entry_on_shutdown_sleep"] = stop_entry_on_shutdown_sleep;
     json["show_touch_bar"] = show_touch_bar;
     json["start_autotracker_without_suggestions"] = start_autotracker_without_suggestions;
+    json["start_autotracker_while_timer_is_running"] = start_autotracker_while_timer_is_running;
     json["active_tab"] = active_tab;
     json["color_theme"] = color_theme;
     json["force_ignore_cert"] = force_ignore_cert;
@@ -77,6 +78,7 @@ std::string Settings::String() const {
        << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep
        << " show_touch_bar=" << show_touch_bar
        << " start_autotracker_without_suggestions=" << start_autotracker_without_suggestions
+       << " start_autotracker_while_timer_is_running=" << start_autotracker_while_timer_is_running
        << " active_tab=" << active_tab
        << " color_theme=" << color_theme
        << " force_ignore_cert=" << force_ignore_cert;
@@ -115,6 +117,7 @@ bool Settings::IsSame(const Settings &other) const {
             && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep)
             && (show_touch_bar == other.show_touch_bar)
             && (start_autotracker_without_suggestions == other.start_autotracker_without_suggestions)
+            && (start_autotracker_while_timer_is_running == other.start_autotracker_while_timer_is_running)
             && (active_tab == other.active_tab)
             && (color_theme == other.color_theme)
             && (force_ignore_cert == other.force_ignore_cert));

--- a/src/model/settings.h
+++ b/src/model/settings.h
@@ -47,6 +47,7 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     , stop_entry_on_shutdown_sleep(false)
     , show_touch_bar(true)
     , start_autotracker_without_suggestions(false)
+    , start_autotracker_while_timer_is_running(false)
     , active_tab(0)
     , color_theme(0)
     , force_ignore_cert(false) {}
@@ -83,6 +84,7 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     bool stop_entry_on_shutdown_sleep;
     bool show_touch_bar;
     bool start_autotracker_without_suggestions;
+    bool start_autotracker_while_timer_is_running;
     Poco::UInt8 active_tab;
     Poco::UInt8 color_theme;
     bool force_ignore_cert;

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -183,6 +183,12 @@ bool_t toggl_set_settings_start_autotracker_without_suggestions(
     return toggl::noError == app(context)->SetSettingsStartAutotrackerWithoutSuggestions(start_autotracker_without_suggestions);
 }
 
+bool_t toggl_set_settings_start_autotracker_while_timer_is_running(
+    void* context,
+    const bool_t start_autotracker_while_timer_is_running) {
+    return toggl::noError == app(context)->SetSettingsStartAutotrackerWhileTimerIsRunning(start_autotracker_while_timer_is_running);
+}
+
 bool_t toggl_set_settings_active_tab(
     void *context,
     const uint8_t active_tab) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -193,6 +193,7 @@ extern "C" {
         bool_t StopEntryOnShutdownSleep;
         bool_t ShowTouchBar;
         bool_t StartAutotrackerWithoutSuggestions;
+        bool_t StartAutotrackerWhileTimerIsRunning;
         uint8_t ActiveTab;
         uint8_t ColorTheme;
         bool_t ForceIgnoreCert;
@@ -902,6 +903,10 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_set_settings_start_autotracker_without_suggestions(
         void *context,
         const bool_t start_autotracker_without_suggestions);
+
+    TOGGL_EXPORT bool_t toggl_set_settings_start_autotracker_while_timer_is_running(
+        void* context,
+        const bool_t start_autotracker_while_timer_is_running);
 
     TOGGL_EXPORT bool_t toggl_set_settings_active_tab(
         void *context,

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -491,6 +491,7 @@ TogglSettingsView *settings_view_item_init(
     view->StopEntryOnShutdownSleep = settings.stop_entry_on_shutdown_sleep;
     view->ShowTouchBar = settings.show_touch_bar;
     view->StartAutotrackerWithoutSuggestions = settings.start_autotracker_without_suggestions;
+    view->StartAutotrackerWhileTimerIsRunning = settings.start_autotracker_while_timer_is_running;
     view->ActiveTab = settings.active_tab;
     view->ColorTheme = settings.color_theme;
     view->ForceIgnoreCert = settings.force_ignore_cert;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -600,6 +600,11 @@ public static partial class Toggl
             return false;
         }
 
+        if (!toggl_set_settings_start_autotracker_while_timer_is_running(ctx, settings.StartAutotrackerWhileTimerIsRunning))
+        {
+            return false;
+        }
+
         return toggl_timeline_toggle_recording(ctx, settings.RecordTimeline);
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -315,6 +315,8 @@ public         bool StopEntryOnShutdownSleep;
 public         bool ShowTouchBar;
 [MarshalAs(UnmanagedType.I1)]
 public         bool StartAutotrackerWithoutSuggestions;
+[MarshalAs(UnmanagedType.I1)]
+public         bool StartAutotrackerWhileTimerIsRunning;
 public         byte ActiveTab;
 public         byte ColorTheme;
 [MarshalAs(UnmanagedType.I1)]
@@ -1367,6 +1369,13 @@ private static extern bool toggl_set_settings_start_autotracker_without_suggesti
         IntPtr context,
 [MarshalAs(UnmanagedType.I1)]
         bool start_autotracker_without_suggestions);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return: MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_start_autotracker_while_timer_is_running(
+        IntPtr context,
+[MarshalAs(UnmanagedType.I1)]
+        bool start_autotracker_while_timer_is_running);
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
 [return:MarshalAs(UnmanagedType.I1)]

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -340,9 +340,14 @@
                         <mah:ToggleSwitch Name="enableAutotrackerCheckbox" x:FieldModifier="private"
                                           Margin="0 14 0 0"/>
                     </StackPanel>
-                    <StackPanel Grid.Row="1" IsEnabled="{Binding ElementName=enableAutotrackerCheckbox, Path=IsChecked}">
+                    <StackPanel Grid.Row="1" IsEnabled="{Binding ElementName=enableAutotrackerCheckbox, Path=IsChecked}"
+                                Margin="0 30 0 0">
                         <TextBlock Style="{StaticResource Toggl.BodyText}"
-                                   Margin="0 30 0 0"
+                                   Text="Show suggestions also when the timer is running" />
+                        <mah:ToggleSwitch x:Name="showAutotrackerWhileTimerIsRunning" x:FieldModifier="private"
+                                          Margin="0 14 0 0" />
+                        <TextBlock Style="{StaticResource Toggl.BodyText}"
+                                   Margin="0 12 0 0"
                                    Text="Allow starting tracking automatically without showing the suggestion" />
                         <mah:ToggleSwitch x:Name="startTrackingWithoutSuggestionCheckbox" x:FieldModifier="private"
                                           Margin="0 14 0 0" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -154,6 +154,7 @@ namespace TogglDesktop
             #region auto tracker
 
             this.enableAutotrackerCheckbox.IsChecked = settings.Autotrack;
+            this.showAutotrackerWhileTimerIsRunning.IsChecked = settings.StartAutotrackerWhileTimerIsRunning;
             this.startTrackingWithoutSuggestionCheckbox.IsChecked = settings.StartAutotrackerWithoutSuggestions;
 
             #endregion
@@ -296,6 +297,7 @@ namespace TogglDesktop
                 #region auto tracker
 
                 Autotrack = isChecked(this.enableAutotrackerCheckbox),
+                StartAutotrackerWhileTimerIsRunning = isChecked(this.showAutotrackerWhileTimerIsRunning),
                 StartAutotrackerWithoutSuggestions = isChecked(this.startTrackingWithoutSuggestionCheckbox),
 
                 #endregion


### PR DESCRIPTION
### 📒 Description
Add a setting for showing autotracker suggestions while the timer is running (Library + Windows UI).
Removes the recently introduced 5sec delay not to break existing users' flow and to wait for a more comprehensive solution.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Add a new setting to the library
- [x] Add a new setting to the Windows UI
- [x] Remove the recently introduced 5-second delay before showing the autotracker suggestion

### 👫 Relationships
Closes #4605

### 🔎 Review hints
Test the Windows app with all combinations of autotracker settings.
Test the macOS app with all combinations of autotracker settings.