### PR TITLE
Fix failing GH Actions on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,7 +234,7 @@ jobs:
         path: ../Qt
         key: QtCache512-networkauth
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v2.10.0
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         modules: qtnetworkauth
@@ -295,7 +295,7 @@ jobs:
         path: ../Qt
         key: QtCache512-networkauth
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v2.10.0
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         modules: qtnetworkauth


### PR DESCRIPTION
### 📒 Description
Fix failing GH Actions on Linux by set `install-qt-action` to v2.10.0 as something in the newer version has broken.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Set `install-qt-action` to v2.10.0

### 👫 Relationships
Closes #4727

### 🔎 Review hints
I decided to go with the trivial version rollback because it's not worth investigating the issue more deeply and we don't care about updating the Linux build scripts at this point.