### PR TITLE
Use keepEndTimeFixed option everywhere in Timeline UI (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -460,6 +460,14 @@ public static partial class Toggl
         }
     }
 
+    public static bool SetTimeEntryStartTimeStampWithOption(string guid, long timeStamp, bool keepEndTimeFixed)
+    {
+        using (Performance.Measure("changing time entry start time stamp"))
+        {
+            return toggl_set_time_entry_start_timestamp_with_option(ctx, guid, timeStamp, keepEndTimeFixed);
+        }
+    }
+
     public static bool SetTimeEntryEndTimeStamp(string guid, long timeStamp)
     {
         using (Performance.Measure("changing time entry end time stamp"))

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -96,8 +96,8 @@ namespace TogglDesktop.ViewModels
 
         public void ChangeStartTime()
         {
-            Toggl.SetTimeEntryStartTimeStamp(TimeEntryId,
-                (long)TimelineUtils.ConvertOffsetToUnixTime(VerticalOffset, DateCreated, _hourHeight));
+            Toggl.SetTimeEntryStartTimeStampWithOption(TimeEntryId,
+                (long)TimelineUtils.ConvertOffsetToUnixTime(VerticalOffset, DateCreated, _hourHeight), true);
         }
 
         public void ChangeEndTime()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -342,7 +342,7 @@ namespace TogglDesktop.ViewModels
                     (offset, height) =>
                     {
                         var id = Toggl.Start("", "", 0, 0, "", "");
-                        Toggl.SetTimeEntryStartTimeStamp(id, (long)lastTimeEntry.Ended+1);
+                        Toggl.SetTimeEntryStartTimeStampWithOption(id, (long)lastTimeEntry.Ended+1, true);
                         return id;
                     })
                 {
@@ -374,7 +374,7 @@ namespace TogglDesktop.ViewModels
         {
             var (first, last) = GetOverlappingPair(item, blocks);
             if (last == null) return;
-            Toggl.SetTimeEntryStartTimeStamp(last.TimeEntryId, (long)first.Ended);
+            Toggl.SetTimeEntryStartTimeStampWithOption(last.TimeEntryId, (long)first.Ended, true);
         }
 
         private static (TimeEntryBlock First, TimeEntryBlock Last) GetOverlappingPair(TimeEntryBlock item, IEnumerable<TimeEntryBlock> blocks)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -24,7 +24,7 @@ namespace TogglDesktop
         public static void CreateAndEditRunningTimeEntryFrom(ulong started)
         {
             var teId = Toggl.Start("", "", 0, 0, "", "");
-            Toggl.SetTimeEntryStartTimeStamp(teId, (long)started);
+            Toggl.SetTimeEntryStartTimeStampWithOption(teId, (long)started, true);
             Toggl.Edit(teId, true, Toggl.Description);
         }
 


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Introduce `SetTimeEntryStartTimeStampWithOption(string guid, long timeStamp, bool keepEndTimeFixed)` in Toggl API and use it in all Timeline related resizing functions.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4779 

### 🔎 Review hints
Please test with "end time" setting on in Time ending settings:
1. Creating TEs from gap entries
2. "Start from end of this entry" menu option
3. Creating TE from "running" gap
4. Resizing on both top and bottom

