### PR TITLE
Revert "Add an in-app message for new Windows App (#4903)"

### DIFF
--- a/releases/message.json
+++ b/releases/message.json
@@ -1,12 +1,13 @@
 {
-    "id": 1000,
-    "from": 1660694400,
-    "to": 1664582400,
-    "type": 2,
-    "appversion": "7.0.0",
-    "title": "A new and improved Windows app!",
-    "text": "For a better desktop experience, get our rewritten Windows app. We'll be deprecating this version at the end of September 2022.",
-    "button": "Get it now!",
-    "url-win": "https://toggl.com/track/toggl-desktop/downloads/windows/stable/TogglTrack-windows64.exe"
+    "id": 5,
+    "from": 1600925481,
+    "to": 1601301350,
+    "type": 0,
+    "appversion": "7.5.286",
+    "title": "How is your experience using the updated Timer?",
+    "text": "Let us know in a 2-minute survey!",
+    "button": "Give feedback",
+    "url-mac": "https://forms.gle/QKX7datPDVV7axvu8",
+    "url-win": "https://forms.gle/QKX7datPDVV7axvu8",
+    "url-linux": "https://forms.gle/QKX7datPDVV7axvu8"
 }
-    

--- a/src/context.cc
+++ b/src/context.cc
@@ -1605,7 +1605,7 @@ error Context::fetchMessage(const bool periodic) {
             if ("production" != environment_) {
                 // testing location
                 req.host = "https://raw.githubusercontent.com";
-                req.relative_url = "/toggl-open-source/toggldesktop/test-in-app-notification/releases/message.json";
+                req.relative_url = "/toggl-open-source/toggldesktop/rebranding/post-rebranding-notification/releases/message.json";
             } else {
                 req.host = "https://raw.githubusercontent.com";
                 req.relative_url = "/toggl-open-source/toggldesktop/master/releases/message.json";


### PR DESCRIPTION
This reverts commit 4099e8cd5f6656431685ecf49ea8b92985be920e.

### 📒 Description
<!-- Describe your changes in detail -->
Removes the in-app notification to move to the new Windows App.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->
In-app notification.

<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->
None in app behavior.

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->
None.

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

