### PR TITLE
Fix automatic scrolling to first entry

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -94,11 +94,10 @@ namespace TogglDesktop.ViewModels
                     GenerateRunningGapBlock(tuple.TimeEntries.Values, tuple.Running, CurrentTimeOffset, SelectedDate))
                 .ToPropertyEx(this, x => x.RunningGapTimeEntryBlock);
 
-            this.WhenAnyValue(x => x.TimeEntryBlocks)
+            FistTimeEntryOffsetForSelectedDate = this.WhenAnyValue(x => x.TimeEntryBlocks)
                 .Select(_ => SelectedDate).Buffer(2, 1)
                 .Where(b => b[1] != b[0]) // if there is new first TE offset for the same date, skip
-                .Select(blocks => TimeEntryBlocks.MinOrDefaultTimeEntryBlock())
-                .ToPropertyEx(this, x => x.FirstTimeEntryOffset);
+                .Select(blocks => TimeEntryBlocks.FirstTimeEntryVerticalOffset());
 
             Toggl.OnTimeEntryList += HandleTimeEntryListChanged;
             Toggl.OnTimeEntryEditor += (open, te, field) =>
@@ -429,7 +428,7 @@ namespace TogglDesktop.ViewModels
         public ReactiveCommand<Unit, int> IncreaseScale { get; }
         public ReactiveCommand<Unit, int> DecreaseScale { get; }
 
-        public double? FirstTimeEntryOffset { [ObservableAsProperty] get; }
+        public IObservable<double?> FistTimeEntryOffsetForSelectedDate { get; }
 
         [Reactive]
         public double CurrentTimeOffset { get; set; }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -95,8 +95,9 @@ namespace TogglDesktop.ViewModels
                 .ToPropertyEx(this, x => x.RunningGapTimeEntryBlock);
 
             this.WhenAnyValue(x => x.TimeEntryBlocks)
-                .Select(blocks => blocks == null || !blocks.Any() ? (double?)null 
-                    : blocks.Min(te => te.Value.VerticalOffset))
+                .Select(_ => SelectedDate).Buffer(2, 1)
+                .Where(b => b[1] != b[0]) // if there is new first TE offset for the same date, skip
+                .Select(blocks => TimeEntryBlocks.MinOrDefaultTimeEntryBlock())
                 .ToPropertyEx(this, x => x.FirstTimeEntryOffset);
 
             Toggl.OnTimeEntryList += HandleTimeEntryListChanged;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -95,8 +95,8 @@ namespace TogglDesktop.ViewModels
                 .ToPropertyEx(this, x => x.RunningGapTimeEntryBlock);
 
             this.WhenAnyValue(x => x.TimeEntryBlocks)
-                .Where(blocks => blocks != null && blocks.Any())
-                .Select(blocks => blocks.Min(te => te.Value.VerticalOffset))
+                .Select(blocks => blocks == null || !blocks.Any() ? (double?)null 
+                    : blocks.Min(te => te.Value.VerticalOffset))
                 .ToPropertyEx(this, x => x.FirstTimeEntryOffset);
 
             Toggl.OnTimeEntryList += HandleTimeEntryListChanged;
@@ -428,7 +428,7 @@ namespace TogglDesktop.ViewModels
         public ReactiveCommand<Unit, int> IncreaseScale { get; }
         public ReactiveCommand<Unit, int> DecreaseScale { get; }
 
-        public double FirstTimeEntryOffset { [ObservableAsProperty] get; }
+        public double? FirstTimeEntryOffset { [ObservableAsProperty] get; }
 
         [Reactive]
         public double CurrentTimeOffset { get; set; }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -50,10 +50,8 @@ namespace TogglDesktop
                     .DisposeWith(_disposable);
                 ViewModel?.WhenAnyValue(x => x.FirstTimeEntryOffset)
                     .ObserveOn(RxApp.MainThreadScheduler)
-                    .Select(_ => ViewModel.SelectedDate).Buffer(2, 1)
-                    .Where(b => !ViewModel.IsTodaySelected && ViewModel.FirstTimeEntryOffset.HasValue &&
-                                b[1] != b[0]) // if there is new first TE offset for the same date, skip
-                    .Subscribe(value => SetMainViewScrollOffset(ViewModel.FirstTimeEntryOffset.Value))
+                    .Where(offset => !ViewModel.IsTodaySelected && offset.HasValue)
+                    .Subscribe(offset => SetMainViewScrollOffset(offset.Value))
                     .DisposeWith(_disposable);
             }
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -48,7 +48,7 @@ namespace TogglDesktop
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(_ => MainViewScroll.ScrollToVerticalOffset(ViewModel.CurrentTimeOffset - MainViewScroll.ActualHeight / 2))
                     .DisposeWith(_disposable);
-                ViewModel?.WhenAnyValue(x => x.FirstTimeEntryOffset)
+                ViewModel?.FistTimeEntryOffsetForSelectedDate
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Where(offset => !ViewModel.IsTodaySelected && offset.HasValue)
                     .Subscribe(offset => SetMainViewScrollOffset(offset.Value))

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml.cs
@@ -50,8 +50,10 @@ namespace TogglDesktop
                     .DisposeWith(_disposable);
                 ViewModel?.WhenAnyValue(x => x.FirstTimeEntryOffset)
                     .ObserveOn(RxApp.MainThreadScheduler)
-                    .Where(_ => !ViewModel.IsTodaySelected)
-                    .Subscribe(SetMainViewScrollOffset)
+                    .Select(_ => ViewModel.SelectedDate).Buffer(2, 1)
+                    .Where(b => !ViewModel.IsTodaySelected && ViewModel.FirstTimeEntryOffset.HasValue &&
+                                b[1] != b[0]) // if there is new first TE offset for the same date, skip
+                    .Subscribe(value => SetMainViewScrollOffset(ViewModel.FirstTimeEntryOffset.Value))
                     .DisposeWith(_disposable);
             }
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -45,7 +45,7 @@ namespace TogglDesktop
         public static bool IsOverlappingWith(this TimeEntryBlock first, TimeEntryBlock second) =>
             first.Started < second.Ended && second.Started < first.Ended;
 
-        public static double? MinOrDefaultTimeEntryBlock(this IDictionary<string, TimeEntryBlock> blocks) =>
+        public static double? FirstTimeEntryVerticalOffset(this IDictionary<string, TimeEntryBlock> blocks) =>
             blocks == null || !blocks.Any()
                 ? (double?) null
                 : blocks.Min(te => te.Value.VerticalOffset);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using TogglDesktop.ViewModels;
 
 namespace TogglDesktop
@@ -42,5 +44,10 @@ namespace TogglDesktop
 
         public static bool IsOverlappingWith(this TimeEntryBlock first, TimeEntryBlock second) =>
             first.Started < second.Ended && second.Started < first.Ended;
+
+        public static double? MinOrDefaultTimeEntryBlock(this IDictionary<string, TimeEntryBlock> blocks) =>
+            blocks == null || !blocks.Any()
+                ? (double?) null
+                : blocks.Min(te => te.Value.VerticalOffset);
     }
 }


### PR DESCRIPTION
### 📒 Description
Fixes scrolling for two scenarios:
1. You have no entries tracked today, then you go to some day with some TEs, then go back to today and then back to that day. No scrolling happened previously.
2. You so to some day with no entries (not today). Create a TE. Scrolling happened here, despite it shouldn't.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes

- TimelineViewModel.FirstTimeEntryOffset was made a nullable double
- Timeline.xaml.cs condition for calling `SetMainViewScrollOffset`

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4760 

### 🔎 Review hints
Test the scenarios described in Description section.

