### PR TITLE
Do not crash the app when launching auto-updater fails with Win32Exception

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Services/UpdateService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -56,6 +57,10 @@ namespace TogglDesktop.Services
                     when (e is UpdaterAlreadyLaunchedException || e is LockFileNotAcquiredException)
                 {
                     // Ignore race conditions
+                }
+                catch (Win32Exception e)
+                {
+                    BugsnagService.NotifyBugsnag(e);
                 }
             }
 


### PR DESCRIPTION
### 📒 Description
Do not crash the app when launching auto-updater fails with Win32Exception.
Simply report the error to Bugsnag.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4814

### 🔎 Review hints
The code is simple enough, just check the code and compare it with the #4814 report and Bugsnag errors.
STR are unknown, probably either some specific Windows settings or corrupted installation files (or both).