### PR TITLE
Reset validation error when setting TE duration - that will trigger TE to be synced when stopped

### DIFF
--- a/src/model/time_entry.cc
+++ b/src/model/time_entry.cc
@@ -144,7 +144,10 @@ void TimeEntry::DiscardAt(const Poco::Int64 at) {
 
     SetDurationInSeconds(duration, true);
     SetStopTime(at, true);
-    SetUIModified();
+    if (Dirty()) {
+        ClearValidationError();
+        SetUIModified();
+    }
 }
 
 void TimeEntry::StopTracking() {


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
This PR fixes the following problem:

1. Start a TE, that violates some constraints.
2. Stop this TE.
3. Create a TE, that meets all necessary constraints. See the sync error displayed (because of the previous violating TE).
4. Delete the TE, that violates the constraints.

AR: The TE meeting all constraints won't be ever synced.

ER: TE that meets all the constraints will be synced when stopped.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 - **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->
This PR simply clears validation error in `StopTracking()` (this method is called when TE is stopped).
Note that the same thing is done in `SetStopUserInput` - I'm not sure that this method is used anywhere (there is method in `context` that calls it, but that method is most probably never called through `TogglApi`).

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #4868

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Try to reproduce the bug:

1. Start a TE, that violates some constraints.
2. Stop this TE.
3. Start another TE and fill it in to meet all necessary constraints.
4. Stop this TE.

There should be no sync error for the second TE (it should be synced after stopping). The error for the first TE should be preserved until user fixes the error.