### PR TITLE
Fix code signing on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -453,7 +453,7 @@ jobs:
       if: github.event_name == 'release'
       shell: cmd
       run: |
-        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller.exe
+        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t http://timestamp.digicert.com -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller.exe
     - name: Upload artifacts to GitHub
       if: github.event_name != 'release'
       uses: actions/upload-artifact@v2
@@ -523,7 +523,7 @@ jobs:
       if: github.event_name == 'release'
       shell: cmd
       run: |
-        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller-x64.exe
+        "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t http://timestamp.digicert.com -f Certificate.pfx -p "${{ secrets.CERT_WINDOWS_PASSWORD }}" dist\windows\TogglDesktopInstaller-x64.exe
     - name: Upload artifacts to GitHub
       if: github.event_name != 'release'
       uses: actions/upload-artifact@v2

--- a/dist/windows/TogglDesktopInstaller-x64.nsi
+++ b/dist/windows/TogglDesktopInstaller-x64.nsi
@@ -23,7 +23,7 @@
   ; That will have written an uninstaller binary for us.  Now we sign it with your
   ; favorite code signing tool.
  
-  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t "http://timestamp.verisign.com/scripts/timestamp.dll" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
+  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t "http://timestamp.digicert.com" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
  
   ; Good.  Now we can carry on writing the real installer.
  

--- a/dist/windows/TogglDesktopInstaller-x86.nsi
+++ b/dist/windows/TogglDesktopInstaller-x86.nsi
@@ -23,7 +23,7 @@
   ; That will have written an uninstaller binary for us.  Now we sign it with your
   ; favorite code signing tool.
  
-  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t "http://timestamp.verisign.com/scripts/timestamp.dll" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
+  !system '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64\signtool.exe" sign -fd SHA256 -a -t "http://timestamp.digicert.com" -f "Certificate.pfx" -p ${CERT_PASSWORD} "$%TEMP%\Uninstall.exe"' = 0
  
   ; Good.  Now we can carry on writing the real installer.
  

--- a/dist/windows/scripts/sign.sh
+++ b/dist/windows/scripts/sign.sh
@@ -23,6 +23,6 @@ arguments=$(sed 's/\</\*./g' <<< $EXTENSIONS | sed 's/\s/ -or -name /g' | sed 's
 
 for i in $(find $PATHS $arguments 2>/dev/null); do
     echo "Signing $i"
-    "$SIGNTOOL" sign -fd SHA256 -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f "Certificate.pfx" -p $cert_password $i
+    "$SIGNTOOL" sign -fd SHA256 -a -t http://timestamp.digicert.com -f "Certificate.pfx" -p $cert_password $i
 done
 


### PR DESCRIPTION
### 📒 Description
Fixes code signing on Windows by replacing a retired timestamp server url with a working one

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4791

### 🔎 Review hints
Look through the changes, think if there are any other places where this timestamp server URL could be used.

In the branch, CI builds code signing happens only in the uninstaller.
As I've tested `sign.sh` locally, I think we can just go ahead and merge this if the code looks good.