### PR TITLE
Fix description is not always shown for long non-overlapping TEs

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -89,8 +89,8 @@ namespace TogglDesktop.ViewModels
                 .Select(h => h >= TimelineConstants.MinResizableTimeEntryBlockHeight)
                 .Where(_ => !IsDragged)
                 .ToPropertyEx(this, x => x.IsResizable);
-            this.WhenAnyValue(x => x.IsOverlapping)
-                .Select(isOverlapping => !isOverlapping && Height >= TimelineConstants.MinShowTEDescriptionHeight)
+            this.WhenAnyValue(x => x.IsOverlapping, x => x.Height,
+                (isOverlapping, height) => !isOverlapping && height >= TimelineConstants.MinShowTEDescriptionHeight)
                 .ToPropertyEx(this, x => x.ShowDescription);
         }
 


### PR DESCRIPTION
### 📒 Description
Fix description is not always shown for long non-overlapping TEs.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4737 

### 🔎 Review hints
Try to create a TE > 15 mins, drag to change its start/end. Try to create an overlapping TE. 

