### PR TITLE
Stop sending sync requests when time entry fails to sync

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -5996,6 +5996,7 @@ error Context::pushEntries(
 
             if (kBadRequestError == resp.err) {
                 error_message = resp.body;
+                (*it)->SetValidationError(error_message);
             }
 
             continue;
@@ -6402,7 +6403,6 @@ void Context::syncCollectJSON(Json::Value &array, const std::vector<T*> &source)
         // That causes the whole syncing process to grind to a halt, so let's not sync those entities
         if (!found) {
             logger.error("Was not able to sync entity: ", i->String());
-            i->SetUnsynced();
             i->SetValidationError(kForeignEntityLostError);
         }
 
@@ -6530,7 +6530,6 @@ error Context::syncHandleResponse(Json::Value &array, const std::vector<T*> &sou
                     model->MarkAsDeletedOnServer();
                     continue;
                 }
-                model->SetUnsynced();
                 model->SetValidationError(errorMessage);
                 logger.error("Sync: Error when syncing ", modelInfo, ": ", errorMessage);
                 displayError(errorMessage);

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -1870,7 +1870,7 @@ error Database::loadTimeEntriesFromSQLStatement(
                     model->ProjectGUID.SetCurrent(rs[18].convert<std::string>());
                 }
                 if (rs[19].isEmpty()) {
-                    model->SetValidationError("");
+                    model->ClearValidationError();
                 } else {
                     model->SetValidationError(rs[19].convert<std::string>());
                 }

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -139,7 +139,6 @@ void BaseModel::SetUnsynced() {
 }
 
 void BaseModel::ClearUnsynced() {
-    Unsynced.Set(false);
     ClearValidationError();
 }
 

--- a/src/model/base_model.cc
+++ b/src/model/base_model.cc
@@ -55,6 +55,7 @@ void BaseModel::ClearValidationError() {
 }
 
 void BaseModel::SetValidationError(const std::string &value) {
+    Unsynced.Set(!value.empty());
     if (ValidationError.Set(value))
         SetDirty();
 }
@@ -139,6 +140,7 @@ void BaseModel::SetUnsynced() {
 
 void BaseModel::ClearUnsynced() {
     Unsynced.Set(false);
+    ClearValidationError();
 }
 
 void BaseModel::SetDeletedAt(Poco::Int64 value) {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimeEntryCellViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimeEntryCellViewModel.cs
@@ -48,6 +48,9 @@ namespace TogglDesktop.ViewModels
         [Reactive]
         public ulong GroupItemCount { get; set; }
 
+        [Reactive]
+        public string UnsyncedTimeEntryErrorMessage { get; set; }
+
         public long DurationInSeconds { get; set; }
 
         public bool TryExpand()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml
@@ -90,7 +90,7 @@
         <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom" Grid.Column="3">
             <Canvas Width="25" Height="26"
                     Name="unsyncedIcon" x:FieldModifier="private"
-                    ToolTip="Unsynced entry">
+                    ToolTip="{Binding UnsyncedTimeEntryErrorMessage}">
                 <Path Fill="{DynamicResource Toggl.UnsyncedEntryIndicatorBrush}" Opacity=".3" Data="M25 .214V25.93H.657z"/>
                 <Path Fill="{DynamicResource Toggl.UnsyncedEntryIndicatorBrush}" Data="M17.9 20.571c.56 0 1.014.48 1.014 1.072 0 .592-.454 1.071-1.014 1.071s-1.014-.48-1.014-1.071c0-.592.454-1.072 1.014-1.072zm.024-6.428c.54 0 .99.451.99 1.007v3.342c0 .551-.443 1.008-.99 1.008h-.048c-.54 0-.99-.451-.99-1.008V15.15c0-.55.443-1.007.99-1.007z"/>
             </Canvas>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
@@ -52,6 +52,8 @@ namespace TogglDesktop
             ViewModel.DurationInSeconds = item.DurationInSeconds;
             ResetTimeEntryLabelIfChanged(item);
 
+            ViewModel.UnsyncedTimeEntryErrorMessage = item.Error.IsNullOrEmpty() ? "Unsynced entry" : item.Error;
+
             this.durationLabel.Text = item.Duration;
             this.durationPanel.ToolTip = $"{item.StartTimeString} - {item.EndTimeString}";
 


### PR DESCRIPTION
### 📒 Description
Stop sending requests when time entry fails to sync until there are any changes to the 

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] If time entry syncing responds with "Bad Request" - stop syncing this time entry until it is edited in some way
- [x] Display the syncing error in the app UI on Windows
- [x] ~Display the syncing error in the app UI on macOS~ (was already implemented)
- [x] On app startup either make sure the unsynced time entry is shown as unsynced ~or force the time entry syncing~.
- [x] Make sure that the time entry is being synced when the app is coming back from offline mode.

### 👫 Relationships
Closes #4173
Closes #4181
Closes #4513
Closes #4310 

### 🔎 Review hints

Use Fiddler / Proxyman to observe the number of requests the app is making. There should be no repeated/looping requests returning 400.

### Offline Mode
- Unsynced time entries should be displayed as such
- When coming back from offline mode unsynced time entries should start syncing 

### Required fields feature
Needs Premium subscription
Note: You can use a Staging account (not your Toggl workspace account) in a workspace where you're an admin, and then start a Premium trial by starting the Premium subscription and stopping when you need to enter credit card details.

Set some of the fields as Required and try to create time entries from the desktop app. Observe how errors are displayed and how editing time entries makes them sync again.

### Other errors
Try other error scenarios and see if some behavior is buggy.
In particular, try doing some changes to the time entries, projects, workspace settings in the FE and see if the desktop app reacts properly.