### PR TITLE
Update Bundler (mac)

### DIFF
--- a/src/ui/osx/Gemfile.lock
+++ b/src/ui/osx/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    json (2.4.0)
+    json (2.4.1)
     minitest (5.14.2)
     molinillo (0.6.6)
     nanaimo (0.3.0)
@@ -74,7 +74,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.8)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -85,9 +85,10 @@ GEM
 
 PLATFORMS
   ruby
+  universal-darwin-20
 
 DEPENDENCIES
   cocoapods (~> 1.10.0)
 
 BUNDLED WITH
-   2.0.2
+   2.2.1


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
GH Actions workflow for releasing macOS app breaks with an error:
```
error: Your local changes to the following files would be overwritten by checkout:
2457
	src/ui/osx/Gemfile.lock
```

Seems like GH uses a different version of Bundler that makes new changes to Gemfile.lock.
Updated to latest Bundler version to fix this.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Potentially closes #4767

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Merge and see if it builds 😄 
