### PR TITLE
Fix "date change" analytics sending at app launch (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
@@ -81,9 +81,15 @@ class TimeEditView: NSView {
 
     // MARK: - Overrides
 
+    required init?(coder: NSCoder) {
+        dateValue = Date()
+        super.init(coder: coder)
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
-        dateValue = Date()
+
+        update(with: dateValue)
 
         // nextDayButton is the last control in key view loop
         nextDayButton.didPressKey = { [weak self] key, modifiers in


### PR DESCRIPTION
### 📒 Description
Assigning `dateValue` from `awakeFromNib()` would call `didSet` block of this property and as a result make a call to the analytics service.
Setting initial `dateValue` in `init` fixes this problem because `didSet` won't be called then.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4677

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
To test you can set breakpoint to `TimeEditView.swift` line 42 and observe when it's called.
