### PR TITLE
[WIP] set duration as negative starttime when receiving an update for a running time entry

### DIFF
--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -490,9 +490,12 @@ void TimeEntry::LoadFromJSON(const Json::Value &data, bool syncServer) {
         if (!updateMergeableProperty("tid", TID))
             SetTID(0, false);
     updateMergeableProperty("billable", Billable);
-    updateMergeableProperty("duration", DurationInSeconds);
     updateMergeablePropertyConvert("start", StartTime, convertTimeString);
     updateMergeablePropertyConvert("stop", StopTime, convertTimeString);
+    if (StopTime() == 0)
+        SetDurationInSeconds(-StartTime(), false);
+    else
+        updateMergeableProperty("duration", DurationInSeconds);
 
     // These properties are not sync-server-mergeable
     SetDurOnly(data["duronly"].asBool());


### PR DESCRIPTION
### 📒 Description
There used to be a convention that the duration for a running time entry is equal to negative start time. This convention was heavily used by our desktop app logic.
Nowadays clients and the server do not have to respect this convention and are only caring that the running time entry duration is negative or the stop time is `null`. 
An easy fix to the issue is to enforce this convention locally - make sure any external updates 

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
set duration as negative starttime when receiving an update for a running time entry

### 👫 Relationships
Closes #4835 

### 🔎 Review hints
Test case described in #4835.
Also test various updates of start time, stop time, and duration - on desktop client, on other clients + synced into desktop, re-login and change the duration while the user is logged out, etc.

Needs to be tested on Windows and macOS.
The builds can be taken from the GH Actions artifacts.

