### PR TITLE
Fix incorrect gap blocks generation with selected date other than today

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -69,8 +69,8 @@ namespace TogglDesktop.ViewModels
                         .ToDictionary(pair => pair.Key, pair => pair.Value))
                 .ToPropertyEx(this, x => x.TimeEntryBlocks);
             blocksObservable.Select(blocks => GenerateGapTimeEntryBlocks(blocks.Values
-                .Where(v => Toggl.DateTimeFromUnix(v.Started).Date <= SelectedDate &&
-                            Toggl.DateTimeFromUnix(v.Ended).Date >= SelectedDate).ToList(), SelectedScaleMode)).ToPropertyEx(this, x => x.GapTimeEntryBlocks);
+                .Where(v => v.StartTime().Date <= SelectedDate && v.EndTime().Date >= SelectedDate).ToList(), SelectedScaleMode))
+                .ToPropertyEx(this, x => x.GapTimeEntryBlocks);
 
             this.WhenAnyValue(x => x.TimeEntryBlocks)
                 .Where(blocks => blocks != null && blocks.Any())
@@ -149,7 +149,7 @@ namespace TogglDesktop.ViewModels
             {
                 if (chunk.Events.Any())
                 {
-                    var start = Toggl.DateTimeFromUnix(chunk.Started);
+                    var start = chunk.StartTime();
                     var block = new ActivityBlock()
                     {
                         Offset = ConvertTimeIntervalToHeight(selectedDate, start, selectedScaleMode),
@@ -201,7 +201,7 @@ namespace TogglDesktop.ViewModels
             {
                 if (blocks.ContainsKey(entry.GUID)) continue;
 
-                var startTime = Toggl.DateTimeFromUnix(entry.Started);
+                var startTime = entry.StartTime();
                 var ended = entry.GUID == runningEntry?.GUID 
                     ? TimelineUtils.ConvertOffsetToTime(currentTimeOffset - 1, selectedDate, TimelineConstants.ScaleModes[selectedScaleMode])
                     : entry.Ended;
@@ -295,15 +295,15 @@ namespace TogglDesktop.ViewModels
         {
             var gaps = new List<GapTimeEntryBlock>();
             timeEntries.Sort((te1,te2) => te1.Started.CompareTo(te2.Started));
-            ulong? prevEnd = null;
+            TimeEntryBlock lastTimeEntry = null;
             foreach (var entry in timeEntries)
             {
-                if (prevEnd != null && entry.Started > prevEnd.Value)
+                if (lastTimeEntry != null && entry.Started > lastTimeEntry.Ended)
                 {
-                    var start = Toggl.DateTimeFromUnix(prevEnd.Value+1);
+                    var start = lastTimeEntry.EndTime().AddSeconds(-1);
                     var block = new GapTimeEntryBlock((offset, height) => AddNewTimeEntry(offset, height, selectedScaleMode, start.Date))
                     {
-                        Height = ConvertTimeIntervalToHeight(start, Toggl.DateTimeFromUnix(entry.Started - 1), selectedScaleMode),
+                        Height = ConvertTimeIntervalToHeight(start, entry.StartTime().AddSeconds(-1), selectedScaleMode),
                         VerticalOffset =
                             ConvertTimeIntervalToHeight(new DateTime(start.Year, start.Month, start.Day), start, selectedScaleMode),
                         HorizontalOffset = 0
@@ -311,7 +311,7 @@ namespace TogglDesktop.ViewModels
                     if (block.Height > 10) // Don't display to small gaps not to obstruct the view
                         gaps.Add(block);
                 }
-                prevEnd = !prevEnd.HasValue || entry.Ended > prevEnd ? entry.Ended : prevEnd;
+                lastTimeEntry = lastTimeEntry == null || entry.Ended > lastTimeEntry.Ended ? entry : lastTimeEntry;
             }
             
             return gaps;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -68,7 +68,9 @@ namespace TogglDesktop.ViewModels
                     tuple.TimeEntries.Where(b => b.Key != tuple.Running?.GUID)
                         .ToDictionary(pair => pair.Key, pair => pair.Value))
                 .ToPropertyEx(this, x => x.TimeEntryBlocks);
-            blocksObservable.Select(blocks => GenerateGapTimeEntryBlocks(blocks.Values.ToList(), SelectedScaleMode)).ToPropertyEx(this, x => x.GapTimeEntryBlocks);
+            blocksObservable.Select(blocks => GenerateGapTimeEntryBlocks(blocks.Values
+                .Where(v => Toggl.DateTimeFromUnix(v.Started).Date <= SelectedDate &&
+                            Toggl.DateTimeFromUnix(v.Ended).Date >= SelectedDate).ToList(), SelectedScaleMode)).ToPropertyEx(this, x => x.GapTimeEntryBlocks);
 
             this.WhenAnyValue(x => x.TimeEntryBlocks)
                 .Where(blocks => blocks != null && blocks.Any())

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -69,7 +69,7 @@ namespace TogglDesktop.ViewModels
                         .ToDictionary(pair => pair.Key, pair => pair.Value))
                 .ToPropertyEx(this, x => x.TimeEntryBlocks);
             blocksObservable.Select(blocks => GenerateGapTimeEntryBlocks(blocks.Values
-                .Where(v => v.StartTime().Date <= SelectedDate && v.EndTime().Date >= SelectedDate).ToList(), SelectedScaleMode))
+                .Where(timeEntryBlock => timeEntryBlock.StartTime().Date <= SelectedDate && timeEntryBlock.EndTime().Date >= SelectedDate).ToList(), SelectedScaleMode))
                 .ToPropertyEx(this, x => x.GapTimeEntryBlocks);
 
             this.WhenAnyValue(x => x.TimeEntryBlocks)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
 {
-    public class TimelineUtils
+    public static class TimelineUtils
     {
         public static ulong ConvertOffsetToTime(double height, DateTime date, double hourHeight)
         {
@@ -11,5 +12,17 @@ namespace TogglDesktop
             var unixTime = Toggl.UnixFromDateTime(dateTime);
             return unixTime >= 0 ? (ulong)unixTime : 0;
         }
+
+        public static DateTime StartTime(this TimeEntryBlock block) => Toggl.DateTimeFromUnix(block.Started);
+
+        public static DateTime EndTime(this TimeEntryBlock block) => Toggl.DateTimeFromUnix(block.Ended);
+
+        public static DateTime StartTime(this Toggl.TogglTimeEntryView te) => Toggl.DateTimeFromUnix(te.Started);
+
+        public static DateTime EndTime(this Toggl.TogglTimeEntryView te) => Toggl.DateTimeFromUnix(te.Ended);
+
+        public static DateTime StartTime(this Toggl.TimelineChunkView chunk) => Toggl.DateTimeFromUnix(chunk.Started);
+
+        public static DateTime EndTime(this Toggl.TimelineChunkView chunk) => Toggl.DateTimeFromUnix(chunk.Ended);
     }
 }


### PR DESCRIPTION
### 📒 Description
Remove running TE from calculating gap entries if selected date is not today.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4691 

### 🔎 Review hints
Testing:
Start a TE, then go to another day where you have some other TEs. Check there is no gap TE button after the last TE.

