### PR TITLE
Unit tests for ConvertTimeEntriesToBlocks and GenerateGapTimeEntryBlocks 

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
@@ -17,18 +17,19 @@ namespace TogglDesktop.Tests
         [MemberData(nameof(GetData))]
         public void TestConvertTimeEntriesToBlocks_CorrectOffsets(List<Toggl.TogglTimeEntryView> timeEntries,
             Toggl.TogglTimeEntryView? runningEntry,
-            int selectedScaleMode, List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset)> expectedValues)
+            int selectedScaleMode, List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)> expectedValues)
         {
             var blocks = TimelineViewModel.ConvertTimeEntriesToBlocks(timeEntries,
                 runningEntry, selectedScaleMode, _selectedDate);
 
             Assert.Equal(expectedValues.Count, blocks.Count);
-            foreach (var (guid, verticalOffset, height, horizontalOffset) in expectedValues)
+            foreach (var (guid, verticalOffset, height, horizontalOffset, isOverlapping) in expectedValues)
             {
                 Assert.True(blocks.ContainsKey(guid));
                 Assert.Equal(verticalOffset, blocks[guid].VerticalOffset, 5);
                 Assert.Equal(height, blocks[guid].Height, 5);
                 Assert.Equal(horizontalOffset, blocks[guid].HorizontalOffset, 5);
+                Assert.Equal(isOverlapping, blocks[guid].IsOverlapping);
             }
         }
 
@@ -60,14 +61,14 @@ namespace TogglDesktop.Tests
                 timeEntryList,
                 null,
                 scaleMode,
-                new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset)>()
+                new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
                 {
                     (timeEntryList[0].GUID, TimeToHeight(timeEntryList[0].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[0].Ended - timeEntryList[0].Started, scaleMode), 0),
+                        TimeToHeight(timeEntryList[0].Ended - timeEntryList[0].Started, scaleMode), 0, true),
                     (timeEntryList[1].GUID, TimeToHeight(timeEntryList[1].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[1].Ended - timeEntryList[1].Started, scaleMode), 0 + _timeEntryOffset),
+                        TimeToHeight(timeEntryList[1].Ended - timeEntryList[1].Started, scaleMode), 0 + _timeEntryOffset, true),
                     (timeEntryList[2].GUID, TimeToHeight(timeEntryList[2].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[2].Ended - timeEntryList[2].Started, scaleMode), 0)
+                        TimeToHeight(timeEntryList[2].Ended - timeEntryList[2].Started, scaleMode), 0, true)
                 }
             };
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using TogglDesktop.Resources;
+using TogglDesktop.ViewModels;
+using Xunit;
+
+namespace TogglDesktop.Tests
+{
+    public class TimelineConvertTimeEntriesToBlocksTests
+    {
+        private static readonly DateTime _selectedDate = new DateTime(2020, 12, 3);
+        private static readonly ulong _selectedDateUnix = (ulong)Toggl.UnixFromDateTime(_selectedDate);
+        private const double _timeEntryOffset =
+            TimelineConstants.GapBetweenOverlappingTEs + TimelineConstants.TimeEntryBlockWidth;
+
+        [Theory]
+        [MemberData(nameof(GetData))]
+        public void TestConvertTimeEntriesToBlocks_CorrectOffsets(List<Toggl.TogglTimeEntryView> timeEntries,
+            Toggl.TogglTimeEntryView? runningEntry,
+            int selectedScaleMode, List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset)> expectedValues)
+        {
+            var blocks = TimelineViewModel.ConvertTimeEntriesToBlocks(timeEntries,
+                runningEntry, selectedScaleMode, _selectedDate);
+
+            Assert.Equal(expectedValues.Count, blocks.Count);
+            foreach (var (guid, verticalOffset, height, horizontalOffset) in expectedValues)
+            {
+                Assert.True(blocks.ContainsKey(guid));
+                Assert.Equal(verticalOffset, blocks[guid].VerticalOffset, 5);
+                Assert.Equal(height, blocks[guid].Height, 5);
+                Assert.Equal(horizontalOffset, blocks[guid].HorizontalOffset, 5);
+            }
+        }
+
+        public static IEnumerable<object[]> GetData()
+        {
+            yield return TestCase1();
+        }
+
+        //Time entries scheme:
+        //  |
+        //  ||
+        //   |
+        //  ||
+        //  |
+        private static object[] TestCase1()
+        {
+            var timeEntryList = new List<Toggl.TogglTimeEntryView>()
+            {
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "1", Started = _selectedDateUnix + 0, Ended = _selectedDateUnix + 100},
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "2", Started = _selectedDateUnix + 50, Ended = _selectedDateUnix + 200},
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "3", Started = _selectedDateUnix + 150, Ended = _selectedDateUnix + 200}
+            };
+            var scaleMode = 0;
+            return new object[]
+            {
+                timeEntryList,
+                null,
+                scaleMode,
+                new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset)>()
+                {
+                    (timeEntryList[0].GUID, TimeToHeight(timeEntryList[0].Started - _selectedDateUnix, scaleMode),
+                        TimeToHeight(timeEntryList[0].Ended - timeEntryList[0].Started, scaleMode), 0),
+                    (timeEntryList[1].GUID, TimeToHeight(timeEntryList[1].Started - _selectedDateUnix, scaleMode),
+                        TimeToHeight(timeEntryList[1].Ended - timeEntryList[1].Started, scaleMode), 0 + _timeEntryOffset),
+                    (timeEntryList[2].GUID, TimeToHeight(timeEntryList[2].Started - _selectedDateUnix, scaleMode),
+                        TimeToHeight(timeEntryList[2].Ended - timeEntryList[2].Started, scaleMode), 0)
+                }
+            };
+        }
+
+        private static double TimeToHeight(ulong time, int mode) =>
+            TimelineConstants.ScaleModes[mode] * (1d*time / 3600);
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
@@ -13,12 +13,12 @@ namespace TogglDesktop.Tests
         private const double _horizontalTimeEntryOffset =
             TimelineConstants.GapBetweenOverlappingTEs + TimelineConstants.TimeEntryBlockWidth;
 
-        private static readonly ulong T1 = 0;
-        private static readonly ulong T2 = 50;
-        private static readonly ulong T3 = 100;
-        private static readonly ulong T4 = 150;
-        private static readonly ulong T5 = 200;
-        private static readonly ulong T6 = 300;
+        private const ulong T1 = 0;
+        private const ulong T2 = 50;
+        private const ulong T3 = 100;
+        private const ulong T4 = 150;
+        private const ulong T5 = 200;
+        private const ulong T6 = 300;
 
         [Theory]
         [MemberData(nameof(GetData))]

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineConvertTimeEntriesToBlocksTests.cs
@@ -10,8 +10,15 @@ namespace TogglDesktop.Tests
     {
         private static readonly DateTime _selectedDate = new DateTime(2020, 12, 3);
         private static readonly ulong _selectedDateUnix = (ulong)Toggl.UnixFromDateTime(_selectedDate);
-        private const double _timeEntryOffset =
+        private const double _horizontalTimeEntryOffset =
             TimelineConstants.GapBetweenOverlappingTEs + TimelineConstants.TimeEntryBlockWidth;
+
+        private static readonly ulong T1 = 0;
+        private static readonly ulong T2 = 50;
+        private static readonly ulong T3 = 100;
+        private static readonly ulong T4 = 150;
+        private static readonly ulong T5 = 200;
+        private static readonly ulong T6 = 300;
 
         [Theory]
         [MemberData(nameof(GetData))]
@@ -41,6 +48,9 @@ namespace TogglDesktop.Tests
             yield return TestCase2();
             yield return TestCase_MustIncludeRunningEntry();
             yield return TestCase_MustNotIncludeRunningEntry();
+            yield return TestCase_NoOverlap();
+            yield return TestCase_MustIncludeMoreThan24HoursEntry();
+            yield return TestCase_SameGuid();
         }
 
         //Time entries scheme:
@@ -54,11 +64,11 @@ namespace TogglDesktop.Tests
             var timeEntryList = new List<Toggl.TogglTimeEntryView>()
             {
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "1", Started = _selectedDateUnix + 0, Ended = _selectedDateUnix + 100},
+                    {GUID = "1", Started = _selectedDateUnix + T1, Ended = _selectedDateUnix + T3},
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "2", Started = _selectedDateUnix + 50, Ended = _selectedDateUnix + 200},
+                    {GUID = "2", Started = _selectedDateUnix + T2, Ended = _selectedDateUnix + T5},
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "3", Started = _selectedDateUnix + 150, Ended = _selectedDateUnix + 200}
+                    {GUID = "3", Started = _selectedDateUnix + T4, Ended = _selectedDateUnix + T5}
             };
             var scaleMode = 0;
             return new object[]
@@ -69,12 +79,12 @@ namespace TogglDesktop.Tests
                 _selectedDate,
                 new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
                 {
-                    (timeEntryList[0].GUID, TimeToHeight(timeEntryList[0].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[0].Ended - timeEntryList[0].Started, scaleMode), 0, true),
-                    (timeEntryList[1].GUID, TimeToHeight(timeEntryList[1].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[1].Ended - timeEntryList[1].Started, scaleMode), 0 + _timeEntryOffset, true),
-                    (timeEntryList[2].GUID, TimeToHeight(timeEntryList[2].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[2].Ended - timeEntryList[2].Started, scaleMode), 0, true)
+                    (timeEntryList[0].GUID, TimeToHeight(T1, scaleMode),
+                        TimeToHeight(T3 - T1, scaleMode), 0, true),
+                    (timeEntryList[1].GUID, TimeToHeight(T2, scaleMode),
+                        TimeToHeight(T5 - T2, scaleMode), 0 + _horizontalTimeEntryOffset, true),
+                    (timeEntryList[2].GUID, TimeToHeight(T4, scaleMode),
+                        TimeToHeight(T5 - T4, scaleMode), 0, true)
                 }
             };
         }
@@ -89,11 +99,11 @@ namespace TogglDesktop.Tests
             var timeEntryList = new List<Toggl.TogglTimeEntryView>()
             {
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "1", Started = _selectedDateUnix + 0, Ended = _selectedDateUnix + 150},
+                    {GUID = "1", Started = _selectedDateUnix + T1, Ended = _selectedDateUnix + T4},
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "2", Started = _selectedDateUnix + 50, Ended = _selectedDateUnix + 150},
+                    {GUID = "2", Started = _selectedDateUnix + T2, Ended = _selectedDateUnix + T4},
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "3", Started = _selectedDateUnix + 100, Ended = _selectedDateUnix + 200}
+                    {GUID = "3", Started = _selectedDateUnix + T3, Ended = _selectedDateUnix + T5}
             };
             var scaleMode = 1;
             return new object[]
@@ -104,12 +114,12 @@ namespace TogglDesktop.Tests
                 _selectedDate,
                 new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
                 {
-                    (timeEntryList[0].GUID, TimeToHeight(timeEntryList[0].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[0].Ended - timeEntryList[0].Started, scaleMode), 0, true),
-                    (timeEntryList[1].GUID, TimeToHeight(timeEntryList[1].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[1].Ended - timeEntryList[1].Started, scaleMode), 0 + _timeEntryOffset, true),
-                    (timeEntryList[2].GUID, TimeToHeight(timeEntryList[2].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[2].Ended - timeEntryList[2].Started, scaleMode), 0 + 2*_timeEntryOffset, true)
+                    (timeEntryList[0].GUID, TimeToHeight(T1, scaleMode),
+                        TimeToHeight(T4 - T1, scaleMode), 0, true),
+                    (timeEntryList[1].GUID, TimeToHeight(T2, scaleMode),
+                        TimeToHeight(T4 - T2, scaleMode), 0 + _horizontalTimeEntryOffset, true),
+                    (timeEntryList[2].GUID, TimeToHeight(T3, scaleMode),
+                        TimeToHeight(T5 - T3, scaleMode), 0 + 2*_horizontalTimeEntryOffset, true)
                 }
             };
         }
@@ -120,22 +130,23 @@ namespace TogglDesktop.Tests
             var timeEntryList = new List<Toggl.TogglTimeEntryView>()
             {
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "1", Started = _selectedDateUnix + 0, Ended = _selectedDateUnix + 150},
+                    {GUID = "1", Started = _selectedDateUnix + T1, Ended = _selectedDateUnix + T4},
             };
             var scaleMode = 1;
-            var runningEntry = new Toggl.TogglTimeEntryView() {GUID = "4", Started = _selectedDateUnix + 150};
+            var runningEntry = new Toggl.TogglTimeEntryView() {GUID = "4", Started = _selectedDateUnix + T4};
+            var now = _selectedDate.AddSeconds(300);
             return new object[]
             {
                 timeEntryList,
-                new Toggl.TogglTimeEntryView() {GUID = "4", Started = _selectedDateUnix + 150}, 
+                runningEntry, 
                 scaleMode,
-                _selectedDate.AddSeconds(300),
+                now,
                 new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
                 {
-                    (timeEntryList[0].GUID, TimeToHeight(timeEntryList[0].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[0].Ended - timeEntryList[0].Started, scaleMode), 0, false),
-                    (runningEntry.GUID, TimeToHeight(runningEntry.Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(_selectedDateUnix + 300 - runningEntry.Started, scaleMode), 0, false)
+                    (timeEntryList[0].GUID, TimeToHeight(T1, scaleMode),
+                        TimeToHeight(T4 - T1, scaleMode), 0, false),
+                    (runningEntry.GUID, TimeToHeight(T4, scaleMode),
+                        TimeToHeight(300 - T4, scaleMode), 0, false)
                 }
             };
         }
@@ -146,20 +157,107 @@ namespace TogglDesktop.Tests
             var timeEntryList = new List<Toggl.TogglTimeEntryView>()
             {
                 new Toggl.TogglTimeEntryView()
-                    {GUID = "1", Started = _selectedDateUnix + 0, Ended = _selectedDateUnix + 150},
+                    {GUID = "1", Started = _selectedDateUnix + T1, Ended = _selectedDateUnix + T4},
             };
             var scaleMode = 1;
             var runningEntry = new Toggl.TogglTimeEntryView() { GUID = "4", Started = _selectedDateUnix - 600 };
+            var now = _selectedDate.Subtract(TimeSpan.FromSeconds(300));
             return new object[]
             {
                 timeEntryList,
-                new Toggl.TogglTimeEntryView() {GUID = "4", Started = _selectedDateUnix + 150},
+                runningEntry,
                 scaleMode,
-                _selectedDate.Subtract(TimeSpan.FromSeconds(300)),
+                now,
                 new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
                 {
-                    (timeEntryList[0].GUID, TimeToHeight(timeEntryList[0].Started - _selectedDateUnix, scaleMode),
-                        TimeToHeight(timeEntryList[0].Ended - timeEntryList[0].Started, scaleMode), 0, false)
+                    (timeEntryList[0].GUID, TimeToHeight(T1, scaleMode),
+                        TimeToHeight(T4 - T1, scaleMode), 0, false)
+                }
+            };
+        }
+
+        //Now >= selected date, and TE is running
+        private static object[] TestCase_MustIncludeMoreThan24HoursEntry()
+        {
+            var startTime = (ulong)Toggl.UnixFromDateTime(_selectedDate.Subtract(TimeSpan.FromHours(6)));
+            var endTime = (ulong)Toggl.UnixFromDateTime(_selectedDate.AddHours(25));
+            var timeEntryList = new List<Toggl.TogglTimeEntryView>()
+            {
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "1", Started = startTime, Ended = endTime},
+            };
+            var scaleMode = 1;
+            return new object[]
+            {
+                timeEntryList,
+                null,
+                scaleMode,
+                _selectedDate,
+                new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
+                {
+                    (timeEntryList[0].GUID, -TimeToHeight(6*3600, scaleMode), // Vertical offset must be negative, as start time is six hours before selected date
+                        TimeToHeight(endTime - startTime, scaleMode), 0, false)
+                }
+            };
+        }
+
+        //Time entries scheme:
+        //  |
+        //  |
+        //  |
+        //  |
+        private static object[] TestCase_NoOverlap()
+        {
+            var timeEntryList = new List<Toggl.TogglTimeEntryView>()
+            {
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "1", Started = _selectedDateUnix + T1, Ended = _selectedDateUnix + T4},
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "2", Started = _selectedDateUnix + T4, Ended = _selectedDateUnix + T6},
+            };
+            var scaleMode = 1;
+            return new object[]
+            {
+                timeEntryList,
+                null,
+                scaleMode,
+                _selectedDate,
+                new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
+                {
+                    (timeEntryList[0].GUID, TimeToHeight(T1, scaleMode),
+                        TimeToHeight(T4 - T1, scaleMode), 0, false),
+                    (timeEntryList[1].GUID, TimeToHeight(timeEntryList[1].Started - _selectedDateUnix, scaleMode),
+                        TimeToHeight(T6 - T4, scaleMode), 0, false)
+                }
+            };
+        }
+
+        //Running TE, and TE from the list have the same guid
+        private static object[] TestCase_SameGuid()
+        {
+            var timeEntryList = new List<Toggl.TogglTimeEntryView>()
+            {
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "1", Started = _selectedDateUnix + T1, Ended = _selectedDateUnix + T4},
+                new Toggl.TogglTimeEntryView()
+                    {GUID = "2", Started = _selectedDateUnix + T4, Ended = _selectedDateUnix + T6},
+            };
+            var scaleMode = 1;
+            var runningTE = new Toggl.TogglTimeEntryView()
+                { GUID = "2", Started = _selectedDateUnix + T4};
+
+            return new object[]
+            {
+                timeEntryList,
+                runningTE,
+                scaleMode,
+                _selectedDate.AddSeconds(T6),
+                new List<(string Guid, double VerticalOffset, double Height, double HorizontalOffset, bool IsOverlapping)>()
+                {
+                    (timeEntryList[0].GUID, TimeToHeight(T1, scaleMode),
+                        TimeToHeight(T4 - T1, scaleMode), 0, false),
+                    (timeEntryList[1].GUID, TimeToHeight(T4, scaleMode),
+                        TimeToHeight(T6 - T4, scaleMode), 0, false)
                 }
             };
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineGenerateGapTimeEntryBlocksTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineGenerateGapTimeEntryBlocksTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using TogglDesktop.ViewModels;
+using Xunit;
+
+namespace TogglDesktop.Tests
+{
+    public class TimelineGenerateGapTimeEntryBlocksTests
+    {
+        private static readonly DateTime _selectedDate = new DateTime(2020, 12, 3);
+
+        [Theory]
+        [MemberData(nameof(GetData))]
+        public void TestGenerateGapTimeEntryBlocks_CorrectOffsets(List<TimeEntryBlock> timeEntries,
+            List<(double VerticalOffset, double Height)> expectedValues)
+        {
+            var gaps = TimelineViewModel.GenerateGapTimeEntryBlocks(timeEntries);
+
+            Assert.Equal(gaps.Count, expectedValues.Count);
+            for (var i = 0; i < gaps.Count; i++)
+            {
+                Assert.Equal(expectedValues[i].VerticalOffset, gaps[i].VerticalOffset);
+                Assert.Equal(expectedValues[i].Height, gaps[i].Height);
+            }
+        }
+
+        public static IEnumerable<object[]> GetData()
+        {
+            yield return TestCase1();
+            yield return TestCase2();
+        }
+
+        //Time entries scheme:
+        //  |
+        //  |
+        //   
+        //  |
+        //  |
+        //   
+        //  |
+        //  |
+        private static object[] TestCase1()
+        {
+            var timeEntryList = new List<TimeEntryBlock>()
+            {
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 0, Height = 100},
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 150, Height = 100},
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 300, Height = 100}
+            };
+            
+            return new object[]
+            {
+                timeEntryList,
+                new List<(double VerticalOffset, double Height)>()
+                {
+                    (100, 50),
+                    (250, 50)
+                }
+            };
+        }
+
+        //Time entries scheme:
+        //  |
+        //  ||
+        //   |
+        // 
+        //  |
+        //  |
+        private static object[] TestCase2()
+        {
+            var timeEntryList = new List<TimeEntryBlock>()
+            {
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 0, Height = 100},
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 50, Height = 100},
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 200, Height = 100}
+            };
+
+            return new object[]
+            {
+                timeEntryList,
+                new List<(double VerticalOffset, double Height)>()
+                {
+                    (150, 50)
+                }
+            };
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineGenerateGapTimeEntryBlocksTests.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TimelineGenerateGapTimeEntryBlocksTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using TogglDesktop.Resources;
 using TogglDesktop.ViewModels;
 using Xunit;
 
@@ -28,6 +29,8 @@ namespace TogglDesktop.Tests
         {
             yield return TestCase1();
             yield return TestCase2();
+            yield return TestCase_NoSpaceForGap();
+            yield return TestCase_TooLittleSpaceForGap();
         }
 
         //Time entries scheme:
@@ -88,6 +91,47 @@ namespace TogglDesktop.Tests
                 {
                     (150, 50)
                 }
+            };
+        }
+
+        //Time entries scheme:
+        //  |
+        //  |
+        //  |
+        //  |
+        private static object[] TestCase_NoSpaceForGap()
+        {
+            var timeEntryList = new List<TimeEntryBlock>()
+            {
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 0, Height = 100},
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 100, Height = 100}
+            };
+
+            return new object[]
+            {
+                timeEntryList,
+                new List<(double VerticalOffset, double Height)>()
+            };
+        }
+
+        //No gap is generated for intervals less than 10 (TimelineConstants.MinGapTimeEntryHeight) now
+        private static object[] TestCase_TooLittleSpaceForGap()
+        {
+            var tooLittleHeight = TimelineConstants.MinGapTimeEntryHeight - 0.1;
+            var timeEntryList = new List<TimeEntryBlock>()
+            {
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 0, Height = 100},
+                new TimeEntryBlock(new Toggl.TogglTimeEntryView(), 100, _selectedDate)
+                    {VerticalOffset = 100 + tooLittleHeight, Height = 100}
+            };
+
+            return new object[]
+            {
+                timeEntryList,
+                new List<(double VerticalOffset, double Height)>()
             };
         }
     }

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="LibraryUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimelineConvertTimeEntriesToBlocksTests.cs" />
+    <Compile Include="TimelineGenerateGapTimeEntryBlocksTests.cs" />
     <Compile Include="UIUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Tests/TogglDesktop.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="LibraryIntegrationTests.cs" />
     <Compile Include="LibraryUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TimelineConvertTimeEntriesToBlocksTests.cs" />
     <Compile Include="UIUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -68,7 +68,7 @@ namespace TogglDesktop.ViewModels
                 .ToPropertyEx(this, x => x.ActivityBlocks);
             var blocksObservable = Toggl.TimelineTimeEntries
                 .CombineLatest(Toggl.RunningTimeEntry, scaleModeObservable,
-                    (list, running, mode) => ConvertTimeEntriesToBlocks(list, running, mode, SelectedDate));
+                    (list, running, mode) => ConvertTimeEntriesToBlocks(list, running, mode, SelectedDate, DateTime.Now));
             var blocksWithRunningObservable = blocksObservable.CombineLatest(Toggl.RunningTimeEntry,
                 (list, te) => (TimeEntries: list, Running: te))
                 .Where(_ => (TimeEntryBlocks == null || !TimeEntryBlocks.Any(item => item.Value.IsDragged)) && 
@@ -208,7 +208,8 @@ namespace TogglDesktop.ViewModels
         public static Dictionary<string, TimeEntryBlock> ConvertTimeEntriesToBlocks(List<Toggl.TogglTimeEntryView> timeEntries,
             Toggl.TogglTimeEntryView? runningEntry,
             int selectedScaleMode,
-            DateTime selectedDate)
+            DateTime selectedDate,
+            DateTime now)
         {
             var timeStampsList = new List<(TimeStampType Type, TimeEntryBlock Block)>();
             var blocks = new Dictionary<string, TimeEntryBlock>();
@@ -216,7 +217,7 @@ namespace TogglDesktop.ViewModels
             // - if it's a start time stamp, then pick up the minimum available offset, if none is available assign a new one.
             // - if it's an end time stamp, then release the offset which it occupied.
             IEnumerable<Toggl.TogglTimeEntryView> allEntries = timeEntries;
-            if (runningEntry != null && runningEntry.Value.StartTime().Date <= selectedDate.Date && DateTime.Now.Date >= selectedDate.Date)
+            if (runningEntry != null && runningEntry.Value.StartTime().Date <= selectedDate.Date && now.Date >= selectedDate.Date)
                 allEntries = allEntries.Union(new List<Toggl.TogglTimeEntryView>(){runningEntry.Value});
             foreach (var entry in allEntries)
             {
@@ -224,7 +225,7 @@ namespace TogglDesktop.ViewModels
 
                 var startTime = entry.StartTime();
                 var ended = entry.GUID == runningEntry?.GUID 
-                    ? (ulong)Toggl.UnixFromDateTime(DateTime.Now)
+                    ? (ulong)Toggl.UnixFromDateTime(now)
                     : entry.Ended;
                 var height = ConvertTimeIntervalToHeight(startTime, Toggl.DateTimeFromUnix(ended), selectedScaleMode);
                 var block = new TimeEntryBlock(entry, TimelineConstants.ScaleModes[selectedScaleMode], selectedDate)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -205,7 +205,7 @@ namespace TogglDesktop.ViewModels
             End,
             Empty
         }
-        private static Dictionary<string, TimeEntryBlock> ConvertTimeEntriesToBlocks(List<Toggl.TogglTimeEntryView> timeEntries,
+        public static Dictionary<string, TimeEntryBlock> ConvertTimeEntriesToBlocks(List<Toggl.TogglTimeEntryView> timeEntries,
             Toggl.TogglTimeEntryView? runningEntry,
             int selectedScaleMode,
             DateTime selectedDate)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -303,7 +303,7 @@ namespace TogglDesktop.ViewModels
             return timeInterval * TimelineConstants.ScaleModes[scaleMode] / 60;
         }
 
-        private static List<GapTimeEntryBlock> GenerateGapTimeEntryBlocks(List<TimeEntryBlock> timeEntries)
+        public static List<GapTimeEntryBlock> GenerateGapTimeEntryBlocks(List<TimeEntryBlock> timeEntries)
         {
             var gaps = new List<GapTimeEntryBlock>();
             TimeEntryBlock lastTimeEntry = null;


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Unit tests**

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4696 

### 🔎 Review hints
Introduced `now` parameter in `ConvertTimeEntriesToBlocks` method to test that `runningEntry` is filtered correctly.
