### PR TITLE
Context menu: overlap resolving

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/Models/TimelineData.swift
@@ -209,7 +209,7 @@ final class TimelineData {
             let started = entry.timeEntry.started else { return }
 
         // Set the end time as a start time of selected entry
-        DesktopLibraryBridge.shared().updateTimeEntryWithEnd(atTimestamp: started.timeIntervalSince1970 - 1,
+        DesktopLibraryBridge.shared().updateTimeEntryWithEnd(atTimestamp: started.timeIntervalSince1970,
                                                              guid: firstEntry.timeEntry.guid)
     }
 
@@ -222,7 +222,7 @@ final class TimelineData {
             let endAt = firstEntry.timeEntry.ended else { return }
 
         // Set the start time as a stop time of First entry
-        DesktopLibraryBridge.shared().updateTimeEntryWithStart(atTimestamp: endAt.timeIntervalSince1970 + 1,
+        DesktopLibraryBridge.shared().updateTimeEntryWithStart(atTimestamp: endAt.timeIntervalSince1970,
                                                                guid: entry.timeEntry.guid,
                                                                keepEndTimeFixed: true)
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -38,7 +38,8 @@ namespace TogglDesktop.ViewModels
     public class TimeEntryBlock : TimelineBlockViewModel
     {
         [Reactive]
-        public bool ShowDescription { get; set; }
+        public bool IsOverlapping { get; set; }
+        public bool ShowDescription { [ObservableAsProperty] get; }
         public string Color => _timeEntry.Color;
         public string Description => _timeEntry.Description.IsNullOrEmpty() ? "No Description" : _timeEntry.Description;
         public string ProjectName => _timeEntry.ProjectLabel;
@@ -88,6 +89,9 @@ namespace TogglDesktop.ViewModels
                 .Select(h => h >= TimelineConstants.MinResizableTimeEntryBlockHeight)
                 .Where(_ => !IsDragged)
                 .ToPropertyEx(this, x => x.IsResizable);
+            this.WhenAnyValue(x => x.IsOverlapping)
+                .Select(isOverlapping => !isOverlapping && Height >= TimelineConstants.MinShowTEDescriptionHeight)
+                .ToPropertyEx(this, x => x.ShowDescription);
         }
 
         public void ChangeStartTime()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -14,6 +14,7 @@ namespace TogglDesktop.ViewModels
     public class TimelineViewModel : ReactiveObject
     {
         private DateTime _lastDateLoaded;
+        private List<TimeEntryBlock> SortedTimeEntryBlocks { [ObservableAsProperty] get; }
 
         public TimelineViewModel()
         {
@@ -51,6 +52,11 @@ namespace TogglDesktop.ViewModels
             CreateFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditTimeEntry(ActiveTimeEntryBlock.Ended, ActiveTimeEntryBlock.Ended + TimelineConstants.DefaultTimeEntryLengthInSeconds), isNotRunningObservable);
             StartFromEnd = ReactiveCommand.Create(() => TimelineUtils.CreateAndEditRunningTimeEntryFrom(ActiveTimeEntryBlock.Ended), isNotRunningObservable);
             Delete = ReactiveCommand.Create(() => ActiveTimeEntryBlock.DeleteTimeEntry(), activeBlockObservable.Select(next => next != null));
+            var isOverlapping = activeBlockObservable.Select(next => next != null && next.IsOverlapping);
+            ChangeFirstTimeEntryStopCommand =
+                ReactiveCommand.Create(() => ChangeFirstEntryStop(ActiveTimeEntryBlock, SortedTimeEntryBlocks), isOverlapping);
+            ChangeLastTimeEntryStartCommand =
+                ReactiveCommand.Create(() => ChangeLastEntryStart(ActiveTimeEntryBlock, SortedTimeEntryBlocks), isOverlapping);
             var scaleModeObservable = this.WhenAnyValue(x => x.SelectedScaleMode);
             scaleModeObservable.Subscribe(_ =>
                 HourHeightView = TimelineConstants.ScaleModes[SelectedScaleMode] * GetHoursInLine(SelectedScaleMode));
@@ -74,7 +80,14 @@ namespace TogglDesktop.ViewModels
                     tuple.TimeEntries.Where(b => b.Key != tuple.Running?.GUID)
                         .ToDictionary(pair => pair.Key, pair => pair.Value))
                 .ToPropertyEx(this, x => x.TimeEntryBlocks);
-            blocksObservable.Select(blocks => GenerateGapTimeEntryBlocks(blocks.Values.ToList()))
+            var sortedTimeEntriesObservable = blocksObservable.Select(blocks =>
+            {
+                var timeEntries = blocks.Values.ToList();
+                timeEntries.Sort((te1, te2) => te1.VerticalOffset.CompareTo(te2.VerticalOffset));
+                return timeEntries;
+            });
+            sortedTimeEntriesObservable.ToPropertyEx(this, x => x.SortedTimeEntryBlocks);
+            sortedTimeEntriesObservable.Select(GenerateGapTimeEntryBlocks)
                 .ToPropertyEx(this, x => x.GapTimeEntryBlocks);
             blocksWithRunningObservable
                 .Select(tuple =>
@@ -251,6 +264,7 @@ namespace TogglDesktop.ViewModels
             });
             var offsets = new HashSet<double>();
             var curOffset = 0d;
+            var usedNumOfOffsets = 0;
             TimeEntryBlock prevLayerBlock = null;
             foreach (var item in timeStampsList)
             {
@@ -261,18 +275,21 @@ namespace TogglDesktop.ViewModels
                         offsets.Add(curOffset);
                         curOffset += TimelineConstants.TimeEntryBlockWidth+TimelineConstants.GapBetweenOverlappingTEs;
                     }
-                    if (prevLayerBlock != null)
+                    if (usedNumOfOffsets > 0)
                     {
                         item.Block.IsOverlapping = true;
-                        prevLayerBlock.IsOverlapping = true;
+                        if (prevLayerBlock != null)
+                            prevLayerBlock.IsOverlapping = true;
                     }
                     item.Block.HorizontalOffset = offsets.Min();
                     offsets.Remove(offsets.Min());
+                    usedNumOfOffsets++;
                     prevLayerBlock = item.Block;
                 }
                 if (item.Type == TimeStampType.End || item.Type == TimeStampType.Empty)
                 {
                     offsets.Add(item.Block.HorizontalOffset);
+                    usedNumOfOffsets--;
                     prevLayerBlock = null;
                 }
             }
@@ -289,7 +306,6 @@ namespace TogglDesktop.ViewModels
         private static List<GapTimeEntryBlock> GenerateGapTimeEntryBlocks(List<TimeEntryBlock> timeEntries)
         {
             var gaps = new List<GapTimeEntryBlock>();
-            timeEntries.Sort((te1,te2) => te1.VerticalOffset.CompareTo(te2.VerticalOffset));
             TimeEntryBlock lastTimeEntry = null;
             foreach (var entry in timeEntries)
             {
@@ -346,6 +362,30 @@ namespace TogglDesktop.ViewModels
             return timeEntryId;
         }
 
+        public static void ChangeFirstEntryStop(TimeEntryBlock item, List<TimeEntryBlock> blocks)
+        {
+            var (first, last) = GetOverlappingPair(item, blocks);
+            if (last == null) return;
+            Toggl.SetTimeEntryEndTimeStamp(first.TimeEntryId, (long)last.Started - 1);
+        }
+
+        public static void ChangeLastEntryStart(TimeEntryBlock item, List<TimeEntryBlock> blocks)
+        {
+            var (first, last) = GetOverlappingPair(item, blocks);
+            if (last == null) return;
+            Toggl.SetTimeEntryStartTimeStamp(last.TimeEntryId, (long)first.Ended + 1);
+        }
+
+        private static (TimeEntryBlock First, TimeEntryBlock Last) GetOverlappingPair(TimeEntryBlock item, IEnumerable<TimeEntryBlock> blocks)
+        {
+            var overlapping = blocks.FirstOrDefault(b => b.TimeEntryId != item.TimeEntryId && b.IsOverlappingWith(item));
+            if (overlapping == null) return (item, null);
+
+            var first = item.Started < overlapping.Started ? item : overlapping;
+            var last = item.Started < overlapping.Started ? overlapping : item;
+            return (first, last);
+        }
+
         [Reactive] 
         public int SelectedScaleMode { get; private set; } = 0;
         [Reactive] 
@@ -398,6 +438,8 @@ namespace TogglDesktop.ViewModels
         public ReactiveCommand<Unit, Unit> CreateFromEnd { get; }
         public ReactiveCommand<Unit, Unit> StartFromEnd { get; }
         public ReactiveCommand<Unit, Unit> Delete { get; }
+        public ReactiveCommand<Unit, Unit> ChangeFirstTimeEntryStopCommand { get; }
+        public ReactiveCommand<Unit, Unit> ChangeLastTimeEntryStartCommand { get; }
 
         public class ActivityBlock
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -366,14 +366,14 @@ namespace TogglDesktop.ViewModels
         {
             var (first, last) = GetOverlappingPair(item, blocks);
             if (last == null) return;
-            Toggl.SetTimeEntryEndTimeStamp(first.TimeEntryId, (long)last.Started - 1);
+            Toggl.SetTimeEntryEndTimeStamp(first.TimeEntryId, (long)last.Started);
         }
 
         public static void ChangeLastEntryStart(TimeEntryBlock item, List<TimeEntryBlock> blocks)
         {
             var (first, last) = GetOverlappingPair(item, blocks);
             if (last == null) return;
-            Toggl.SetTimeEntryStartTimeStamp(last.TimeEntryId, (long)first.Ended + 1);
+            Toggl.SetTimeEntryStartTimeStamp(last.TimeEntryId, (long)first.Ended);
         }
 
         private static (TimeEntryBlock First, TimeEntryBlock Last) GetOverlappingPair(TimeEntryBlock item, IEnumerable<TimeEntryBlock> blocks)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -218,7 +218,7 @@ namespace TogglDesktop.ViewModels
                 {
                     Height = height,
                     VerticalOffset = ConvertTimeIntervalToHeight(selectedDate, startTime, selectedScaleMode),
-                    ShowDescription = true
+                    IsOverlapping = false
                 };
                 if (entry.Started < ended)
                 {
@@ -251,7 +251,6 @@ namespace TogglDesktop.ViewModels
             });
             var offsets = new HashSet<double>();
             var curOffset = 0d;
-            var usedNumOfOffsets = 0;
             TimeEntryBlock prevLayerBlock = null;
             foreach (var item in timeStampsList)
             {
@@ -262,21 +261,18 @@ namespace TogglDesktop.ViewModels
                         offsets.Add(curOffset);
                         curOffset += TimelineConstants.TimeEntryBlockWidth+TimelineConstants.GapBetweenOverlappingTEs;
                     }
-                    if (usedNumOfOffsets > 0 || item.Block.Height < TimelineConstants.MinShowTEDescriptionHeight)
+                    if (prevLayerBlock != null)
                     {
-                        item.Block.ShowDescription = false;
-                        if (prevLayerBlock != null)
-                            prevLayerBlock.ShowDescription = false;
+                        item.Block.IsOverlapping = true;
+                        prevLayerBlock.IsOverlapping = true;
                     }
                     item.Block.HorizontalOffset = offsets.Min();
                     offsets.Remove(offsets.Min());
-                    usedNumOfOffsets++;
                     prevLayerBlock = item.Block;
                 }
                 if (item.Type == TimeStampType.End || item.Type == TimeStampType.Empty)
                 {
                     offsets.Add(item.Block.HorizontalOffset);
-                    usedNumOfOffsets--;
                     prevLayerBlock = null;
                 }
             }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -23,6 +23,9 @@
                 <MenuItem Header="Create entry from the end of this entry" Command="{Binding CreateFromEnd}"
                           Visibility="{Binding IsTodaySelected, Converter={StaticResource BooleanInvertToVisibilityConverter}}"/>
                 <MenuItem Header="Delete" Command="{Binding Delete}"/>
+                <Separator Style="{StaticResource {x:Static MenuItem.SeparatorStyleKey}}"/>
+                <MenuItem Header="Change first entry stop time" Command="{Binding ChangeFirstTimeEntryStopCommand}"/>
+                <MenuItem Header="Change last entry start time" Command="{Binding ChangeLastTimeEntryStartCommand}"/>
             </ContextMenu>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
 {
@@ -38,5 +39,8 @@ namespace TogglDesktop
         public static DateTime StartTime(this Toggl.TimelineChunkView chunk) => Toggl.DateTimeFromUnix(chunk.Started);
 
         public static DateTime EndTime(this Toggl.TimelineChunkView chunk) => Toggl.DateTimeFromUnix(chunk.Ended);
+
+        public static bool IsOverlappingWith(this TimeEntryBlock first, TimeEntryBlock second) =>
+            first.Started < second.Ended && second.Started < first.Ended;
     }
 }


### PR DESCRIPTION
### 📒 Description
Add menu items, which would do the following:
- "Change first entry stop time" (enabled only if a time entry is intersecting with another time entry)
- "Change last entry start time" (enabled only if a time entry is intersecting with another time entry)

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
 - **New feature** (non-breaking change which adds functionality)
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4685 

### 🔎 Review hints
What to test:
![image](https://user-images.githubusercontent.com/11901598/101147149-4506f480-361c-11eb-908f-622227072691.png)
If there are 2 overlaps for current TE (at the start and at the end), then the first one (sorting by start time) will be resolved.

