### PR TITLE
Fix right gridsplitter behavior (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
@@ -32,6 +32,7 @@
             <converters:BooleanInvertToVisibilityConverter x:Key="BooleanInvertToVisibilityConverter"/>
             <converters:HasAnyFlagToVisibilityConverter x:Key="HasAnyFlagToVisibilityConverter"/>
             <converters:EmptyListToCollapsedConverter x:Key="EmptyListToVisibleConverter" Inverse="True"/>
+            <converters:CalculateCenterConverter x:Key="CalculateCenterConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -263,6 +263,7 @@
     <Compile Include="ui\Converters\AdaptProjectColorConverter.cs" />
     <Compile Include="ui\Converters\AndConverter.cs" />
     <Compile Include="ui\Converters\BooleanInvertToVisibilityConverter.cs" />
+    <Compile Include="ui\Converters\CalculateCenterConverter.cs" />
     <Compile Include="ui\Converters\CapitalizeConverter.cs" />
     <Compile Include="ui\Converters\EmptyListToCollapsedConverter.cs" />
     <Compile Include="ui\Converters\EmptyStringToCollapsedConverter.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/CalculateCenterConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/CalculateCenterConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace TogglDesktop.Converters
+{
+    public class CalculateCenterConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is double totalWidth && parameter is double elementWidth)
+            {
+                return (totalWidth - elementWidth) / 2;
+            }
+
+            return 0;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -272,7 +272,7 @@
                     <ItemsControl Grid.Row="1" Grid.Column="4" ItemsSource="{Binding Path=ActivityBlocks}" x:Name="ActivityBlocks">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <Canvas />
+                                <Canvas Name="ActivityBlocksCanvas" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
@@ -290,7 +290,8 @@
                         </ItemsControl.ItemTemplate>
                         <ItemsControl.ItemContainerStyle>
                             <Style TargetType="ContentPresenter">
-                                <Setter Property="Canvas.Left" Value="25" />
+                                <Setter Property="Canvas.Left" Value="{Binding ElementName=ActivityBlocksCanvas, Path=ActualWidth,
+                                    Converter={StaticResource CalculateCenterConverter}, ConverterParameter={x:Static res:TimelineConstants.TimeEntryBlockWidth}}" />
                                 <Setter Property="Canvas.Top" Value="{Binding Path=Offset}" />
                             </Style>
                         </ItemsControl.ItemContainerStyle>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -27,9 +27,9 @@
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="55" Name="HoursColumn"></ColumnDefinition>
-                <ColumnDefinition Width="*" Name="TimeEntryColumn"></ColumnDefinition>
-                <ColumnDefinition Width="70" Name="ActivityColumn"></ColumnDefinition>
+                <ColumnDefinition Width="{Binding ElementName=HoursColumn, Path=Width}" MinWidth="40"/>
+                <ColumnDefinition Width="{Binding ElementName=TimeEntryColumn, Path=Width}"/>
+                <ColumnDefinition Width="{Binding ElementName=ActivityColumn, Path=Width}" MinWidth="45" MaxWidth="200"/>
             </Grid.ColumnDefinitions>
             <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
                 <mah:ToggleSwitch Margin="10 14 0 0"
@@ -115,11 +115,11 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="{Binding ElementName=HoursColumn, Path=Width}"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="{Binding ElementName=TimeEntryColumn, Path=Width}"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="{Binding ElementName=ActivityColumn, Path=Width}"/>
+                        <ColumnDefinition Width="55" MinWidth="40" Name="HoursColumn"/>
+                        <ColumnDefinition Width="1"/>
+                        <ColumnDefinition Width="*" MinWidth="60" Name="TimeEntryColumn"/>
+                        <ColumnDefinition Width="1"/>
+                        <ColumnDefinition Width="70" MinWidth="45" MaxWidth="200" Name="ActivityColumn"/>
                     </Grid.ColumnDefinitions>
                     <ItemsControl ItemsSource="{Binding HourViews}" AlternationCount="2" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5"
                                   x:Name="HoursItemsControl">
@@ -233,7 +233,7 @@
                             </Style>
                         </ItemsControl.ItemContainerStyle>
                     </ItemsControl>
-                    <GridSplitter Grid.Column="3" Grid.Row="1" Width="1">
+                    <GridSplitter Grid.Column="3" Grid.Row="1" Width="1" HorizontalAlignment="Center" VerticalAlignment="Stretch">
                         <GridSplitter.Style>
                             <Style TargetType="{x:Type GridSplitter}">
                                 <Setter Property="Template">


### PR DESCRIPTION
### 📒 Description
Fixes gridsplitter behavior: the Time entries column now doesn't shrink when resizing right gridsplitter.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4659 
Closes #4628 

### 🔎 Review hints
Testing:
Try to move both gridsplitters on Timeline UI, make sure there are appropriate min and max column widths and no strange behaviors.

