### PR TITLE
Fix autotracker list visibility in high-scaling or lower-resolution scenarios

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutotrackerSettings.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutotrackerSettings.xaml
@@ -88,15 +88,13 @@
             <TextBlock Text="Keyword" Grid.Column="0" Grid.Row="2" Style="{StaticResource Toggl.CaptionText}" Margin="12 19 0 0"/>
             <TextBlock Text="Project name" Grid.Column="1" Grid.Row="2" Style="{StaticResource Toggl.CaptionText}" Margin="12 19 0 0"/>
         </Grid>
-        <ScrollViewer Grid.Row="2"
-            Margin="0 10 0 0" Focusable="True" IsTabStop="True"
-            GotKeyboardFocus="onListGotKeyboardFocus"
-            LostKeyboardFocus="onListLostKeyboardFocus"
-            PreviewKeyDown="onListPreviewKeyDown"
-            VerticalScrollBarVisibility="Auto">
-            <StackPanel Name="rulesPanel" x:FieldModifier="private">
-                <!-- filled programmatically -->
-            </StackPanel>
-        </ScrollViewer>
+        <StackPanel Name="rulesPanel" x:FieldModifier="private"
+                    Grid.Row="2"
+                    Margin="0 10 0 0" Focusable="True"
+                    GotKeyboardFocus="onListGotKeyboardFocus"
+                    LostKeyboardFocus="onListLostKeyboardFocus"
+                    PreviewKeyDown="onListPreviewKeyDown">
+            <!-- filled programmatically -->
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -325,36 +325,39 @@
             </TabItem>
 
             <TabItem Header="Autotracker">
-                <Grid Margin="24 32 20 0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <StackPanel Orientation="Vertical">
-                        <TextBlock Style="{StaticResource Toggl.TitleText}"
-                                   Text="Autotracker" />
-                        <TextBlock Margin="0 12 0 0"
-                                   Style="{StaticResource Toggl.CaptionText}"
-                                   Text="Autotracker helps to make time tracking faster by triggering customized suggestions. When a selected app is open in the foreground, you'll get one of the prefilled suggestions." />
-                        <mah:ToggleSwitch Name="enableAutotrackerCheckbox" x:FieldModifier="private"
-                                          Margin="0 14 0 0"/>
-                    </StackPanel>
-                    <StackPanel Grid.Row="1" IsEnabled="{Binding ElementName=enableAutotrackerCheckbox, Path=IsChecked}"
-                                Margin="0 30 0 0">
-                        <TextBlock Style="{StaticResource Toggl.BodyText}"
-                                   Text="Show suggestions also when the timer is running" />
-                        <mah:ToggleSwitch x:Name="showAutotrackerWhileTimerIsRunning" x:FieldModifier="private"
-                                          Margin="0 14 0 0" />
-                        <TextBlock Style="{StaticResource Toggl.BodyText}"
-                                   Margin="0 12 0 0"
-                                   Text="Allow starting tracking automatically without showing the suggestion" />
-                        <mah:ToggleSwitch x:Name="startTrackingWithoutSuggestionCheckbox" x:FieldModifier="private"
-                                          Margin="0 14 0 0" />
-                    </StackPanel>
+                <ScrollViewer>
+                    <Grid Margin="24 32 20 0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock Style="{StaticResource Toggl.TitleText}"
+                                       Text="Autotracker" />
+                            <TextBlock Margin="0 12 0 0"
+                                       Style="{StaticResource Toggl.CaptionText}"
+                                       Text="Autotracker helps to make time tracking faster by triggering customized suggestions. When a selected app is open in the foreground, you'll get one of the prefilled suggestions." />
+                            <mah:ToggleSwitch Name="enableAutotrackerCheckbox" x:FieldModifier="private"
+                                              Margin="0 14 0 0"/>
+                        </StackPanel>
+                        <StackPanel Grid.Row="1" IsEnabled="{Binding ElementName=enableAutotrackerCheckbox, Path=IsChecked}"
+                                    Margin="0 30 0 0">
+                            <TextBlock Style="{StaticResource Toggl.BodyText}"
+                                       Text="Show suggestions also when the timer is running" />
+                            <mah:ToggleSwitch x:Name="showAutotrackerWhileTimerIsRunning" x:FieldModifier="private"
+                                              Margin="0 14 0 0" />
+                            <TextBlock Style="{StaticResource Toggl.BodyText}"
+                                       Margin="0 12 0 0"
+                                       Text="Allow starting tracking automatically without showing the suggestion" />
+                            <mah:ToggleSwitch x:Name="startTrackingWithoutSuggestionCheckbox" x:FieldModifier="private"
+                                              Margin="0 14 0 0" />
+                        </StackPanel>
 
-                    <toggl:AutotrackerSettings Grid.Row="2" Margin="0 22 0 12" IsEnabled="{Binding ElementName=enableAutotrackerCheckbox, Path=IsChecked}"/>
-                </Grid>
+                        <toggl:AutotrackerSettings Grid.Row="2" Margin="0 22 0 12" IsEnabled="{Binding ElementName=enableAutotrackerCheckbox, Path=IsChecked}"/>
+                    </Grid>
+
+                </ScrollViewer>
             </TabItem>
             <TabItem Header="Proxy">
                 <StackPanel Margin="24 32 20 48">


### PR DESCRIPTION
### 📒 Description
Make the whole tab scrollable by moving the ScrollViewer from the autotracker list up to the entire Autotracker tab.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #4815

### 🔎 Review hints
Reproduce #4815 by setting high scaling to your monitor. 150% on my 1920x1080 laptop display worked well.
Try adding/removing autotrackers with mouse and keyboard. See if nothing is broken.