### PR TITLE
Fix crash with NullReferenceException in Tutorial

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -934,7 +934,15 @@ public static partial class Toggl
     public static readonly BehaviorSubject<DateTime> TimelineSelectedDate = new BehaviorSubject<DateTime>(DateTime.Today);
 
     public static readonly BehaviorSubject<TogglTimeEntryView?> RunningTimeEntry = new BehaviorSubject<TogglTimeEntryView?>(null);
-    public static IObservable<Unit> StoppedTimerState = RunningTimeEntry.Where(te => te == null).Select(_ => Unit.Default);
+
+    public static readonly IObservable<Unit> StoppedTimerState =
+        RunningTimeEntry
+        .Where(te => te == null)
+        .Select(_ => Unit.Default);
+    public static readonly IObservable<TogglTimeEntryView> RunningTimerState =
+        RunningTimeEntry
+            .Where(te => te != null)
+            .Select(te => te.Value);
     public static event DisplayTimelineUI OnDisplayTimelineUI = delegate { };
     private static void listenToLibEvents()
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
@@ -17,6 +17,7 @@
     <FontFamily x:Key="DefaultFont">Segoe UI</FontFamily>
 
     <sys:Double x:Key="TimerHeight">68</sys:Double>
+    <sys:Double x:Key="TabsHeight">40</sys:Double>
 
     <Style TargetType="Control">
         <Setter Property="FontFamily" Value="{StaticResource DefaultFont}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen2.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen2.xaml.cs
@@ -1,6 +1,4 @@
-﻿
-using System;
-using System.Reactive.Disposables;
+﻿using System;
 
 namespace TogglDesktop.Tutorial
 {
@@ -14,7 +12,7 @@ namespace TogglDesktop.Tutorial
         private IDisposable _runningTimeEntryObservable;
         protected override void initialise()
         {
-            _runningTimeEntryObservable = Toggl.RunningTimeEntry.Subscribe(this.onRunningTimerState);
+            _runningTimeEntryObservable = Toggl.RunningTimerState.Subscribe(this.onRunningTimerState);
             this.tutorialManager.Timer.DescriptionTextBoxTextChanged += this.onDescriptionTextChanged;
         }
 
@@ -24,7 +22,7 @@ namespace TogglDesktop.Tutorial
             this.tutorialManager.Timer.DescriptionTextBoxTextChanged -= this.onDescriptionTextChanged;
         }
 
-        private void onRunningTimerState(Toggl.TogglTimeEntryView? te)
+        private void onRunningTimerState(Toggl.TogglTimeEntryView te)
         {
             this.tutorialManager.ActivateScreen<BasicTutorialScreen4>();
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen3.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen3.xaml.cs
@@ -1,6 +1,5 @@
 ﻿
 using System;
-using System.Reactive.Disposables;
 
 namespace TogglDesktop.Tutorial
 {
@@ -14,7 +13,7 @@ namespace TogglDesktop.Tutorial
         private IDisposable _runningTimeEntryObservable;
         protected override void initialise()
         {
-            _runningTimeEntryObservable = Toggl.RunningTimeEntry.Subscribe(this.onRunningTimerState);
+            _runningTimeEntryObservable = Toggl.RunningTimerState.Subscribe(this.onRunningTimerState);
         }
 
         protected override void cleanup()
@@ -22,7 +21,7 @@ namespace TogglDesktop.Tutorial
             _runningTimeEntryObservable.Dispose();
         }
 
-        private void onRunningTimerState(Toggl.TogglTimeEntryView? te)
+        private void onRunningTimerState(Toggl.TogglTimeEntryView te)
         {
             this.activateScreen<BasicTutorialScreen4>();
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen4.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen4.xaml.cs
@@ -21,7 +21,7 @@ namespace TogglDesktop.Tutorial
         protected override void cleanup()
         {
             Toggl.OnTimeEntryEditor -= this.onTimeEntryEditor;
-            _timerStateObservable.Dispose();
+            _timerStateObservable?.Dispose();
         }
 
         private void onTimeEntryEditor(bool open, Toggl.TogglTimeEntryView te, string focusedFieldName)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen5.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen5.xaml.cs
@@ -22,7 +22,7 @@ namespace TogglDesktop.Tutorial
         protected override void cleanup()
         {
             Toggl.OnTimeEntryList -= this.onTimeEntryList;
-            _timerStateObservable.Dispose();
+            _timerStateObservable?.Dispose();
         }
 
         private void onTimeEntryList(bool open, List<Toggl.TogglTimeEntryView> list, bool showLoadMoreButton)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen6.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen6.xaml.cs
@@ -19,7 +19,7 @@ namespace TogglDesktop.Tutorial
 
         protected override void cleanup()
         {
-            _timerStateObservable.Dispose();
+            _timerStateObservable?.Dispose();
         }
 
         private void onStoppedTimerState()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen7.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen7.xaml
@@ -5,24 +5,30 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:tutorial="clr-namespace:TogglDesktop.Tutorial"
              xmlns:toggl="clr-namespace:TogglDesktop"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" 
              d:DesignHeight="559.069" d:DesignWidth="381.927"
              Style="{StaticResource TutorialScreen}">
+    <UserControl.Resources>
+        <system:Double x:Key="TabsHeight">40</system:Double>
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition />
         </Grid.RowDefinitions>
         <FrameworkElement Grid.Row="0" Height="{DynamicResource TimerHeight}"/>
-        <FrameworkElement Grid.Row="1" Height="{StaticResource TimeEntryDayHeaderHeight}"/>
-        <FrameworkElement Grid.Row="2" Height="{StaticResource TimeEntryHeight}"/>
+        <FrameworkElement Grid.Row="1" Height="{StaticResource TabsHeight}"/>
+        <FrameworkElement Grid.Row="2" Height="{StaticResource TimeEntryDayHeaderHeight}"/>
+        <FrameworkElement Grid.Row="3" Height="{StaticResource TimeEntryHeight}"/>
 
-        <Grid Grid.Row="3" Background="{StaticResource ViewBackgroundLight}">
+        <Grid Grid.Row="4" Background="{StaticResource ViewBackgroundLight}">
             <StackPanel Background="{StaticResource TutorialDarkOverlay}">
                 <Grid Margin="0 0 0 40">
-                    <TextBlock Margin="20 10 10 10" TextAlignment="Center"
+                    <TextBlock Margin="30 10 10 10" TextAlignment="Center"
                         HorizontalAlignment="Left">
                         <Image Source="/TogglDesktop;component/Resources/tutorial-arrow-curved.png"
                                Height="22" VerticalAlignment="Top" Margin="-20 -5 -10 5">
@@ -36,7 +42,7 @@
                         in the list.
                     </TextBlock>
 
-                    <TextBlock Margin="10" HorizontalAlignment="Right">
+                    <TextBlock Margin="10 10 20 10" HorizontalAlignment="Right">
                         Or <Bold>continue</Bold>
                         <Image Source="/TogglDesktop;component/Resources/tutorial-arrow-curved.png"
                                Height="22" VerticalAlignment="Top" Margin="-15 -5 -10 5">
@@ -60,7 +66,7 @@
             </StackPanel>
         </Grid>
 
-        <toggl:ProgressBar Grid.Row="3" Margin="30 20"
+        <toggl:ProgressBar Grid.Row="4" Margin="30 20"
             VerticalAlignment="Bottom"
             MaxValue="6" Value="6"/>
     </Grid>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen7.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen7.xaml
@@ -9,9 +9,6 @@
              mc:Ignorable="d" 
              d:DesignHeight="559.069" d:DesignWidth="381.927"
              Style="{StaticResource TutorialScreen}">
-    <UserControl.Resources>
-        <system:Double x:Key="TabsHeight">40</system:Double>
-    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen7.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Tutorial/BasicTutorialScreen7.xaml.cs
@@ -1,6 +1,5 @@
 ﻿
 using System;
-using System.Windows;
 
 namespace TogglDesktop.Tutorial
 {
@@ -14,7 +13,7 @@ namespace TogglDesktop.Tutorial
         private IDisposable _runningTimeEntryObservable;
         protected override void initialise()
         {
-            _runningTimeEntryObservable = Toggl.RunningTimeEntry.Subscribe(this.onRunningTimerState);
+            _runningTimeEntryObservable = Toggl.RunningTimerState.Subscribe(this.onRunningTimerState);
             Toggl.OnTimeEntryEditor += this.onTimerEntryEditor;
         }
 
@@ -24,7 +23,7 @@ namespace TogglDesktop.Tutorial
             Toggl.OnTimeEntryEditor -= this.onTimerEntryEditor;
         }
 
-        private void onRunningTimerState(Toggl.TogglTimeEntryView? te)
+        private void onRunningTimerState(Toggl.TogglTimeEntryView te)
         {
             this.quitTutorial();
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimerViewModel.cs
@@ -27,7 +27,7 @@ namespace TogglDesktop.ui.ViewModels
 
             setupSecondsTimer();
 
-            Toggl.RunningTimeEntry.Subscribe(onRunningTimerState);
+            Toggl.RunningTimerState.Subscribe(onRunningTimerState);
             Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
 
             ResetRunningTimeEntry(false, true);
@@ -72,12 +72,11 @@ namespace TogglDesktop.ui.ViewModels
             };
         }
 
-        private void onRunningTimerState(Toggl.TogglTimeEntryView? te)
+        private void onRunningTimerState(Toggl.TogglTimeEntryView te)
         {
             using (Performance.Measure("timer responding to OnRunningTimerState"))
             {
-                if (te != null)
-                    SetRunningTimeEntry(te.Value);
+                SetRunningTimeEntry(te);
                 secondsTimer.IsEnabled = true;
             }
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml
@@ -26,7 +26,8 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
-                                <Border BorderThickness="0" Margin="0,0,0,0" Background="{DynamicResource Toggl.CardBackground}" Height="40"
+                                <Border BorderThickness="0" Margin="0,0,0,0" Background="{DynamicResource Toggl.CardBackground}"
+                                        Height="{StaticResource TabsHeight}"
                                         Visibility="{Binding Path=IsTimelineViewEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                                     <UniformGrid Rows="1" x:Name="HeaderPanel" IsItemsHost="True"
                                                  VerticalAlignment="Stretch"/>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -240,8 +240,7 @@ namespace TogglDesktop
             Toggl.OnOnlineState += this.onOnlineState;
             Toggl.OnURL += this.onURL;
             Toggl.OnUserTimeEntryStart += this.onUserTimeEntryStart;
-            Toggl.RunningTimeEntry.Subscribe(this.onRunningTimerState);
-            Toggl.StoppedTimerState.Subscribe(_ => this.onStoppedTimerState());
+            Toggl.RunningTimeEntry.Subscribe(this.onRunningTimeEntry);
             Toggl.OnSettings += this.onSettings;
             Toggl.OnDisplayInAppNotification += this.onDisplayInAppNotification;
         }
@@ -301,17 +300,9 @@ namespace TogglDesktop
             }
         }
 
-        private void onStoppedTimerState()
+        private void onRunningTimeEntry(Toggl.TogglTimeEntryView? te)
         {
-            if (this.TryBeginInvoke(this.onStoppedTimerState))
-                return;
-
-            this.updateTracking(null);
-        }
-
-        private void onRunningTimerState(Toggl.TogglTimeEntryView? te)
-        {
-            if (this.TryBeginInvoke(this.onRunningTimerState, te))
+            if (this.TryBeginInvoke(this.onRunningTimeEntry, te))
                 return;
 
             this.updateTracking(te);


### PR DESCRIPTION
### 📒 Description
Fix crash with NullReferenceException in Tutorial.
Tweak the tutorial screen to adjust for UI changes.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Update the tutorial on RunningTimerState (when the time entry starts running) instead of RunningTimeEntry (time entry is running or stopped).
- [x] Use RunningTimerState instead of RunningTimeEntry in the TimerViewModel, as it's the way it has worked there before.
- [x] Remove StoppedTimerState from MainWindow as it's not needed there.
- [x] Tweak the XAML of Tutorial Screen 7 to account for the newly introduced tabs (List/Timeline).

### 👫 Relationships
Closes #4733.

### 🔎 Review hints
Check there's no crash when working with the tutorial.
Check that the XAML update in TutorialScreen7 makes sense.
Running/Stopped timer states - smoke test for any other possible issues related to it.