### PR TITLE
Timeline UI - fix overlapping for running TE

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -284,8 +284,6 @@ namespace TogglDesktop.ViewModels
 
         public static double ConvertTimeIntervalToHeight(DateTime start, DateTime end, int scaleMode)
         {
-            if (end <= start) return 0;
-            
             var timeInterval = (end - start).TotalMinutes;
             return timeInterval * TimelineConstants.ScaleModes[scaleMode] / 60;
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -218,7 +218,7 @@ namespace TogglDesktop.ViewModels
                     HasTag = !entry.Tags.IsNullOrEmpty(),
                     IsBillable = entry.Billable
                 };
-                if (entry.Started != entry.Ended)
+                if (entry.Started < ended)
                 {
                     timeStampsList.Add((TimeStampType.Start, block));
                     timeStampsList.Add((TimeStampType.End, block));
@@ -284,6 +284,8 @@ namespace TogglDesktop.ViewModels
 
         public static double ConvertTimeIntervalToHeight(DateTime start, DateTime end, int scaleMode)
         {
+            if (end <= start) return 0;
+            
             var timeInterval = (end - start).TotalMinutes;
             return timeInterval * TimelineConstants.ScaleModes[scaleMode] / 60;
         }


### PR DESCRIPTION
### 📒 Description
Fixes that running TE is not considered as overlap when it's too small.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4717 

### 🔎 Review hints
For running TE end time stamp was less than start time stamp, this caused wrong sorting in the layout algorithm.

