### PR TITLE
Update macOS build settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ jobs:
   macos:
     runs-on: macos-11.0
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '12.2'
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
@@ -117,6 +120,9 @@ jobs:
   macos-cmake:
     runs-on: macos-11.0
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '12.2'
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   macos:
-    runs-on: macOS-latest
+    runs-on: macos-11.0
     steps:
     - uses: actions/checkout@v2
       with:
@@ -115,7 +115,7 @@ jobs:
         bash ./dist/osx/build.sh update_release
 
   macos-cmake:
-    runs-on: macOS-latest
+    runs-on: macos-11.0
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ _By default the app builds for testing server. To use the compiled app with live
 
 ## macOS
 ### Requirements
-- macOS 10.15+, Xcode 12.0+ and Swift 5+
+- macOS 11+, Xcode 12.2+ and Swift 5+
 - Install Bundler
 ```bash
 $ sudo gem install bundler

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -851,6 +851,7 @@
 		C55DA5AB17F06A3B00B42178 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = x86_64;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CODE_SIGN_IDENTITY = "Mac Developer";

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -3775,6 +3775,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B671ACF75B3267B013176BD7 /* Pods-TogglDesktop.release.xcconfig */;
 			buildSettings = {
+				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CLANG_CXX_LIBRARY = "compiler-default";
@@ -4033,6 +4034,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4BCB2D1F3BD02A806D947C18 /* Pods-TogglDesktop-AppStore.release.xcconfig */;
 			buildSettings = {
+				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
### 📒 Description
When building the app using macOS Big Sur & Xcode 12 it tries to build Universal Binary by default, and because it's currently not possible, the build fails. We are updating our build settings to build only for x86_64 till it's possible for us to build Universal Binary.
Along with this change, the PR also updates GitHub Actions to use the latest environment (same as local development env).

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4686 

### 🔎 Review hints
CI should build the app successfully. 