### PR TITLE
Trying to fix macOS CI build again

### DIFF
--- a/dist/update_releases.sh
+++ b/dist/update_releases.sh
@@ -16,7 +16,6 @@ if [[ ! $channel =~ ^(dev|beta|stable)$ ]]; then
 fi
 
 prepare() {
-  git clean -xdf
   # Copy to tmp folder before checkout to gh-pages
   mkdir -p tmp
   cp dist/update_updates.sh tmp/update_updates.sh
@@ -36,7 +35,7 @@ fetch_releases () {
   git remote set-url origin https://github.com/toggl-open-source/toggldesktop.git
   git remote -v
   git fetch 
-  git checkout --track origin/gh-pages
+  git checkout --track --force origin/gh-pages
   
   cp assets/releases/releases.json tmp/releases.json
 }


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
GH Actions workflow for releasing macOS app still breaks with an error:
```
error: Your local changes to the following files would be overwritten by checkout:
2457
	src/ui/osx/Gemfile.lock
```

Force checkout should remove this error.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes ##4767 
Related to PR #4777

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

