### PR TITLE
Fix press enter twice to start timer

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
@@ -356,7 +356,7 @@ namespace TogglDesktop
         {
             var item = this.controller.SelectedItem;
             this.select(item, withKeyboard);
-            return true;
+            return item != null;
         }
 
         private void select(IAutoCompleteItem item, bool withKeyboard)


### PR DESCRIPTION
### 📒 Description
Fixes bug: when Autocompletion popup is open, user has to press Enter twice; first one to close the popup, and second one to actually start the timer.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue) 
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
Don't set PreviewKeyDown event to handled in AutoCompletionPopup.xaml.cs

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4158 

### 🔎 Review hints
Test that the following keys work as expected when focused and not on timer: key down, key up, esc, enter.
