### PR TITLE
Fix time format in Timeline view

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -469,6 +469,10 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         return user_ && user_->RecordTimeline();
     }
 
+    std::string GetTimeOfDayFormat() const {
+        return user_ ? user_->TimeOfDayFormat() : "";
+    }
+
     error SetDefaultProject(
         const Poco::UInt64 pid,
         const Poco::UInt64 tid);

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1017,6 +1017,11 @@ bool_t toggl_timeline_is_recording_enabled(
     return app(context)->IsTimelineRecordingEnabled();
 }
 
+char_t* toggl_time_of_day_format(
+    void* context) {
+    return copy_string(app(context)->GetTimeOfDayFormat());
+}
+
 bool_t toggl_can_see_billable(
     void *context,
     const int64_t workspaceID) {

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1017,8 +1017,8 @@ bool_t toggl_timeline_is_recording_enabled(
     return app(context)->IsTimelineRecordingEnabled();
 }
 
-char_t* toggl_time_of_day_format(
-    void* context) {
+char_t *toggl_time_of_day_format(
+    void *context) {
     return copy_string(app(context)->GetTimeOfDayFormat());
 }
 

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1137,8 +1137,8 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_timeline_is_recording_enabled(
         void *context);
 
-    TOGGL_EXPORT char_t* toggl_time_of_day_format(
-        void* context);
+    TOGGL_EXPORT char_t *toggl_time_of_day_format(
+        void *context);
 
     TOGGL_EXPORT void toggl_set_sleep(
         void *context);

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1137,6 +1137,9 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_timeline_is_recording_enabled(
         void *context);
 
+    TOGGL_EXPORT char_t* toggl_time_of_day_format(
+        void* context);
+
     TOGGL_EXPORT void toggl_set_sleep(
         void *context);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -621,6 +621,8 @@ public static partial class Toggl
         return toggl_timeline_is_recording_enabled(ctx);
     }
 
+    public static string GetTimeOfDayFormat() => toggl_time_of_day_format(ctx);
+
     public static bool Logout()
     {
         return toggl_logout(ctx);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -1708,6 +1708,10 @@ private static extern bool toggl_timeline_is_recording_enabled(
         IntPtr context);
 
 [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_time_of_day_format(
+        IntPtr context);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
 private static extern void toggl_set_sleep(
         IntPtr context);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineBlockViewModel.cs
@@ -77,7 +77,7 @@ namespace TogglDesktop.ViewModels
             OpenEditView = ReactiveCommand.Create(() => Toggl.Edit(TimeEntryId, false, Toggl.Description));
             var startEndObservable = this.WhenAnyValue(x => x.VerticalOffset, x => x.Height, (offset, height) =>
                 (Started: TimelineUtils.ConvertOffsetToDateTime(offset, date, _hourHeight), Ended: TimelineUtils.ConvertOffsetToDateTime(offset + height, date, _hourHeight)));
-            startEndObservable.Select(tuple => $"{tuple.Started:HH:mm tt} - {tuple.Ended:HH:mm tt}")
+            startEndObservable.Select(tuple => $"{tuple.Started.ToString(TimelineViewModel.TimeOfDayFormat)} - {tuple.Ended.ToString(TimelineViewModel.TimeOfDayFormat)}")
                 .ToPropertyEx(this, x => x.StartEndCaption);
             startEndObservable.Select(tuple =>
                 {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -442,6 +442,8 @@ namespace TogglDesktop.ViewModels
         public ReactiveCommand<Unit, Unit> ChangeFirstTimeEntryStopCommand { get; }
         public ReactiveCommand<Unit, Unit> ChangeLastTimeEntryStartCommand { get; }
 
+        public static string TimeOfDayFormat => TimelineUtils.ToDateTimeFormat(Toggl.GetTimeOfDayFormat());
+
         public class ActivityBlock
         {
             public double Offset { get; set; }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/ViewModels/TimelineViewModel.cs
@@ -125,13 +125,13 @@ namespace TogglDesktop.ViewModels
                 ? SelectedScaleMode
                 : SelectedScaleMode + value;
 
-        private static List<DateTime> GetHoursListFromScale(int scale)
+        private static List<string> GetHoursListFromScale(int scale)
         {
             int inc = GetHoursInLine(scale);
-            var hourViews = new List<DateTime>();
+            var hourViews = new List<string>();
             for (int i = 0; i < 24; i+=inc)
             {
-                hourViews.Add(new DateTime(1, 1, 1, i, 0, 0));
+                hourViews.Add(new DateTime(1, 1, 1, i, 0, 0).ToString(TimeOfDayFormat));
             }
 
             return hourViews;
@@ -403,7 +403,7 @@ namespace TogglDesktop.ViewModels
 
         public ReactiveCommand<Unit, Unit> SelectNextDay { get; }
 
-        public List<DateTime> HourViews { [ObservableAsProperty] get;  }
+        public List<string> HourViews { [ObservableAsProperty] get;  }
         
         public List<ActivityBlock> ActivityBlocks { [ObservableAsProperty] get; }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/Timeline.xaml
@@ -137,7 +137,7 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Height="{Binding ElementName=HoursItemsControl, Path=DataContext.HourHeightView}" x:Name="TimeRow" ZIndex="0">
-                                    <TextBlock Text="{Binding Path=., StringFormat='hh:mm tt'}"
+                                    <TextBlock Text="{Binding Path=.}"
                                            Width="29"
                                            TextWrapping="Wrap"
                                            FontSize="12"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -49,5 +49,12 @@ namespace TogglDesktop
             blocks == null || !blocks.Any()
                 ? (double?) null
                 : blocks.Min(te => te.Value.VerticalOffset);
+
+        public static string ToDateTimeFormat(string format) =>
+            format switch
+            {
+                "h:mm A" => "h:mm tt",
+                _ => "h:mm"
+            };
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/TimelineUtils.cs
@@ -54,7 +54,7 @@ namespace TogglDesktop
             format switch
             {
                 "h:mm A" => "h:mm tt",
-                _ => "h:mm"
+                _ => "H:mm"
             };
     }
 }


### PR DESCRIPTION
### 📒 Description
This PR utilizes time of day format from user profile settings. I introduced `toggl_time_of_day_format` function in c++ api, to make it accessible in c# code. Also added `time_of_day_format` field to settings structure. The format provided is not aligned with existing formats for `DateTime` in c#, so I introduced a function `ToDateTimeFormat` for format converting. This function is an analogue to c++ function `togglTimeOfDayToPocoFormat` in `formatter.cc`.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

- **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #4785 

### 🔎 Review hints
Testing: 
- Go to https://track.toggl.com (or https://track.toggl.space if tested on stage server) and see the time format.
- Run desktop app, open timeline view and check that time format is correct in TE tooltip.
- Change format on the web. Check that the format has changed in in the tooltip (and it's correct).

