### PR TITLE
Enable per monitor DPI (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.config
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.config
@@ -42,4 +42,7 @@
             </setting>
         </TogglDesktop.Properties.Settings>
     </userSettings>
+  <runtime>
+    <AppContextSwitchOverrides value = "Switch.System.Windows.DoNotScaleForDpiChanges=false"/>
+  </runtime>
 </configuration>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/app.manifest
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/app.manifest
@@ -49,13 +49,14 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <!--
+
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings"> PerMonitor</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </windowsSettings>
   </application>
-  -->
+
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--


### PR DESCRIPTION
### 📒 Description
Enabled per monitor DPI as it's described here https://github.com/microsoft/WPF-Samples/blob/master/PerMonitorDPI/readme.md

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
App.config
app.manifest

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #2066 

### 🔎 Review hints
Requires 2 monitors with different DPI. How to test:
1. Start the app on the screen with higher DPI.
2. Drag it to the screen with lower DPI.
3. See if the text doesn't get blurred.

