### PR TITLE
Vertically center text on project select button (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Common/Views/TextFields/VerticallyCenteredTextFieldCell.swift
+++ b/src/ui/osx/TogglDesktop/Common/Views/TextFields/VerticallyCenteredTextFieldCell.swift
@@ -90,6 +90,7 @@ final class VerticallyCenteredButtonCell: NSButtonCell {
 
     @IBInspectable var focusRingCornerRadius: CGFloat = 0
     @IBInspectable var leftPadding: CGFloat = 0
+    @IBInspectable var verticalTitleOffset: CGFloat = 0
 
     override func drawingRect(forBounds theRect: NSRect) -> NSRect {
         var newRect = super.drawingRect(forBounds: theRect)
@@ -99,6 +100,12 @@ final class VerticallyCenteredButtonCell: NSButtonCell {
         newRect.size.width -= leftPadding
 
         return newRect
+    }
+
+    override func titleRect(forBounds rect: NSRect) -> NSRect {
+        var titleFrame = super.titleRect(forBounds: rect)
+        titleFrame.origin.y += verticalTitleOffset
+        return titleFrame
     }
 
     override func drawFocusRingMask(withFrame cellFrame: NSRect, in controlView: NSView) {

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.xib
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -113,9 +113,14 @@
                                     <constraints>
                                         <constraint firstAttribute="height" constant="24" id="aos-pz-lzF"/>
                                     </constraints>
-                                    <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="project-button" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" imageScaling="proportionallyDown" inset="2" id="XiJ-UQ-fKx">
+                                    <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="project-button" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" imageScaling="proportionallyDown" inset="2" id="XiJ-UQ-fKx" customClass="VerticallyCenteredButtonCell" customModule="Toggl_Track" customModuleProvider="target">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" size="12" name="HelveticaNeue"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="verticalTitleOffset">
+                                                <real key="value" value="-1"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
                                     </buttonCell>
                                     <color key="contentTintColor" name="lighter-grey-color"/>
                                     <userDefinedRuntimeAttributes>
@@ -145,7 +150,7 @@
                                         <constraint firstAttribute="width" constant="24" id="K6L-TG-EPU"/>
                                         <constraint firstAttribute="height" constant="24" id="hHI-j8-8eD"/>
                                     </constraints>
-                                    <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="tag-button" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="gdT-xR-BDt">
+                                    <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="tag-button" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="gdT-xR-BDt" customClass="VerticallyCenteredButtonCell" customModule="Toggl_Track" customModuleProvider="target">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" size="12" name="HelveticaNeue"/>
                                     </buttonCell>
@@ -177,7 +182,7 @@
                                         <constraint firstAttribute="width" constant="24" id="1aZ-p7-qEl"/>
                                         <constraint firstAttribute="height" constant="24" id="MD6-2y-exy"/>
                                     </constraints>
-                                    <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="billable-button" imagePosition="only" alignment="center" enabled="NO" imageScaling="proportionallyDown" inset="2" id="im8-is-hrS">
+                                    <buttonCell key="cell" type="roundRect" bezelStyle="roundedRect" image="billable-button" imagePosition="only" alignment="center" enabled="NO" imageScaling="proportionallyDown" inset="2" id="im8-is-hrS" customClass="VerticallyCenteredButtonCell" customModule="Toggl_Track" customModuleProvider="target">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" size="12" name="HelveticaNeue"/>
                                     </buttonCell>


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Updates vertical position of text on "project select" button.
`NSButton` text position is not centered by default. This PR introduces the ability to set offset on title when needed.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4762

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

