### PR TITLE
Fix activity menu tooltip about total time (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/App/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/App/AppDelegate.m
@@ -119,6 +119,7 @@
 
 void *ctx;
 
+static NSString *statusItemDefaultTooltip = @"Total today: 0h 0min";
 
 - (void)applicationWillFinishLaunching:(NSNotification *)not
 {
@@ -819,8 +820,10 @@ void *ctx;
 			free(str);
 		}
 
-		// Update tooltip
-		[self.statusItem setToolTip:[NSString stringWithFormat:@"Total today: %@", self.lastKnownRunningTimeEntry.dateDuration]];
+		// Update tooltip if was not set before
+		if ([self.statusItem.toolTip isEqualToString:statusItemDefaultTooltip]) {
+			[self.statusItem setToolTip:[NSString stringWithFormat:@"Total today: %@", self.lastKnownRunningTimeEntry.dateDuration]];
+		}
 	}
 
 	NSString *key = nil;
@@ -1554,7 +1557,7 @@ void on_time_entry_list(const bool_t open,
 						TogglTimeEntryView *first,
 						const bool_t show_load_more)
 {
-	NSString *todayTotal = @"Total today: 0h 0min";
+	NSString *todayTotal = statusItemDefaultTooltip;
 	NSMutableArray *viewitems = [[NSMutableArray alloc] init];
 	TogglTimeEntryView *it = first;
 

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -792,7 +792,7 @@
 		69FC180217E6534400B96425 /* TogglDesktop-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TogglDesktop-Prefix.pch"; sourceTree = "<group>"; };
 		69FC180417E6534400B96425 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = en; path = en.lproj/Credits.rtf; sourceTree = "<group>"; };
 		69FC180617E6534400B96425 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
-		69FC180717E6534400B96425 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		69FC180717E6534400B96425 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; usesTabs = 1; };
 		69FC181217E6534500B96425 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		74033C8D17EC1CFD00CA53D3 /* libstdc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.dylib"; path = "usr/lib/libstdc++.dylib"; sourceTree = SDKROOT; };
 		74033C9617EC1DE100CA53D3 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Fixes bug when tooltip on activity menu was showing currently running TE duration instead of total time.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4255

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Tested cases:
1. When today section is empty and there is a running TE
2. When today section has items and there is a running TE
3. Cases above but when TE is not running
