### PR TITLE
Use environment files instead of set-env (actions)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,12 @@ jobs:
         echo $installer_name
 
         # Export env to all future steps
-        echo "::set-env name=TAG_NAME::$TAG_NAME"
-        echo "::set-env name=version::$version"
-        echo "::set-env name=timestamp::$timestamp"
-        echo "::set-env name=escaped_version::$escaped_version"
-        echo "::set-env name=installer::$installer"
-        echo "::set-env name=installer_name::$installer_name"
+        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+        echo "version=$version" >> $GITHUB_ENV
+        echo "timestamp=$timestamp" >> $GITHUB_ENV
+        echo "escaped_version=$escaped_version" >> $GITHUB_ENV
+        echo "installer=$installer" >> $GITHUB_ENV
+        echo "installer_name=$installer_name" >> $GITHUB_ENV
     - name: Setup Golang env
       if: github.event_name == 'release'
       uses: actions/setup-go@v1
@@ -132,12 +132,12 @@ jobs:
         echo $installer
         echo $installer_name
         # Export env to all future steps
-        echo "::set-env name=TAG_NAME::$TAG_NAME"
-        echo "::set-env name=version::$version"
-        echo "::set-env name=timestamp::$timestamp"
-        echo "::set-env name=escaped_version::$escaped_version"
-        echo "::set-env name=installer::$installer"
-        echo "::set-env name=installer_name::$installer_name"
+        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+        echo "version=$version" >> $GITHUB_ENV
+        echo "timestamp=$timestamp" >> $GITHUB_ENV
+        echo "escaped_version=$escaped_version" >> $GITHUB_ENV
+        echo "installer=$installer" >> $GITHUB_ENV
+        echo "installer_name=$installer_name" >> $GITHUB_ENV
     - name: Setup Golang env
       if: github.event_name == 'release'
       uses: actions/setup-go@v1


### PR DESCRIPTION
### 📒 Description
Use environment files instead of the deprecated `set-env` feature (actions).
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4516 

### 🔎 Review hints
Check the code and check that CI does not fail.
Environment variables are used in the macOS scripts, so check that the environment that is printed before each GitHub Actions step looks the same as in the previous successful runs. 
For example: ![image](https://user-images.githubusercontent.com/16451391/99372754-4c629a00-28c9-11eb-8bd1-c5c3d022bc87.png)

Docs: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files