### PR TITLE
Show default workspace as the first one in the description and project autocomplete list

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -932,7 +932,7 @@ void Context::updateUI(const UIElements &what) {
     if (what.display_time_entry_autocomplete) {
         if (what.first_load) {
             if (user_) {
-                user_->related.TimeEntryAutocompleteItems(&time_entry_autocompletes);
+                user_->related.TimeEntryAutocompleteItems(&time_entry_autocompletes, user_->DefaultWID());
             }
             UI()->DisplayTimeEntryAutocomplete(&time_entry_autocompletes);
         } else {
@@ -945,7 +945,7 @@ void Context::updateUI(const UIElements &what) {
     if (what.display_mini_timer_autocomplete) {
         if (what.first_load) {
             if (user_) {
-                user_->related.MinitimerAutocompleteItems(&minitimer_autocompletes);
+                user_->related.MinitimerAutocompleteItems(&minitimer_autocompletes, user_->DefaultWID());
             }
             UI()->DisplayMinitimerAutocomplete(&minitimer_autocompletes);
         } else {
@@ -1000,7 +1000,7 @@ void Context::updateUI(const UIElements &what) {
     if (what.display_project_autocomplete) {
         if (what.first_load) {
             if (user_) {
-                user_->related.ProjectAutocompleteItems(&project_autocompletes);
+                user_->related.ProjectAutocompleteItems(&project_autocompletes, user_->DefaultWID());
             }
             UI()->DisplayProjectAutocomplete(&project_autocompletes);
         } else {
@@ -1119,7 +1119,7 @@ void Context::Sync() {
 void Context::onTimeEntryAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
     std::vector<view::Autocomplete> time_entry_autocompletes;
     if (user_) {
-        user_->related.TimeEntryAutocompleteItems(&time_entry_autocompletes);
+        user_->related.TimeEntryAutocompleteItems(&time_entry_autocompletes, user_->DefaultWID());
     }
     UI()->DisplayTimeEntryAutocomplete(&time_entry_autocompletes);
 }
@@ -1127,7 +1127,7 @@ void Context::onTimeEntryAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
 void Context::onMiniTimerAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
     std::vector<view::Autocomplete> minitimer_autocompletes;
     if (user_) {
-        user_->related.MinitimerAutocompleteItems(&minitimer_autocompletes);
+        user_->related.MinitimerAutocompleteItems(&minitimer_autocompletes, user_->DefaultWID());
     }
     UI()->DisplayMinitimerAutocomplete(&minitimer_autocompletes);
 }
@@ -1135,7 +1135,7 @@ void Context::onMiniTimerAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
 void Context::onProjectAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
     std::vector<view::Autocomplete> project_autocompletes;
     if (user_) {
-        user_->related.ProjectAutocompleteItems(&project_autocompletes);
+        user_->related.ProjectAutocompleteItems(&project_autocompletes, user_->DefaultWID());
     }
     UI()->DisplayProjectAutocomplete(&project_autocompletes);
 }

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -478,8 +478,6 @@ void RelatedData::projectAutocompleteItems(
 
     poco_check_ptr(list);
 
-    auto default_workspace_items_inserted = 0;
-
     for (auto p : Projects) {
         if (p->WID() == defaultWID) {
             projectAutocompleteItem(unique_names, ws_names, list, items, task_items, p);

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -96,9 +96,9 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
         std::string end_time,
         const Poco::UInt8 days_of_week);
 
-    void TimeEntryAutocompleteItems(std::vector<view::Autocomplete> *) const;
-    void MinitimerAutocompleteItems(std::vector<view::Autocomplete> *) const;
-    void ProjectAutocompleteItems(std::vector<view::Autocomplete> *) const;
+    void TimeEntryAutocompleteItems(std::vector<view::Autocomplete> *, const Poco::UInt64 defaultWID) const;
+    void MinitimerAutocompleteItems(std::vector<view::Autocomplete> *, const Poco::UInt64 defaultWID) const;
+    void ProjectAutocompleteItems(std::vector<view::Autocomplete> *, const Poco::UInt64 defaultWID) const;
 
     void ProjectLabelAndColorCode(
         TimeEntry * const te,
@@ -131,7 +131,8 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
         std::map<Poco::UInt64, std::string> *ws_names,
         std::vector<view::Autocomplete> *list,
         std::map<std::string, std::vector<view::Autocomplete> > *items,
-        std::map<Poco::UInt64, std::vector<view::Autocomplete> > *task_items) const;
+        std::map<Poco::UInt64, std::vector<view::Autocomplete> > *task_items,
+        const Poco::UInt64 defaultWID) const;
 
     void workspaceAutocompleteItems(
         std::set<std::string> *unique_names,
@@ -140,7 +141,9 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
 
     void mergeGroupedAutocompleteItems(
         std::vector<view::Autocomplete> *result,
-        std::map<std::string, std::vector<view::Autocomplete> > *items) const;
+        std::map<std::string, std::vector<view::Autocomplete> > *items,
+        std::map<Poco::UInt64, std::string> *ws_names,
+        const Poco::UInt64 defaultWID) const;
 };
 
 template<> inline TimeEntry *RelatedData::ModelByID<TimeEntry>(Poco::UInt64 id) { return TimeEntryByID(id); }

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -125,6 +125,11 @@ class TOGGL_INTERNAL_EXPORT RelatedData {
                                std::map<Poco::UInt64, std::string> *ws_names,
                                std::vector<view::Autocomplete> *list,
                                std::map<Poco::UInt64, std::vector<view::Autocomplete> > *items) const;
+    void projectAutocompleteItem(std::set<std::string>* unique_names,
+                                 std::map<Poco::UInt64, std::string>* ws_names,
+                                 std::vector<view::Autocomplete>* list,
+                                 std::map<std::string, std::vector<view::Autocomplete>>* items,
+                                 std::map<Poco::UInt64, std::vector<view::Autocomplete>>* task_items, Project* p) const;
 
     void projectAutocompleteItems(
         std::set<std::string> *unique_names,


### PR DESCRIPTION
### 📒 Description
Show default workspace as the first one in the description and project autocomplete list

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
Populate items from the default workspace before populating the rest of the items.
Do it for
- Description Autocomplete list
- Project Autocomplete list

### 👫 Relationships
Closes #3508

### 🔎 Review hints
Test the functionality with a single-workspace account and with a multi-workspace account.
Keep in mind the workspaces are sorted alphabetically, so if the default workspace was alphabetically the first one, then nothing should change for such a user.

Needs to be checked on Windows and macOS. Let me know if you can test it on macOS. If not, I can check it out myself.