### PR TITLE
Fix TEs are displayed overlapped when they are actually not

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
@@ -12,6 +12,7 @@ namespace TogglDesktop.Resources
         public const double DescriptionOpacity = 0.2;
         public const double TimeEntryBlockWidth = 20;
         public const double GapBetweenOverlappingTEs = 5;
+        public const double AcceptableBlocksOverlap = 1e-5;
 
         public static IReadOnlyDictionary<int, int> ScaleModes { get; } = new Dictionary<int, int>()
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -194,7 +194,7 @@ namespace TogglDesktop.ViewModels
             // - if it's a start time stamp, then pick up the minimum available offset, if none is available assign a new one.
             // - if it's an end time stamp, then release the offset which it occupied.
             IEnumerable<Toggl.TogglTimeEntryView> allEntries = timeEntries;
-            if (runningEntry != null && selectedDate.Date == DateTime.Today)
+            if (runningEntry != null && runningEntry.Value.StartTime().Date <= selectedDate.Date && DateTime.Now.Date >= selectedDate.Date)
                 allEntries = allEntries.Union(new List<Toggl.TogglTimeEntryView>(){runningEntry.Value});
             foreach (var entry in allEntries)
             {
@@ -300,7 +300,7 @@ namespace TogglDesktop.ViewModels
                     var block = new GapTimeEntryBlock((offset, height) => AddNewTimeEntry(offset, height, selectedScaleMode, selectedDate))
                     {
                         Height = entry.VerticalOffset - lastTimeEntry.Bottom,
-                        VerticalOffset = lastTimeEntry.VerticalOffset + lastTimeEntry.Height,
+                        VerticalOffset = lastTimeEntry.Bottom,
                         HorizontalOffset = 0
                     };
                     if (block.Height > 10) // Don't display to small gaps not to obstruct the view

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryInfo.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimelineTimeEntryInfo.xaml
@@ -4,10 +4,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModels="clr-namespace:TogglDesktop.ViewModels"
+             xmlns:res="clr-namespace:TogglDesktop.Resources"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance viewModels:TimeEntryBlock, IsDesignTimeCreatable=False}">
-    <StackPanel Height="{Binding Height}" Margin="20,0,0,0">
+    <StackPanel Height="{Binding Height}" MinHeight="{x:Static res:TimelineConstants.MinTimeEntryBlockHeight}" Margin="20,0,0,0">
         <TextBlock Text="{Binding Description}" Style="{StaticResource Toggl.CaptionBlackText}"/>
         <DockPanel Visibility="{Binding ProjectName, Converter={StaticResource EmptyStringToCollapsedConverter}}">
             <Ellipse Width="8" Height="8"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -1,21 +1,22 @@
 ﻿using System;
-using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
 {
     public static class TimelineUtils
     {
-        public static ulong ConvertOffsetToTime(double height, DateTime date, double hourHeight)
+        public static ulong ConvertOffsetToUnixTime(double height, DateTime date, double hourHeight)
         {
-            var hours = 1.0 * height / hourHeight;
-            var dateTime = date.AddHours(hours);
+            var dateTime = ConvertOffsetToDateTime(height, date, hourHeight);
             var unixTime = Toggl.UnixFromDateTime(dateTime);
             return unixTime >= 0 ? (ulong)unixTime : 0;
         }
 
-        public static DateTime StartTime(this TimeEntryBlock block) => Toggl.DateTimeFromUnix(block.Started);
-
-        public static DateTime EndTime(this TimeEntryBlock block) => Toggl.DateTimeFromUnix(block.Ended);
+        public static DateTime ConvertOffsetToDateTime(double height, DateTime date, double hourHeight)
+        {
+            var hours = 1.0 * height / hourHeight;
+            var dateTime = date.AddHours(hours);
+            return dateTime;
+        }
 
         public static DateTime StartTime(this Toggl.TogglTimeEntryView te) => Toggl.DateTimeFromUnix(te.Started);
 


### PR DESCRIPTION
### 📒 Description
Fix TEs are displayed overlapped when they are actually not.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4673 

### 🔎 Review hints
Some refactoring is done is scope if this bugfix:
1. Started and Ended time stamps are removed from `TimeEntryBlock` class, as all necessary info can be got from `VerticalOffset` and `Height` properties.
2. Height and offset properties now correspond to time stamps strictly, the case of zero time entry length is handled in xaml code by setting `MinHeight`.
3. There is now  a precision constant introduced for doubles comparison, so everything that has an overlap less than 10^-5 is not considered to be an actual overlap.

