### PR TITLE
Fix gap TE overlap & Running TE visibility

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
@@ -33,6 +33,7 @@
             <converters:HasAnyFlagToVisibilityConverter x:Key="HasAnyFlagToVisibilityConverter"/>
             <converters:EmptyListToCollapsedConverter x:Key="EmptyListToVisibleConverter" Inverse="True"/>
             <converters:CalculateCenterConverter x:Key="CalculateCenterConverter"/>
+            <converters:NullToCollapsedConverter x:Key="NullToCollapsedConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -269,6 +269,7 @@
     <Compile Include="ui\Converters\EmptyStringToCollapsedConverter.cs" />
     <Compile Include="ui\Converters\HasAnyFlagToVisibilityConverter.cs" />
     <Compile Include="ui\Converters\IsSelectableItemConverter.cs" />
+    <Compile Include="ui\Converters\NullToCollapsedConverter.cs" />
     <Compile Include="ui\Converters\PopupAlignmentAwareConverter.cs" />
     <Compile Include="ui\Converters\StringFormatIfNotEmptyConverter.cs" />
     <Compile Include="ui\Converters\BytesToStringConverter.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/NullToCollapsedConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/NullToCollapsedConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace TogglDesktop.Converters
+{
+    class NullToCollapsedConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value == null ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -300,7 +300,7 @@ namespace TogglDesktop.ViewModels
             {
                 if (lastTimeEntry != null && entry.Started > lastTimeEntry.Ended)
                 {
-                    var start = lastTimeEntry.EndTime().AddSeconds(-1);
+                    var start = lastTimeEntry.EndTime().AddSeconds(1);
                     var block = new GapTimeEntryBlock((offset, height) => AddNewTimeEntry(offset, height, selectedScaleMode, start.Date))
                     {
                         Height = ConvertTimeIntervalToHeight(start, entry.StartTime().AddSeconds(-1), selectedScaleMode),

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -199,7 +199,7 @@
                             </Style>
                         </ItemsControl.ItemContainerStyle>
                     </ItemsControl>
-                    <Canvas Name="RunningTimeEntryCanvas" Grid.Row="1" Grid.Column="2" Margin="10 0 0 0" Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Canvas Name="RunningTimeEntryCanvas" Grid.Row="1" Grid.Column="2" Margin="10 0 0 0" Visibility="{Binding RunningTimeEntryBlock, Converter={StaticResource NullToCollapsedConverter}}">
                         <togglDesktop:TimelineRunningTimeEntryBlock DataContext="{Binding RunningTimeEntryBlock}"
                                                                     Canvas.Top="{Binding VerticalOffset}"
                                                                     Canvas.Left="{Binding HorizontalOffset}">


### PR DESCRIPTION
### 📒 Description
Fix gap TE overlap & Running TE visibility

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue) 
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

### 🔎 Review hints

During quick fix of #4691 a new bug was introduced: a gap TE now always overlaps with previous TE. It's not visible while it's a gap, but a new TE, which would be created from it would go to the second layer of TEs.
Also noticed a strange issue with running TE description being displayed while there is no running TE. Fixed visibility.
