### PR TITLE
Context menu: continue, start from this entry, delete

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ModelExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ModelExtensions.cs
@@ -15,6 +15,11 @@ namespace TogglDesktop
             return IsDurationLessThan15Seconds(timeEntry.DurationInSeconds);
         }
 
+        public static bool ConfirmlessDelete(this TimeEntryBlock block)
+        {
+            return IsDurationLessThan15Seconds(block.DurationInSeconds);
+        }
+
         public static void DeleteTimeEntry(this TimeEntryCellViewModel cell)
         {
             if (cell.ConfirmlessDelete())
@@ -23,6 +28,16 @@ namespace TogglDesktop
                 return;
             }
             Toggl.AskToDeleteEntry(cell.Guid);
+        }
+
+        public static void DeleteTimeEntry(this TimeEntryBlock block)
+        {
+            if (block.ConfirmlessDelete())
+            {
+                Toggl.DeleteTimeEntry(block.TimeEntryId);
+                return;
+            }
+            Toggl.AskToDeleteEntry(block.TimeEntryId);
         }
 
         private static bool IsDurationLessThan15Seconds(long durationInSeconds)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
@@ -14,6 +14,8 @@ namespace TogglDesktop.Resources
         public const double GapBetweenOverlappingTEs = 5;
         public const double AcceptableBlocksOverlap = 1e-5;
         public const double MinGapTimeEntryHeight = 10;
+        public const int DefaultTimeEntryLengthInSeconds= 3600;
+        public const double DefaultTimeEntryLengthInHours = 1;
 
         public static IReadOnlyDictionary<int, int> ScaleModes { get; } = new Dictionary<int, int>()
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/TimelineConstants.cs
@@ -14,7 +14,7 @@ namespace TogglDesktop.Resources
         public const double GapBetweenOverlappingTEs = 5;
         public const double AcceptableBlocksOverlap = 1e-5;
         public const double MinGapTimeEntryHeight = 10;
-        public const int DefaultTimeEntryLengthInSeconds= 3600;
+        public const int DefaultTimeEntryLengthInSeconds= (int) (DefaultTimeEntryLengthInHours * 3600);
         public const double DefaultTimeEntryLengthInHours = 1;
 
         public static IReadOnlyDictionary<int, int> ScaleModes { get; } = new Dictionary<int, int>()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -46,13 +46,14 @@ namespace TogglDesktop.ViewModels
         public string TaskName => _timeEntry.TaskLabel;
         public bool HasTag => !_timeEntry.Tags.IsNullOrEmpty();
         public bool IsBillable => _timeEntry.Billable;
+        public long DurationInSeconds => _timeEntry.DurationInSeconds;
         public string Duration { [ObservableAsProperty]get; }
         public string StartEndCaption { [ObservableAsProperty]get; }
         public ReactiveCommand<Unit, Unit> OpenEditView { get; }
         public ReactiveCommand<Unit, bool> ContinueEntry { get; }
         public ReactiveCommand<Unit, Unit> CreateFromEnd { get; }
         public ReactiveCommand<Unit, Unit> StartFromEnd { get; }
-        public ReactiveCommand<Unit, bool> Delete { get; }
+        public ReactiveCommand<Unit, Unit> Delete { get; }
         public string TimeEntryId => _timeEntry.GUID;
 
         [Reactive]
@@ -81,7 +82,7 @@ namespace TogglDesktop.ViewModels
             ContinueEntry = ReactiveCommand.Create(() => Toggl.Continue(TimeEntryId), isNotRunningObservable);
             CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(Ended, Ended + 3600), isNotRunningObservable);
             StartFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditRunningTimeEntryFrom(Ended), isNotRunningObservable);
-            Delete = ReactiveCommand.Create(() => Toggl.DeleteTimeEntry(TimeEntryId));
+            Delete = ReactiveCommand.Create(this.DeleteTimeEntry);
             var startEndObservable = this.WhenAnyValue(x => x.VerticalOffset, x => x.Height, (offset, height) =>
                 (Started: TimelineUtils.ConvertOffsetToDateTime(offset, date, _hourHeight), Ended: TimelineUtils.ConvertOffsetToDateTime(offset + height, date, _hourHeight)));
             startEndObservable.Select(tuple => $"{tuple.Started:HH:mm tt} - {tuple.Ended:HH:mm tt}")

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -77,9 +77,10 @@ namespace TogglDesktop.ViewModels
             DateCreated = date;
             _timeEntry = te;
             OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(TimeEntryId, false, Toggl.Description));
-            ContinueEntry = ReactiveCommand.Create(() => Toggl.Continue(TimeEntryId));
-            CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(Ended, Ended + 3600));
-            StartFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditRunningTimeEntryFrom(Ended));
+            var isNotRunningObservable = Observable.Return(_timeEntry.DurationInSeconds >= 0);
+            ContinueEntry = ReactiveCommand.Create(() => Toggl.Continue(TimeEntryId), isNotRunningObservable);
+            CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(Ended, Ended + 3600), isNotRunningObservable);
+            StartFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditRunningTimeEntryFrom(Ended), isNotRunningObservable);
             Delete = ReactiveCommand.Create(() => Toggl.DeleteTimeEntry(TimeEntryId));
             var startEndObservable = this.WhenAnyValue(x => x.VerticalOffset, x => x.Height, (offset, height) =>
                 (Started: TimelineUtils.ConvertOffsetToDateTime(offset, date, _hourHeight), Ended: TimelineUtils.ConvertOffsetToDateTime(offset + height, date, _hourHeight)));

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -50,10 +50,6 @@ namespace TogglDesktop.ViewModels
         public string Duration { [ObservableAsProperty]get; }
         public string StartEndCaption { [ObservableAsProperty]get; }
         public ReactiveCommand<Unit, Unit> OpenEditView { get; }
-        public ReactiveCommand<Unit, bool> ContinueEntry { get; }
-        public ReactiveCommand<Unit, Unit> CreateFromEnd { get; }
-        public ReactiveCommand<Unit, Unit> StartFromEnd { get; }
-        public ReactiveCommand<Unit, Unit> Delete { get; }
         public string TimeEntryId => _timeEntry.GUID;
 
         [Reactive]
@@ -78,11 +74,6 @@ namespace TogglDesktop.ViewModels
             DateCreated = date;
             _timeEntry = te;
             OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(TimeEntryId, false, Toggl.Description));
-            var isNotRunningObservable = Observable.Return(_timeEntry.DurationInSeconds >= 0);
-            ContinueEntry = ReactiveCommand.Create(() => Toggl.Continue(TimeEntryId), isNotRunningObservable);
-            CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(Ended, Ended + 3600), isNotRunningObservable);
-            StartFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditRunningTimeEntryFrom(Ended), isNotRunningObservable);
-            Delete = ReactiveCommand.Create(this.DeleteTimeEntry);
             var startEndObservable = this.WhenAnyValue(x => x.VerticalOffset, x => x.Height, (offset, height) =>
                 (Started: TimelineUtils.ConvertOffsetToDateTime(offset, date, _hourHeight), Ended: TimelineUtils.ConvertOffsetToDateTime(offset + height, date, _hourHeight)));
             startEndObservable.Select(tuple => $"{tuple.Started:HH:mm tt} - {tuple.Ended:HH:mm tt}")

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using TogglDesktop.Resources;
@@ -48,6 +49,10 @@ namespace TogglDesktop.ViewModels
         public string Duration { [ObservableAsProperty]get; }
         public string StartEndCaption { [ObservableAsProperty]get; }
         public ReactiveCommand<Unit, Unit> OpenEditView { get; }
+        public ReactiveCommand<Unit, bool> ContinueEntry { get; }
+        public ReactiveCommand<Unit, Unit> CreateFromEnd { get; }
+        public ReactiveCommand<Unit, Unit> StartFromEnd { get; }
+        public ReactiveCommand<Unit, bool> Delete { get; }
         public string TimeEntryId => _timeEntry.GUID;
 
         [Reactive]
@@ -72,6 +77,10 @@ namespace TogglDesktop.ViewModels
             DateCreated = date;
             _timeEntry = te;
             OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(TimeEntryId, false, Toggl.Description));
+            ContinueEntry = ReactiveCommand.Create(() => Toggl.Continue(TimeEntryId));
+            CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(Ended, Ended + 3600));
+            StartFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditRunningTimeEntryFrom(Ended));
+            Delete = ReactiveCommand.Create(() => Toggl.DeleteTimeEntry(TimeEntryId));
             var startEndObservable = this.WhenAnyValue(x => x.VerticalOffset, x => x.Height, (offset, height) =>
                 (Started: TimelineUtils.ConvertOffsetToDateTime(offset, date, _hourHeight), Ended: TimelineUtils.ConvertOffsetToDateTime(offset + height, date, _hourHeight)));
             startEndObservable.Select(tuple => $"{tuple.Started:HH:mm tt} - {tuple.Ended:HH:mm tt}")

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -379,6 +379,9 @@ namespace TogglDesktop.ViewModels
 
         [Reactive]
         public string SelectedForEditTEId { get; set; }
+
+        [Reactive]
+        public TimeEntryBlock ActiveTimeEntryBlock { get; set; }
         public ReactiveCommand<Unit, int> IncreaseScale { get; }
         public ReactiveCommand<Unit, int> DecreaseScale { get; }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -48,7 +48,7 @@ namespace TogglDesktop.ViewModels
             var activeBlockObservable = this.WhenAnyValue(x => x.ActiveTimeEntryBlock);
             var isNotRunningObservable = activeBlockObservable.Select(next => next != null && next.DurationInSeconds >= 0);
             ContinueEntry = ReactiveCommand.Create(() => Toggl.Continue(ActiveTimeEntryBlock.TimeEntryId), isNotRunningObservable);
-            CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(ActiveTimeEntryBlock.Ended, ActiveTimeEntryBlock.Ended + 3600), isNotRunningObservable);
+            CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(ActiveTimeEntryBlock.Ended, ActiveTimeEntryBlock.Ended + TimelineConstants.DefaultTimeEntryLengthInSeconds), isNotRunningObservable);
             StartFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditRunningTimeEntryFrom(ActiveTimeEntryBlock.Ended), isNotRunningObservable);
             Delete = ReactiveCommand.Create(() => ActiveTimeEntryBlock.DeleteTimeEntry(), activeBlockObservable.Select(next => next != null));
             var scaleModeObservable = this.WhenAnyValue(x => x.SelectedScaleMode);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -17,12 +17,12 @@
         <ResourceDictionary>
             <converters:TimelineHeightToCornerRadiusConverter x:Key="TimelineHeightToCornerRadiusConverter"/>
             <ContextMenu x:Key="TimeEntryBlockMenu" Width="300">
-                <MenuItem Header="Continue this entry" Command="{Binding ActiveTimeEntryBlock.ContinueEntry}"/>
-                <MenuItem Header="Start entry from end of this entry" Command="{Binding ActiveTimeEntryBlock.StartFromEnd}"
+                <MenuItem Header="Continue this entry" Command="{Binding ContinueEntry}"/>
+                <MenuItem Header="Start entry from end of this entry" Command="{Binding StartFromEnd}"
                           Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                <MenuItem Header="Create entry from the end of this entry" Command="{Binding ActiveTimeEntryBlock.CreateFromEnd}"
+                <MenuItem Header="Create entry from the end of this entry" Command="{Binding CreateFromEnd}"
                           Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanInvertToVisibilityConverter}}"/>
-                <MenuItem Header="Delete" Command="{Binding ActiveTimeEntryBlock.Delete}"/>
+                <MenuItem Header="Delete" Command="{Binding Delete}"/>
             </ContextMenu>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -164,7 +164,7 @@
                                                                     Canvas.Top="{Binding VerticalOffset}"
                                                                     Canvas.Left="{Binding HorizontalOffset}"
                                                                     Visibility="{Binding Path=., Converter={StaticResource NullToCollapsedConverter}}"
-                                                                    MouseDown="OnTimeEntryBlockMouseDown">
+                                                                    ContextMenuOpening="OnTimeEntryContextMenuOpen">
                             <togglDesktop:TimelineRunningTimeEntryBlock.Style>
                                 <Style TargetType="FrameworkElement">
                                     <Style.Triggers>
@@ -217,7 +217,7 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <togglDesktop:TimelineTimeEntryBlock Panel.ZIndex="1" DataContext="{Binding Path=Value}"
-                                                                     MouseDown="OnTimeEntryBlockMouseDown"
+                                                                     ContextMenuOpening="OnTimeEntryContextMenuOpen"
                                                                      MouseEnter="OnTimeEntryBlockMouseEnter"
                                                                      MouseLeave="OnTimeEntyrBlockMouseLeave">
                                     <togglDesktop:TimelineTimeEntryBlock.Style>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -197,6 +197,16 @@
                         </Path>
                     </Canvas>
                     <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=TimeEntryBlocks}" Margin="10 0 0 0" Name="TimeEntryBlocks">
+                        <ItemsControl.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Continue this entry" Command="{Binding ActiveTimeEntryBlock.ContinueEntry}" Icon="{StaticResource Toggl.ContinueIcon}"/>
+                                <MenuItem Header="Start entry from end of this entry" Command="{Binding ActiveTimeEntryBlock.StartFromEnd}"
+                                          Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                <MenuItem Header="Create entry from the end of this entry" Command="{Binding ActiveTimeEntryBlock.CreateFromEnd}"
+                                          Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanInvertToVisibilityConverter}}"/>
+                                <MenuItem Header="Delete" Command="{Binding ActiveTimeEntryBlock.Delete}"/>
+                            </ContextMenu>
+                        </ItemsControl.ContextMenu>
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <Canvas Name="TimeEntryCanvas"/>
@@ -205,6 +215,7 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <togglDesktop:TimelineTimeEntryBlock Panel.ZIndex="1" DataContext="{Binding Path=Value}"
+                                                                     MouseDown="OnTimeEntryBlockMouseDown"
                                                                      MouseEnter="OnTimeEntryBlockMouseEnter"
                                                                      MouseLeave="OnTimeEntyrBlockMouseLeave">
                                     <togglDesktop:TimelineTimeEntryBlock.Style>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -16,6 +16,14 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:TimelineHeightToCornerRadiusConverter x:Key="TimelineHeightToCornerRadiusConverter"/>
+            <ContextMenu x:Key="TimeEntryBlockMenu" Width="300">
+                <MenuItem Header="Continue this entry" Command="{Binding ActiveTimeEntryBlock.ContinueEntry}"/>
+                <MenuItem Header="Start entry from end of this entry" Command="{Binding ActiveTimeEntryBlock.StartFromEnd}"
+                          Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                <MenuItem Header="Create entry from the end of this entry" Command="{Binding ActiveTimeEntryBlock.CreateFromEnd}"
+                          Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanInvertToVisibilityConverter}}"/>
+                <MenuItem Header="Delete" Command="{Binding ActiveTimeEntryBlock.Delete}"/>
+            </ContextMenu>
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid MinHeight="100">
@@ -151,11 +159,12 @@
                             MouseDown="OnTimeEntryCanvasMouseDown"
                             MouseMove="OnTimeEntryCanvasMouseMove"
                             MouseUp="OnTimeEntryCanvasMouseUp"/>
-                    <Canvas Name="RunningTimeEntryCanvas" Grid.Row="1" Grid.Column="2" Margin="10 0 0 0">
+                    <Canvas Name="RunningTimeEntryCanvas" Grid.Row="1" Grid.Column="2" Margin="10 0 0 0" ContextMenu="{StaticResource TimeEntryBlockMenu}">
                         <togglDesktop:TimelineRunningTimeEntryBlock DataContext="{Binding RunningTimeEntryBlock}"
                                                                     Canvas.Top="{Binding VerticalOffset}"
                                                                     Canvas.Left="{Binding HorizontalOffset}"
-                                                                    Visibility="{Binding Path=., Converter={StaticResource NullToCollapsedConverter}}">
+                                                                    Visibility="{Binding Path=., Converter={StaticResource NullToCollapsedConverter}}"
+                                                                    MouseDown="OnTimeEntryBlockMouseDown">
                             <togglDesktop:TimelineRunningTimeEntryBlock.Style>
                                 <Style TargetType="FrameworkElement">
                                     <Style.Triggers>
@@ -166,6 +175,8 @@
                                 </Style>
                             </togglDesktop:TimelineRunningTimeEntryBlock.Style>
                         </togglDesktop:TimelineRunningTimeEntryBlock>
+                    </Canvas>
+                    <Canvas Grid.Row="1" Grid.Column="2" Margin="10 0 0 0">
                         <Button DataContext="{Binding RunningGapTimeEntryBlock}"
                                 Style="{StaticResource Toggl.Timeline.GapButton.Running}"
                                 Canvas.Top="{Binding VerticalOffset}"
@@ -196,17 +207,8 @@
                             </Path.Data>
                         </Path>
                     </Canvas>
-                    <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=TimeEntryBlocks}" Margin="10 0 0 0" Name="TimeEntryBlocks">
-                        <ItemsControl.ContextMenu>
-                            <ContextMenu>
-                                <MenuItem Header="Continue this entry" Command="{Binding ActiveTimeEntryBlock.ContinueEntry}" Icon="{StaticResource Toggl.ContinueIcon}"/>
-                                <MenuItem Header="Start entry from end of this entry" Command="{Binding ActiveTimeEntryBlock.StartFromEnd}"
-                                          Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                <MenuItem Header="Create entry from the end of this entry" Command="{Binding ActiveTimeEntryBlock.CreateFromEnd}"
-                                          Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanInvertToVisibilityConverter}}"/>
-                                <MenuItem Header="Delete" Command="{Binding ActiveTimeEntryBlock.Delete}"/>
-                            </ContextMenu>
-                        </ItemsControl.ContextMenu>
+                    <ItemsControl Grid.Row="1" Grid.Column="2" ItemsSource="{Binding Path=TimeEntryBlocks}" Margin="10 0 0 0" Name="TimeEntryBlocks"
+                                  ContextMenu="{StaticResource TimeEntryBlockMenu}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <Canvas Name="TimeEntryCanvas"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -148,7 +148,7 @@ namespace TogglDesktop
             Mouse.Capture(null);
         }
 
-        private void OnTimeEntryBlockMouseDown(object sender, MouseButtonEventArgs e)
+        private void OnTimeEntryContextMenuOpen(object sender, ContextMenuEventArgs contextMenuEventArgs)
         {
             if (sender is FrameworkElement uiElement)
             {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -147,5 +147,13 @@ namespace TogglDesktop
             _timeEntryId = null;
             Mouse.Capture(null);
         }
+
+        private void OnTimeEntryBlockMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement uiElement)
+            {
+                ViewModel.ActiveTimeEntryBlock = uiElement.DataContext as TimeEntryBlock;
+            }
+        }
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -136,7 +136,7 @@ namespace TogglDesktop
             {
                 if (Math.Abs(mouseButtonEventArgs.GetPosition(TimeEntryBlocks).Y - _dragStartedPoint.Value) <= 2)
                 {
-                    ViewModel.TimeEntryBlocks[_timeEntryId].Height = TimelineConstants.ScaleModes[ViewModel.SelectedScaleMode];
+                    ViewModel.TimeEntryBlocks[_timeEntryId].Height = TimelineConstants.DefaultTimeEntryLengthInHours*TimelineConstants.ScaleModes[ViewModel.SelectedScaleMode];
                 }
                 ViewModel.TimeEntryBlocks[_timeEntryId].ChangeStartEndTime();
                 ViewModel.TimeEntryBlocks[_timeEntryId].IsDragged = false;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -18,6 +18,19 @@ namespace TogglDesktop
             return dateTime;
         }
 
+        public static void CreateAndEditRunningTimeEntryFrom(ulong started)
+        {
+            var teId = Toggl.Start("", "", 0, 0, "", "");
+            Toggl.SetTimeEntryStartTimeStamp(teId, (long)started);
+            Toggl.Edit(teId, true, Toggl.Description);
+        }
+
+        public static void CreateAndEditTimeEntry(ulong started, ulong ended)
+        {
+            var teId = Toggl.CreateEmptyTimeEntry(started, ended);
+            Toggl.Edit(teId, false, Toggl.Description);
+        }
+
         public static DateTime StartTime(this Toggl.TogglTimeEntryView te) => Toggl.DateTimeFromUnix(te.Started);
 
         public static DateTime EndTime(this Toggl.TogglTimeEntryView te) => Toggl.DateTimeFromUnix(te.Ended);


### PR DESCRIPTION
### 📒 Description
Implementation of context menu for time entry block. List of menu items:
 - Continue
- "Start entry from the end of this entry" if the selected day is today, or "Create entry from the end of this entry" if the selected day is different (will create a 1h time entry and open the Edit view).
- Delete

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
- **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4684 

### 🔎 Review hints
Test:
Right-click on any TE, there is supposed to be 3 menu-items.
For running TE 2 of 3 items are disabled and only "Delete" is accessible.