### PR TITLE
Include duration dropdown date controls into key loop for everyone (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/Views/CursorButton.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/Views/CursorButton.swift
@@ -32,4 +32,11 @@ class CursorButton: NSButton {
             didPressKey?(key, event.modifierFlags)
         }
     }
+
+    private var _canBecomeKeyView = false
+    override var canBecomeKeyView: Bool { _canBecomeKeyView }
+
+    func setCanBecomeKeyView(_ canBecome: Bool) {
+        _canBecomeKeyView = canBecome
+    }
 }

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/Views/TimeEditView.swift
@@ -64,8 +64,19 @@ class TimeEditView: NSView {
     @IBOutlet private weak var startTextField: NSTextField!
     @IBOutlet private weak var todayButton: CursorButton!
     @IBOutlet private weak var datePicker: KeyboardDatePicker!
-    @IBOutlet private weak var prevDayButton: CursorButton!
-    @IBOutlet private weak var nextDayButton: CursorButton!
+
+    @IBOutlet private weak var prevDayButton: CursorButton! {
+        didSet {
+            prevDayButton.setCanBecomeKeyView(true)
+        }
+    }
+
+    @IBOutlet private weak var nextDayButton: CursorButton! {
+        didSet {
+            nextDayButton.setCanBecomeKeyView(true)
+        }
+    }
+
     @IBOutlet private weak var dateBox: NSBox!
 
     @IBOutlet private weak var dateBoxBottomConstraint: NSLayoutConstraint!
@@ -208,12 +219,6 @@ extension TimeEditView: NSTextFieldDelegate {
             || commandSelector == #selector(insertBacktab(_:)) {
 
             hideWindow()
-        }
-
-        if NSApplication.shared.isFullKeyboardAccessEnabled == false {
-            if commandSelector == #selector(insertTab(_:)) {
-                hideWindow()
-            }
         }
 
         return false


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
On the Duration Dropdown the keyboard navigation now will work the same, regardless of "Use keyboard navigation" option in System Preferences.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4678

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

