### PR TITLE
Close duration dropdown when user clicks the List/Timeline tabs

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timeline/MainDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timeline/MainDashboardViewController.swift
@@ -60,10 +60,18 @@ final class MainDashboardViewController: NSViewController {
     }
 
     @IBAction func listBtnOnTap(_ sender: Any) {
+        guard currentTab != .timeEntryList else {
+            view.window?.makeFirstResponder(nil)
+            return
+        }
         currentTab = .timeEntryList
     }
 
     @IBAction func timelineBtnOnTap(_ sender: Any) {
+        guard currentTab != .timeline else {
+            view.window?.makeFirstResponder(nil)
+            return
+        }
         currentTab = .timeline
         timelineController.scrollToVisibleItem()
         // Onboarding states


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Previously duration dropdown would close when switching between tabs, but if you're already on the List tab and click the button again - nothing would happen. This PR fixes that.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4742

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

