### PR TITLE
Set idle state when PC is locked

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4515,7 +4515,7 @@ void Context::SetSleep() {
     // Set Sleep as usual
     if (!isHandled) {
         logger.debug("SetSleep");
-        idle_.SetSleep();
+        idle_.SetSystemLocked();
         if (window_change_recorder_) {
             window_change_recorder_->SetIsSleeping(true);
         }
@@ -4673,7 +4673,7 @@ void Context::onWake(Poco::Util::TimerTask&) {  // NOLINT
             updateUI(render);
         }
 
-        idle_.SetWake(user_);
+        idle_.SetSystemUnlocked(user_);
         if (window_change_recorder_) {
             window_change_recorder_->SetIsSleeping(false);
         }
@@ -4693,6 +4693,7 @@ void Context::onWake(Poco::Util::TimerTask&) {  // NOLINT
 
 void Context::SetLocked() {
     logger.debug("SetLocked");
+    idle_.SetSystemLocked();
     if (window_change_recorder_) {
         window_change_recorder_->SetIsLocked(true);
     }
@@ -4700,6 +4701,7 @@ void Context::SetLocked() {
 
 void Context::SetUnlocked() {
     logger.debug("SetUnlocked");
+    idle_.SetSystemUnlocked(user_);
     if (window_change_recorder_) {
         window_change_recorder_->SetIsLocked(false);
     }

--- a/src/idle.cc
+++ b/src/idle.cc
@@ -17,7 +17,7 @@ namespace toggl {
 Idle::Idle(GUI *ui)
     : last_idle_seconds_reading_(0)
 , last_idle_started_(0)
-, last_sleep_started_(0)
+, last_locked_started_(0)
 , ui_(ui) {
 }
 

--- a/src/idle.h
+++ b/src/idle.h
@@ -28,19 +28,20 @@ class TOGGL_INTERNAL_EXPORT Idle {
         settings_ = settings;
     }
 
-    void SetSleep() {
-        last_sleep_started_ = time(nullptr);
+    void SetSystemLocked() {
+        if (!last_locked_started_)
+            last_locked_started_ = time(nullptr);
     }
 
-    void SetWake(User *current_user) {
-        if (last_sleep_started_) {
-            Poco::Int64 slept_seconds = time(nullptr) - last_sleep_started_;
+    void SetSystemUnlocked(User *current_user) {
+        if (last_locked_started_) {
+            Poco::Int64 slept_seconds = time(nullptr) - last_locked_started_;
             if (slept_seconds > 0) {
                 SetIdleSeconds(slept_seconds, current_user);
             }
         }
 
-        last_sleep_started_ = 0;
+        last_locked_started_ = 0;
     }
 
  private:
@@ -52,7 +53,7 @@ class TOGGL_INTERNAL_EXPORT Idle {
     // Idle detection related values
     Poco::Int64 last_idle_seconds_reading_;
     Poco::Int64 last_idle_started_;
-    time_t last_sleep_started_;
+    time_t last_locked_started_;
 
     Settings settings_;
     GUI *ui_;


### PR DESCRIPTION
### 📒 Description
Forces `SetIdleSeconds` call after PC is unlocked.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3967 

### 🔎 Review hints
How to test: 
1. Turn on idle notifications.
2. Run the app an lock the PC. Keep it locked for long enough to get the notification, but meanwhile move the mouse or type on keyboard to make the PC receive some input.
3. Unlock; there should be an idle notification.

