### PR TITLE
💻 ⏰ Invalidate timer when view goes away to fix memory leaking

### DIFF
--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewController.swift
@@ -114,7 +114,9 @@ class TimerViewController: NSViewController {
 
     override func viewDidDisappear() {
         super.viewDidDisappear()
-
+        
+        viewModel.viewWillDisappear()
+        
         [projectAutocompleteDidResignObserver, tagsAutocompleteDidResignObserver]
             .compactMap { $0 }
             .forEach { NotificationCenter.default.removeObserver($0) }

--- a/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
+++ b/src/ui/osx/TogglDesktop/Features/Timer/TimerViewController/TimerViewModel.swift
@@ -114,7 +114,7 @@ final class TimerViewModel: NSObject {
     var tagsDataSource = TagDataSource(items: TagStorage.shared.tags,
                                        updateNotificationName: .TagStorageChangedNotification)
 
-    private var timer: Timer!
+    private var timer: Timer?
 
     private var actionsUsedBeforeStart: Set<TimerEditActionType> = Set()
 
@@ -138,10 +138,14 @@ final class TimerViewModel: NSObject {
 
     deinit {
         cancelNotificationObservers()
-        timer.invalidate()
     }
 
     // MARK: - Public
+    
+    func viewWillDisappear() {
+        timer?.invalidate()
+        timer = nil
+    }
 
     func startStopAction() {
         if timeEntry.isRunning() {


### PR DESCRIPTION
### 📒 Description
💻 ⏰ Invalidate timer when view goes away to fix memory leaking and also keep supporting macOS 10.11 deployment target.

### 🕶️ Types of changes
**Bug fix**

### 🤯 List of changes
Smaller effort changes to also support macOS 10.11 target.

### 👫 Relationships
None.

### 🔎 Review hints
None.