### PR TITLE
Revert "Enable per monitor DPI (win)"

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.config
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.config
@@ -42,7 +42,4 @@
             </setting>
         </TogglDesktop.Properties.Settings>
     </userSettings>
-  <runtime>
-    <AppContextSwitchOverrides value = "Switch.System.Windows.DoNotScaleForDpiChanges=false"/>
-  </runtime>
 </configuration>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/app.manifest
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/app.manifest
@@ -49,14 +49,13 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-
+  <!--
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings"> PerMonitor</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </windowsSettings>
   </application>
-
+  -->
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--


### PR DESCRIPTION
This reverts commit 9aa726d0f5246a843cbf0367058be8746c88f48d, reversing
changes made to 578058ee14122c67d91e4873e75182be3b292a55.

### 📒 Description
Revert "Enable per monitor DPI (win)" to fix the issue with the Edit View position on multi-monitor setups with different DPIs.

I've decided to revert the per-monitor DPI awareness because the APIs to properly work with it exist starting from .NET 4.6.2 and our app is on 4.6.1. https://github.com/Microsoft/WPF-Samples/tree/master/PerMonitorDPI#using-new-apis-requires-reference-assembly-install-step
Considering we're now minimizing the resources spent on supporting this app, a move to a newer .NET version may uncover some additional work compared to the reverted per-monitor DPI-awareness which had no major issues other than windows being a bit blurred in the multi-monitor different-scaling scenarios.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 👫 Relationships
Closes #4802

### 🔎 Review hints
2+ monitors.
1 monitor should have a different scaling than the other one. Move the main window around and try opening the Edit View. In some positions, the Edit view will open detached from the main window, sometimes going outside the visible screen area.