### PR TITLE
Clean git repo before proceeding with release script

### DIFF
--- a/dist/update_releases.sh
+++ b/dist/update_releases.sh
@@ -16,6 +16,7 @@ if [[ ! $channel =~ ^(dev|beta|stable)$ ]]; then
 fi
 
 prepare() {
+  git clean -xdf
   # Copy to tmp folder before checkout to gh-pages
   mkdir -p tmp
   cp dist/update_updates.sh tmp/update_updates.sh


### PR DESCRIPTION
### 📒 Description
GH Actions workflow for releasing macOS app breaks with an error:
```
error: Your local changes to the following files would be overwritten by checkout:
2457
	src/ui/osx/Gemfile.lock
```

Cleaning the git repo before proceeding with the release script should be totally fine and it should clean up any local changes that have appeared before.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Clean git repo before proceeding with release script

### 👫 Relationships
Closes #4767 (hopefully)

### 🔎 Review hints
Merge and see if it builds.
There should be other safer ways to test, but they are much slower.

