### PR TITLE
Fix Editor color when switching between dark/light modes (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/EditorPopover.swift
+++ b/src/ui/osx/TogglDesktop/Features/TimeEntryEditor/EditorPopover.swift
@@ -23,7 +23,6 @@ final class EditorPopover: NoVibrantPopoverView {
     @objc func prepareViewController() {
         let editor = EditorViewController(nibName: NSNib.Name("EditorViewController"), bundle: nil)
         editor.delegate = self
-        editor.view.appearance = appearance
         let size = DesktopLibraryBridge.shared().getEditorWindowSize()
         editor.view.frame.size = size
         contentViewController = editor


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Fixes a bug when Edit popover was not changing its color when a system changed the appearance to dark/light theme. Editor stayed the same every time you opened it.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3160

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Editor changes its appearance only when you reopen it. E.g.:
1. Open Edit popover
1. Change system theme while popover is visible
1. Popover won't change
1. Close and open it again
1. Popover changed its appearance

It wasn't possible to make it update when it was opened because of our custom logic for removing vibrancy from the popover.
