### PR TITLE
Fix height of error message view on Big Sur (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/Features/MainWindow/MainWindowController.m
@@ -123,10 +123,6 @@ extern void *ctx;
     [self.contentView addSubview:self.messageView];
 
     [self.messageView addConstraint:[NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:270.0]];
-    NSLayoutConstraint *height = [NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:38.0];
-    // Message View should be expandable depend on the length of text
-    height.priority = NSLayoutPriorityDefaultLow;
-    [self.messageView addConstraint:height];
     [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0]];
     [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.messageView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0]];
     [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.messageView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationGreaterThanOrEqual toItem:self.contentView attribute:NSLayoutAttributeTop multiplier:1 constant:16]];


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Fixes a bug when Error view was compressed when shown on the Timeline tab.
Even though `height` constraint had a low priority it still caused the error view to have this fixed 38pt height.
Removing it should still work because `messageView` has bottom and top constraints.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4674

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Test if different types of errors are shown correctly (including offline indicator).
