### PR TITLE
Fix quitting the app doesn't end the process on Windows 7

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -45,7 +45,13 @@ static class Program
     public static void Shutdown(int exitCode)
     {
         Toggl.Clear();
-        Environment.Exit(exitCode);
+        //For mysterious reason on Windows 7 Exit() doesn't always unload the process of TogglDesktop.exe from memory,
+        //and it makes impossible to start the app again next time.
+        //See https://github.com/toggl-open-source/toggldesktop/issues/4682 for more details.
+        if (Utils.IsWindows7())
+            Process.GetCurrentProcess().Kill();
+        else
+            Environment.Exit(exitCode);
     }
 
     public static string Version()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -431,6 +431,9 @@ public static class Utils
 
         public static string Bitness() => Environment.Is64BitProcess ? "(64-bit)" : "(32-bit)";
 
+        public static bool IsWindows7() =>
+            Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 1;
+
         #endregion environment
 }
 }


### PR DESCRIPTION
### 📒 Description
Fix quitting the app doesn't end the process on Windows 7

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue) 
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4682 

### 🔎 Review hints
Like in #4331 `Process.GetCurrentProcess().Kill()` is used here. I inserted a check for Windows version to do that only for Windows 7, but for Windows 10 it also works OK, just feels like incorrect process ending. 
