### PR TITLE
Don't set stop time if it's not valid (lib)

### DIFF
--- a/src/model/time_entry.h
+++ b/src/model/time_entry.h
@@ -55,7 +55,6 @@ class TOGGL_INTERNAL_EXPORT TimeEntry : public BaseModel, public TimedEvent {
     void SetStartTime(Poco::Int64 value, bool userModified);
 
     std::string StopString() const;
-    void SetStopString(const std::string &value, bool userModified);
     void SetStopTime(Poco::Int64 value, bool userModified);
 
     void SetDurationInSeconds(const Poco::Int64 value, bool userModified);

--- a/src/test/app_test.cc
+++ b/src/test/app_test.cc
@@ -1200,16 +1200,12 @@ TEST(TimeEntry, ParseDurationLargerThan24Hours) {
                       toggl::Format::Improved));
 }
 
-TEST(TimeEntry, InterpretsCrazyStartAndStopAsMissingValues) {
+TEST(TimeEntry, InterpretsCrazyStartAsMissingValues) {
     TimeEntry te;
 
     ASSERT_EQ(Poco::UInt64(0), te.StartTime());
     te.SetStartString("0003-03-16T-7:-19:-24Z", false);
     ASSERT_EQ(Poco::UInt64(0), te.StartTime());
-
-    ASSERT_EQ(Poco::UInt64(0), te.StopTime());
-    te.SetStopString("0003-03-16T-5:-52:-51Z", false);
-    ASSERT_EQ(Poco::UInt64(0), te.StopTime());
 }
 
 TEST(User, Continue) {


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Instead of setting `stop time` string right away, we should first check if this date is valid and > than `start time`.

This will probably fix the "Stop time year must be between 2006 and 2030" error.

From the logs, we can tell that this error is triggered by the Edit popover (because of the `DisplayTimeEntryEditor` event).
Platform code on Edit popover is very straightforward, it just passes text from the text field to the library. So I suppose the error is not there.

So the root cause of this issue is still unknown to me... From what I see this would happen only if when setting stop time string and `te->StartTime()` returns 0 (context.cc, line 3684). But it seems strange.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3193

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Please tell me if this solution makes sense.
