### PR TITLE
Update the wording (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingPayload.swift
+++ b/src/ui/osx/TogglDesktop/Features/Onboarding/OnboardingPayload.swift
@@ -127,7 +127,7 @@ struct OnboardingPayload {
         ]
 
         let string = NSMutableAttributedString(
-            string: "You can now add projects or tags even easier!\n",
+            string: "We’ve made it even simpler to add projects and tags!\n",
             attributes: titleAttributes
         )
         string.append(


### PR DESCRIPTION
### 📒 Description
Fix the wording in the shortcuts feature onboarding popup.
Context: https://toggl.slack.com/archives/C010950JMD0/p1609925840000900

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4795

### 🔎 Review hints
Open the local database and set `onboarding_states.is_present_text_shortcuts_onboarding` to 0 for your user, save the DB changes, and run the app.