### PR TITLE
Adds a 

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -156,16 +156,17 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="Windows">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd</HintPath>
-    </Reference>
-    <Reference Include="Windows.Foundation.FoundationContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Windows.Foundation.UniversalApiContract">
-      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.UniversalApiContract\5.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
-      <Private>False</Private>
+    <Reference Include="Windows"> 
+        <HintPath Condition="Exists('C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd')">C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd</HintPath>
+        <HintPath Condition="Exists('C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.19041.0\Windows.winmd')">C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.19041.0\Windows.winmd</HintPath> 
+    </Reference> 
+    <Reference Include="Windows.Foundation.FoundationContract"> 
+        <HintPath Condition="Exists('C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd')">C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath> 
+        <HintPath Condition="Exists('C:\Program Files (x86)\Windows Kits\10\References\10.0.19041.0\Windows.Foundation.FoundationContract\4.0.0.0\Windows.Foundation.FoundationContract.winmd')">C:\Program Files (x86)\Windows Kits\10\References\10.0.19041.0\Windows.Foundation.FoundationContract\4.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath> 
+    </Reference> 
+    <Reference Include="Windows.Foundation.UniversalApiContract"> 
+        <HintPath Condition="Exists('C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.UniversalApiContract\5.0.0.0\Windows.Foundation.UniversalApiContract.winmd')">C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.UniversalApiContract\5.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
+        <HintPath Condition="Exists('C:\Program Files (x86)\Windows Kits\10\References\10.0.19041.0\Windows.Foundation.UniversalApiContract\10.0.0.0\Windows.Foundation.UniversalApiContract.winmd')">C:\Program Files (x86)\Windows Kits\10\References\10.0.19041.0\Windows.Foundation.UniversalApiContract\10.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -193,46 +193,81 @@
                 <!-- times, duration -->
                 <Grid Margin="0 22 0 0">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="42"/>
+                        <RowDefinition Height="42"/>
+                        <RowDefinition Height="42"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="21*" />
-                        <ColumnDefinition Width="17*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="17*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="80"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Style="{DynamicResource Toggl.BodyText}" Margin="0 0 0 8" Text="Duration" />
-                    <toggl:ExtendedTextBox x:Name="durationTextBox" x:FieldModifier="private" Grid.Row="1" Grid.Column="0"
-                                           Margin="0 0 12 0"
-                                           Style="{StaticResource {x:Type TextBox}}"
-                                           LostKeyboardFocus="durationTextBox_OnLostKeyboardFocus"
-                                           KeyDown="durationTextBox_OnKeyDown">10:12 min</toggl:ExtendedTextBox>
-                    <toggl:ExtendedTextBox x:Name="startTimeTextBox" x:FieldModifier="private"
-                                           Grid.Row="1" Grid.Column="1"
-                                           Style="{StaticResource {x:Type TextBox}}"
-                                           LostKeyboardFocus="startTimeTextBox_OnLostKeyboardFocus"
-                                           KeyDown="startTimeTextBox_OnKeyDown">12:45</toggl:ExtendedTextBox>
-                    <ContentControl Focusable="False"
-                                    Margin="6 0"
-                                    Grid.Row="1" Grid.Column="2"
-                                    Content="{StaticResource Toggl.ArrowIcon}" />
-                    <toggl:ExtendedTextBox x:Name="endTimeTextBox" x:FieldModifier="private"
-                                           Grid.Row="1" Grid.Column="3"
-                                           Style="{StaticResource {x:Type TextBox}}"
-                                           LostKeyboardFocus="endTimeTextBox_OnLostKeyboardFocus"
-                                           KeyDown="endTimeTextBox_OnKeyDown">12:55</toggl:ExtendedTextBox>
-                    <DatePicker Name="startDatePicker" x:FieldModifier="private" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4"
-                                Style="{StaticResource EditViewDatePickerStyle}"
-                                Margin="0 8 0 0"
-                                Height="32"
-                                SelectedDate="05.01.2015"
+
+                    <!-- Row 0: Start -->
+                    <TextBlock Style="{DynamicResource Toggl.BodyText}"
+							   Grid.Row="0" Grid.Column="0"
+							   VerticalAlignment="Center"
+							   Margin="0 0 10 8"
+							   Text="Start" />
+
+                    <DatePicker Name="startDatePicker" x:FieldModifier="private"
+								Style="{StaticResource EditViewDatePickerStyle}"
+								Grid.Row="0" Grid.Column="1"
+								Margin="0 0 0 8"
+								Height="32"
                                 LostKeyboardFocus="startDatePicker_LostKeyboardFocus">
                         <i:Interaction.Behaviors>
                             <behaviors:DatePickerKeyboardHandlingBehavior />
                         </i:Interaction.Behaviors>
                     </DatePicker>
+
+                    <toggl:ExtendedTextBox x:Name="startTimeTextBox" x:FieldModifier="private"
+                                           Grid.Row="0" Grid.Column="2"
+										   Margin="8 0 0 8"
+										   Height="32"
+                                           Style="{StaticResource {x:Type TextBox}}"
+                                           LostKeyboardFocus="startTimeTextBox_OnLostKeyboardFocus"
+                                           KeyDown="startTimeTextBox_OnKeyDown">12:45</toggl:ExtendedTextBox>
+
+                    <!-- Row 1: End -->
+                    <TextBlock Style="{DynamicResource Toggl.BodyText}"
+							   Grid.Row="1" Grid.Column="0"
+							   VerticalAlignment="Center"
+							   Margin="0 0 10 8"
+							   Text="End"/>
+
+                    <DatePicker Name="endDatePicker" x:FieldModifier="private"
+								Style="{StaticResource EditViewDatePickerStyle}"
+								Grid.Row="1" Grid.Column="1"
+                                Margin="0 0 0 8"
+								Height="32"
+                                LostKeyboardFocus="endDatePicker_LostKeyboardFocus">
+                        <i:Interaction.Behaviors>
+                            <behaviors:DatePickerKeyboardHandlingBehavior />
+                        </i:Interaction.Behaviors>
+                    </DatePicker>
+
+                    <toggl:ExtendedTextBox x:Name="endTimeTextBox" x:FieldModifier="private"
+                                           Grid.Row="1" Grid.Column="2"
+										   Margin="8 0 0 8"
+										   Height="32"
+                                           Style="{StaticResource {x:Type TextBox}}"
+                                           LostKeyboardFocus="endTimeTextBox_OnLostKeyboardFocus"
+                                           KeyDown="endTimeTextBox_OnKeyDown">12:55</toggl:ExtendedTextBox>
+
+                    <!-- Row 2: Duration -->
+                    <TextBlock Style="{DynamicResource Toggl.BodyText}"
+							   Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+							   VerticalAlignment="Center"
+							   Margin="0 0 10 10"
+							   Text="Duration" />
+                    
+                    <toggl:ExtendedTextBox x:Name="durationTextBox" x:FieldModifier="private" Grid.Row="2" Grid.Column="2"
+                                           Margin="8 0 0 8"
+										   Height="32"
+                                           Style="{StaticResource {x:Type TextBox}}"
+                                           LostKeyboardFocus="durationTextBox_OnLostKeyboardFocus"
+                                           KeyDown="durationTextBox_OnKeyDown">10:12 min</toggl:ExtendedTextBox>
                 </Grid>
 
                 <TextBlock Margin="0 14 0 0" LineHeight="20" FontSize="{DynamicResource NormalFontSize}">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -202,9 +202,6 @@ namespace TogglDesktop
         /// When <paramref name="textBox"/> is not focused, or has an empty <see cref="FrameworkElement.Tag"/> property value, or when <paramref name="evenIfFocused"/> is <see langword="true"/>, this method stores <paramref name="time"/> into <paramref name="textBox"/>'s <see cref="FrameworkElement.Tag"/> property.<br/>
         /// Otherwise, this method does nothing.
         /// </summary>
-        /// <param name="textBox"></param>
-        /// <param name="time"></param>
-        /// <param name="evenIfFocused"></param>
         private static void setTime(ExtendedTextBox textBox, string time, bool evenIfFocused)
         {
             if (evenIfFocused
@@ -369,14 +366,12 @@ namespace TogglDesktop
         }
         private void saveEndTimeIfChanged()
         {
-//          this.setTimeEntryTimeIfChanged(this.endTimeTextBox, Toggl.SetTimeEntryEnd, "end time");
             this.setTimeEntryEndTimestampIfChanged();
         }
         private void saveDurationIfChanged()
         {
             this.setTimeEntryTimeIfChanged(this.durationTextBox, Toggl.SetTimeEntryDuration, "duration");
         }
-
 
         private void setTimeEntryTimeIfChanged(TextBox textBox, Func<string, string, bool> apiCall, string timeType)
         {
@@ -394,7 +389,6 @@ namespace TogglDesktop
             textBox.Tag = null;
 
             apiCall(this.timeEntry.GUID, now);
-
         }
 
         private void setTimeEntryEndTimestampIfChanged()
@@ -406,46 +400,46 @@ namespace TogglDesktop
             }
 
             if (!this.endDatePicker.SelectedDate.HasValue)
-			{
+            {
                Console.WriteLine("Cannot apply change: No end date value.");
                return;
-			}
+            }
 
             DateTime nowEnd;
             DateTime previousEnd;
-			{
+            {
                 DateTime nowEndDate      = this.endDatePicker.SelectedDate.Value.Date;
                 DateTime previousEndDate = ( this.endDatePicker.Tag as DateTime? ?? DateTime.MinValue ).Date;
             
                 TimeSpan nowEndTimeOfDay;
                 TimeSpan previousEndTimeOfDay;
-			    {
+                {
                     if (!DateTime.TryParseExact(this.endTimeTextBox.Text, format: "t", CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal, out DateTime nowEndTimeOfDayAsDate))
-			        {
+                    {
                         Console.WriteLine("Cannot apply change: Invalid end time textbox value.");
                         return;
-			        }
+                    }
 
                     if (!DateTime.TryParseExact(this.endTimeTextBox.Tag as string, format: "t", CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal, out DateTime previousEndTimeOfDayAsDate))
-			        {
+                    {
                         previousEndTimeOfDayAsDate = DateTime.MinValue;
-			        }
+                    }
 
                     nowEndTimeOfDay      = nowEndTimeOfDayAsDate.TimeOfDay;
                     previousEndTimeOfDay = previousEndTimeOfDayAsDate.TimeOfDay;
-			    }
+                }
 
                 nowEnd      = nowEndDate     .Add(nowEndTimeOfDay);
                 previousEnd = previousEndDate.Add(previousEndTimeOfDay);
-			}
+            }
 
             long nowEndUnix      = Toggl.UnixFromDateTime(nowEnd);
             long previousEndUnix = Toggl.UnixFromDateTime(previousEnd);
             if( nowEndUnix == previousEndUnix )
-			{
+            {
                 Console.WriteLine("Cannot apply change: No change detected.");
                 return;
-			}
+            }
 
             this.endTimeTextBox.Tag = null;
 
@@ -475,44 +469,6 @@ namespace TogglDesktop
                 Toggl.SetTimeEntryDate(this.timeEntry.GUID, currentDate); 
             } 
         } 
-
-        /*
-        private void saveDate()
-        {
-            if (!this.hasTimeEntry())
-            {
-                Console.WriteLine("Cannot apply date change: No time entry.");
-                return;
-            }
-
-            if (!this.startDatePicker.SelectedDate.HasValue)
-            {
-                this.startDatePicker.SelectedDate = Toggl.DateTimeFromUnix(this.timeEntry.Started);
-                return;
-            }
-
-            if (!this.endDatePicker.SelectedDate.HasValue)
-            {
-                this.endDatePicker.SelectedDate = Toggl.DateTimeFromUnix(this.timeEntry.Ended);
-            }
-
-            DateTime currentStartedDt = Toggl.DateTimeFromUnix(timeEntry.Started);
-            DateTime currentEndedDt = Toggl.DateTimeFromUnix(timeEntry.Ended);
-
-            if (this.startDatePicker.SelectedDate.Value != currentStartedDt)
-            {
-                currentStartedDt = this.startDatePicker.SelectedDate.Value;
-                Toggl.SetTimeEntryDate(this.timeEntry.GUID, currentStartedDt);
-            }
-
-            if (this.endDatePicker.SelectedDate.Value != currentEndedDt)
-            {
-                currentEndedDt = this.endDatePicker.SelectedDate.Value;
-                long endUnix = Toggl.UnixFromDateTime(currentEndedDt);
-                Toggl.SetTimeEntryEndTimeStamp(this.timeEntry.GUID, endUnix);
-            }
-        }
-        */
 
         private void startDatePicker_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -29,7 +29,7 @@ namespace TogglDesktop
         private ulong selectedClientId;
         private string selectedClientName;
         private bool isCreatingProject;
-        private bool dateSet = false;
+        private bool startDateSet = false;
         public EditView()
         {
             this.DataContext = this;
@@ -75,7 +75,7 @@ namespace TogglDesktop
 
             using (Performance.Measure("filling edit view from OnTimeEntryEditor"))
             {
-                this.dateSet = false;
+                this.startDateSet = false;
                 if (timeEntry.Locked)
                 {
                     open = true;
@@ -110,17 +110,27 @@ namespace TogglDesktop
 
                 this.endTimeTextBox.IsEnabled = !isCurrentlyRunning;
                 this.startDatePicker.IsEnabled = !isCurrentlyRunning;
+                this.endDatePicker.IsEnabled = !isCurrentlyRunning;
 
                 var startDateTime = Toggl.DateTimeFromUnix(timeEntry.Started);
                 var endDateTime = Toggl.DateTimeFromUnix(timeEntry.Ended);
 
                 setText(this.descriptionTextBox, timeEntry.Description, open);
-                setTime(this.durationTextBox, timeEntry.Duration, open);
+
+                // Start:
                 setTime(this.startTimeTextBox, timeEntry.StartTimeString, open);
                 this.startTimeTextBox.ToolTip = startDateTime.ToString("T", CultureInfo.CurrentCulture);
+                this.startDatePicker.SelectedDate = startDateTime;
+
+                // End:
                 setTime(this.endTimeTextBox, timeEntry.EndTimeString, open);
                 this.endTimeTextBox.ToolTip = endDateTime.ToString("T", CultureInfo.CurrentCulture);
-                this.startDatePicker.SelectedDate = startDateTime;
+                this.endDatePicker.SelectedDate = endDateTime;
+
+                // Duration:
+                setTime(this.durationTextBox, timeEntry.Duration, open);
+                
+
                 if (isDifferentTimeEntry)
                 {
                     this.clearUndoHistory();
@@ -128,6 +138,7 @@ namespace TogglDesktop
 
                 if (isCurrentlyRunning)
                 {
+                    this.endDatePicker.SelectedDate = DateTime.Now;
                     this.endTimeTextBox.Text = "";
                 }
 
@@ -165,7 +176,7 @@ namespace TogglDesktop
                             ? "Create a new project"
                             : string.Empty;
                 }
-                this.dateSet = true;
+                this.startDateSet = true;
             }
         }
 
@@ -187,6 +198,13 @@ namespace TogglDesktop
             }
         }
 
+        /// <summary>
+        /// When <paramref name="textBox"/> is not focused, or has an empty <see cref="FrameworkElement.Tag"/> property value, or when <paramref name="evenIfFocused"/> is <see langword="true"/>, this method stores <paramref name="time"/> into <paramref name="textBox"/>'s <see cref="FrameworkElement.Tag"/> property.<br/>
+        /// Otherwise, this method does nothing.
+        /// </summary>
+        /// <param name="textBox"></param>
+        /// <param name="time"></param>
+        /// <param name="evenIfFocused"></param>
         private static void setTime(ExtendedTextBox textBox, string time, bool evenIfFocused)
         {
             if (evenIfFocused
@@ -205,9 +223,9 @@ namespace TogglDesktop
 
         #region duration auto update
 
-        private void durationUpdateTimerTick(object sender, string s)
+        private void durationUpdateTimerTick(object sender, string durationText)
         {
-            if (this.TryBeginInvoke(durationUpdateTimerTick, sender, s))
+            if (this.TryBeginInvoke(durationUpdateTimerTick, sender, durationText))
                 return;
 
             if (!this.hasTimeEntry() || this.timeEntry.DurationInSeconds >= 0)
@@ -222,8 +240,8 @@ namespace TogglDesktop
 
             var caret = this.durationTextBox.CaretIndex;
 
-            this.durationTextBox.SetText(s);
-            this.durationTextBox.Tag = s;
+            this.durationTextBox.SetText(durationText);
+            this.durationTextBox.Tag = durationText;
 
             this.durationTextBox.CaretIndex = caret;
         }
@@ -351,7 +369,8 @@ namespace TogglDesktop
         }
         private void saveEndTimeIfChanged()
         {
-            this.setTimeEntryTimeIfChanged(this.endTimeTextBox, Toggl.SetTimeEntryEnd, "end time");
+//          this.setTimeEntryTimeIfChanged(this.endTimeTextBox, Toggl.SetTimeEntryEnd, "end time");
+            this.setTimeEntryEndTimestampIfChanged();
         }
         private void saveDurationIfChanged()
         {
@@ -367,18 +386,97 @@ namespace TogglDesktop
                 return;
             }
 
-            var before = textBox.Tag as string;
-            var now = textBox.Text;
+            var before = textBox.Tag as string; // e.g. "06:00" or "6:00 AM" etc
+            var now = textBox.Text; // e.g. "06:01" or "6:01 AM" etc
             if (before == now)
                 return;
 
             textBox.Tag = null;
 
             apiCall(this.timeEntry.GUID, now);
+
+        }
+
+        private void setTimeEntryEndTimestampIfChanged()
+        {
+            if (!this.hasTimeEntry())
+            {
+                Console.WriteLine("Cannot apply change: No time entry.");
+                return;
+            }
+
+            if (!this.endDatePicker.SelectedDate.HasValue)
+			{
+               Console.WriteLine("Cannot apply change: No end date value.");
+               return;
+			}
+
+            DateTime nowEnd;
+            DateTime previousEnd;
+			{
+                DateTime nowEndDate      = this.endDatePicker.SelectedDate.Value.Date;
+                DateTime previousEndDate = ( this.endDatePicker.Tag as DateTime? ?? DateTime.MinValue ).Date;
+            
+                TimeSpan nowEndTimeOfDay;
+                TimeSpan previousEndTimeOfDay;
+			    {
+                    if (!DateTime.TryParseExact(this.endTimeTextBox.Text, format: "t", CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal, out DateTime nowEndTimeOfDayAsDate))
+			        {
+                        Console.WriteLine("Cannot apply change: Invalid end time textbox value.");
+                        return;
+			        }
+
+                    if (!DateTime.TryParseExact(this.endTimeTextBox.Tag as string, format: "t", CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AssumeLocal, out DateTime previousEndTimeOfDayAsDate))
+			        {
+                        previousEndTimeOfDayAsDate = DateTime.MinValue;
+			        }
+
+                    nowEndTimeOfDay      = nowEndTimeOfDayAsDate.TimeOfDay;
+                    previousEndTimeOfDay = previousEndTimeOfDayAsDate.TimeOfDay;
+			    }
+
+                nowEnd      = nowEndDate     .Add(nowEndTimeOfDay);
+                previousEnd = previousEndDate.Add(previousEndTimeOfDay);
+			}
+
+            long nowEndUnix      = Toggl.UnixFromDateTime(nowEnd);
+            long previousEndUnix = Toggl.UnixFromDateTime(previousEnd);
+            if( nowEndUnix == previousEndUnix )
+			{
+                Console.WriteLine("Cannot apply change: No change detected.");
+                return;
+			}
+
+            this.endTimeTextBox.Tag = null;
+
+            Toggl.SetTimeEntryEndTimeStamp(this.timeEntry.GUID, nowEndUnix);
         }
 
         #region datepicker
 
+        private void saveDate() 
+        { 
+            if (!this.hasTimeEntry()) 
+            { 
+                Console.WriteLine("Cannot apply date change: No time entry."); 
+                return; 
+            } 
+            if (!this.startDatePicker.SelectedDate.HasValue) 
+            { 
+                this.startDatePicker.SelectedDate = Toggl.DateTimeFromUnix(this.timeEntry.Started); 
+                return; 
+            } 
+ 
+            DateTime currentDate = Toggl.DateTimeFromUnix(timeEntry.Started); 
+ 
+            if (!currentDate.Equals(this.startDatePicker.SelectedDate.Value)) 
+            { 
+                currentDate = this.startDatePicker.SelectedDate.Value; 
+                Toggl.SetTimeEntryDate(this.timeEntry.GUID, currentDate); 
+            } 
+        } 
+
+        /*
         private void saveDate()
         {
             if (!this.hasTimeEntry())
@@ -386,29 +484,52 @@ namespace TogglDesktop
                 Console.WriteLine("Cannot apply date change: No time entry.");
                 return;
             }
+
             if (!this.startDatePicker.SelectedDate.HasValue)
             {
                 this.startDatePicker.SelectedDate = Toggl.DateTimeFromUnix(this.timeEntry.Started);
                 return;
             }
 
-            DateTime currentDate = Toggl.DateTimeFromUnix(timeEntry.Started);
-
-            if (!currentDate.Equals(this.startDatePicker.SelectedDate.Value))
+            if (!this.endDatePicker.SelectedDate.HasValue)
             {
-                currentDate = this.startDatePicker.SelectedDate.Value;
-                Toggl.SetTimeEntryDate(this.timeEntry.GUID, currentDate);
+                this.endDatePicker.SelectedDate = Toggl.DateTimeFromUnix(this.timeEntry.Ended);
+            }
+
+            DateTime currentStartedDt = Toggl.DateTimeFromUnix(timeEntry.Started);
+            DateTime currentEndedDt = Toggl.DateTimeFromUnix(timeEntry.Ended);
+
+            if (this.startDatePicker.SelectedDate.Value != currentStartedDt)
+            {
+                currentStartedDt = this.startDatePicker.SelectedDate.Value;
+                Toggl.SetTimeEntryDate(this.timeEntry.GUID, currentStartedDt);
+            }
+
+            if (this.endDatePicker.SelectedDate.Value != currentEndedDt)
+            {
+                currentEndedDt = this.endDatePicker.SelectedDate.Value;
+                long endUnix = Toggl.UnixFromDateTime(currentEndedDt);
+                Toggl.SetTimeEntryEndTimeStamp(this.timeEntry.GUID, endUnix);
             }
         }
+        */
 
         private void startDatePicker_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
             if (!startDatePicker.IsKeyboardFocusWithin)
             {
-                if (this.dateSet)
+                if (this.startDateSet)
                 {
                     this.saveDate();
                 }
+            }
+        }
+
+        private void endDatePicker_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            if (!endDatePicker.IsKeyboardFocusWithin)
+            {
+                this.setTimeEntryEndTimestampIfChanged();
             }
         }
 
@@ -831,7 +952,7 @@ namespace TogglDesktop
 
         public void SetTimer(Timer timer)
         {
-            timer.ViewModel.WhenValueChanged(x => x.DurationText).Subscribe(x => durationUpdateTimerTick(this, x));
+            timer.ViewModel.WhenValueChanged(x => x.DurationText).Subscribe(durationText => this.durationUpdateTimerTick(this, durationText));
         }
 
         public void FocusField(string focusedFieldName)


### PR DESCRIPTION
### 📒 Description

This change adds a second `<DatePicker>` to `EditView.xaml` which displays the Date component of an event's end timestamp and integrates it with EditView's plumbing.

See https://github.com/toggl-open-source/toggldesktop/issues/2582

### 🕶️ Types of changes

**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes

The `EditView.xaml.cs` now has this layout and UI:

![image](https://user-images.githubusercontent.com/1693078/105576553-528d5080-5d28-11eb-8514-5f0cf6955713.png)


### 👫 Relationships

https://github.com/toggl-open-source/toggldesktop/issues/2582

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #2582

### 🔎 Review hints

I did some cursory testing for both Existing and New entries. I ran all tests in the solution - I wanted to add some UI integration tests for this change but I didn't see any, unfortunately.

I'm perplexed by the design of Toggl's native API - I don't know why it treats the end-time as a localized time-only string instead of passing around _only_ UNIX timestamp integers, that would make the Toggl API much simpler to work with and easier to understand.

